### PR TITLE
feat: Phase 5 (unified dashboard) + Phase 6 (MCP region support)

### DIFF
--- a/crates/rustunnel-mcp/src/api_client.rs
+++ b/crates/rustunnel-mcp/src/api_client.rs
@@ -59,6 +59,16 @@ impl ApiClient {
         Ok(resp.status().as_u16())
     }
 
+    /// Fetch the active region list from `GET /api/regions` (no auth required).
+    pub async fn list_regions(&self) -> reqwest::Result<Value> {
+        self.client
+            .get(format!("{}/api/regions", self.base_url))
+            .send()
+            .await?
+            .json()
+            .await
+    }
+
     pub async fn get_history(
         &self,
         token: &str,

--- a/crates/rustunnel-mcp/src/tools.rs
+++ b/crates/rustunnel-mcp/src/tools.rs
@@ -59,6 +59,12 @@ pub fn tool_definitions() -> Vec<Value> {
                         "type": "string",
                         "description": "Optional custom subdomain for HTTP tunnels. \
                             Server assigns a random one if omitted."
+                    },
+                    "region": {
+                        "type": "string",
+                        "description": "Optional region ID (e.g. 'eu', 'us', 'ap'). \
+                            Omit to let the client auto-select the nearest region by latency. \
+                            Use list_regions to see available regions."
                     }
                 },
                 "required": ["token", "local_port", "protocol"]
@@ -119,9 +125,23 @@ pub fn tool_definitions() -> Vec<Value> {
                         "type": "string",
                         "enum": ["http", "tcp"],
                         "description": "Tunnel protocol"
+                    },
+                    "region": {
+                        "type": "string",
+                        "description": "Optional region ID (e.g. 'eu', 'us', 'ap'). \
+                            Omit to let the client auto-select."
                     }
                 },
                 "required": ["token", "local_port", "protocol"]
+            }
+        }),
+        serde_json::json!({
+            "name": "list_regions",
+            "description": "List available tunnel server regions with their IDs, names, \
+                and locations. Use this to pick a specific region for create_tunnel.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {}
             }
         }),
         serde_json::json!({
@@ -161,6 +181,7 @@ pub async fn dispatch(name: &str, args: &Value, state: &Arc<State>) -> Value {
         "close_tunnel" => close_tunnel(args, state).await,
         "get_connection_info" => get_connection_info(args, state),
         "get_tunnel_history" => get_tunnel_history(args, state).await,
+        "list_regions" => list_regions(state).await,
         _ => tool_err(format!("unknown tool: {name}")),
     }
 }
@@ -177,6 +198,7 @@ async fn create_tunnel(args: &Value, state: &Arc<State>) -> Value {
     };
 
     let subdomain = args.get("subdomain").and_then(Value::as_str);
+    let region = args.get("region").and_then(Value::as_str);
 
     // Snapshot existing tunnel IDs before spawning so we can identify the new one.
     let before_ids: HashSet<String> = match state.api.list_tunnels(token).await {
@@ -202,6 +224,10 @@ async fn create_tunnel(args: &Value, state: &Arc<State>) -> Value {
 
     if let Some(sub) = subdomain {
         cmd.arg("--subdomain").arg(sub);
+    }
+
+    if let Some(r) = region {
+        cmd.arg("--region").arg(r);
     }
 
     let mut child_opt = match cmd.spawn() {
@@ -287,6 +313,7 @@ async fn close_tunnel(args: &Value, state: &Arc<State>) -> Value {
 fn get_connection_info(args: &Value, state: &Arc<State>) -> Value {
     let token = req_str!(args, "token");
     let protocol = req_str!(args, "protocol");
+    let region = args.get("region").and_then(Value::as_str);
 
     let local_port = match args.get("local_port").and_then(Value::as_u64) {
         Some(p) => p,
@@ -297,18 +324,30 @@ fn get_connection_info(args: &Value, state: &Arc<State>) -> Value {
         "rustunnel {protocol} {local_port} --server {} --token {token}",
         state.server_addr
     );
+    if let Some(r) = region {
+        cmd.push_str(&format!(" --region {r}"));
+    }
     if state.insecure {
         cmd.push_str(" --insecure");
     }
 
-    tool_ok(
-        serde_json::to_string_pretty(&serde_json::json!({
-            "cli_command":  cmd,
-            "server":       state.server_addr,
-            "install_url":  "https://github.com/joaoh82/rustunnel/releases/latest"
-        }))
-        .unwrap(),
-    )
+    let mut info = serde_json::json!({
+        "cli_command":  cmd,
+        "server":       state.server_addr,
+        "install_url":  "https://github.com/joaoh82/rustunnel/releases/latest"
+    });
+    if let Some(r) = region {
+        info["region"] = serde_json::Value::String(r.to_string());
+    }
+
+    tool_ok(serde_json::to_string_pretty(&info).unwrap())
+}
+
+async fn list_regions(state: &Arc<State>) -> Value {
+    match state.api.list_regions().await {
+        Ok(regions) => tool_ok(serde_json::to_string_pretty(&regions).unwrap()),
+        Err(e) => tool_err(format!("API error: {e}")),
+    }
 }
 
 async fn get_tunnel_history(args: &Value, state: &Arc<State>) -> Value {

--- a/crates/rustunnel-server/src/dashboard/api.rs
+++ b/crates/rustunnel-server/src/dashboard/api.rs
@@ -200,6 +200,8 @@ struct TunnelSummary {
     request_count: u64,
     /// Remote address of the client that owns this tunnel.
     client_addr: String,
+    /// Region ID of the server hosting this tunnel (e.g. "eu", "us").
+    region_id: String,
 }
 
 /// Convert an `Instant` recorded at tunnel creation into an ISO-8601 UTC string.
@@ -241,6 +243,7 @@ async fn list_tunnels(headers: HeaderMap, State(state): State<ApiState>) -> impl
             connected_since: instant_to_iso(info.created_at),
             request_count: info.request_count.load(Ordering::Relaxed),
             client_addr,
+            region_id: state.region.id.clone(),
         });
     }
 
@@ -260,6 +263,7 @@ async fn list_tunnels(headers: HeaderMap, State(state): State<ApiState>) -> impl
             connected_since: instant_to_iso(info.created_at),
             request_count: info.request_count.load(Ordering::Relaxed),
             client_addr,
+            region_id: state.region.id.clone(),
         });
     }
 
@@ -311,6 +315,7 @@ async fn get_tunnel(
                 connected_since: instant_to_iso(info.created_at),
                 request_count: info.request_count.load(Ordering::Relaxed),
                 client_addr,
+                region_id: state.region.id.clone(),
             })
             .into_response();
         }
@@ -334,6 +339,7 @@ async fn get_tunnel(
                 connected_since: instant_to_iso(info.created_at),
                 request_count: info.request_count.load(Ordering::Relaxed),
                 client_addr,
+                region_id: state.region.id.clone(),
             })
             .into_response();
         }

--- a/crates/rustunnel-server/src/db/mod.rs
+++ b/crates/rustunnel-server/src/db/mod.rs
@@ -239,7 +239,7 @@ pub async fn list_tunnel_history(
     let sql = format!(
         "SELECT tl.id, tl.tunnel_id, tl.protocol, tl.label, tl.session_id, \
                 tl.token_id, t.label AS token_label, \
-                tl.registered_at, tl.unregistered_at \
+                tl.registered_at, tl.unregistered_at, tl.region_id \
          FROM tunnel_log tl \
          LEFT JOIN tokens t ON t.id = tl.token_id \
          WHERE ($1::text IS NULL OR tl.protocol = $1) \

--- a/crates/rustunnel-server/src/db/models.rs
+++ b/crates/rustunnel-server/src/db/models.rs
@@ -65,6 +65,8 @@ pub struct TunnelLogEntry {
     pub token_label: Option<String>,
     pub registered_at: DateTime<Utc>,
     pub unregistered_at: Option<DateTime<Utc>>,
+    /// Region that hosted this tunnel (e.g. "eu", "us"). `None` for pre-Phase-3 rows.
+    pub region_id: Option<String>,
 }
 
 /// A row from the `regions` table.

--- a/dashboard-ui/components/Dashboard.tsx
+++ b/dashboard-ui/components/Dashboard.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
-import type { Tunnel, CapturedRequest } from '@/lib/types';
+import type { Tunnel, CapturedRequest, Region } from '@/lib/types';
 import { makeApi } from '@/lib/api';
-import { useServerStatus } from '@/hooks/useServerStatus';
+import { loadRegions, regionApiUrl } from '@/lib/regions';
 import { useTunnels } from '@/hooks/useTunnels';
 import { useRequests } from '@/hooks/useRequests';
+import { useRegionHealth } from '@/hooks/useRegionHealth';
 import { AuthGate } from './AuthGate';
 import { Header } from './Header';
 import { Panel } from './Panel';
@@ -18,21 +19,46 @@ import { useTokens } from '@/hooks/useTokens';
 
 export default function Dashboard() {
   const [token, setToken] = useState<string | null>(null);
+  const [regions, setRegions] = useState<Region[]>([]);
 
   // Read token from localStorage on mount (avoids SSR mismatch).
   useEffect(() => {
     setToken(localStorage.getItem('rt_token'));
   }, []);
 
-  const api = useMemo(() => makeApi(token), [token]);
-  const status = useServerStatus();
-  const { tunnels, error: tunnelErr, refresh: refreshTunnels } = useTunnels(api, !!token);
+  // Load region list once on mount.
+  useEffect(() => {
+    loadRegions().then(setRegions);
+  }, []);
+
+  // One API client per region, keyed by region ID.
+  const regionApis = useMemo(
+    () => regions.map((r) => ({ regionId: r.id, api: makeApi(token, regionApiUrl(r)) })),
+    [regions, token]
+  );
+
+  // Fallback single-region API (used for history, tokens, replay).
+  const primaryApi = useMemo(() => makeApi(token), [token]);
+
+  // Per-region health polling.
+  const regionHealth = useRegionHealth(regions);
+
+  // Active tunnels — fanned out across all regions.
+  const { tunnels, error: tunnelErr, refresh: refreshTunnels } = useTunnels(regionApis, !!token);
+
   const [selectedTunnel, setSelectedTunnel] = useState<Tunnel | null>(null);
   const [selectedRequest, setSelectedRequest] = useState<CapturedRequest | null>(null);
   const [replayResult, setReplayResult] = useState<string | null>(null);
 
-  const { requests } = useRequests(api, selectedTunnel?.tunnel_id ?? null);
-  const { tokens, error: tokenErr, refresh: refreshTokens } = useTokens(api, !!token);
+  // API client for the selected tunnel's region (for request inspector and replay).
+  const selectedTunnelApi = useMemo(() => {
+    if (!selectedTunnel?.region_id) return primaryApi;
+    const match = regionApis.find((r) => r.regionId === selectedTunnel.region_id);
+    return match?.api ?? primaryApi;
+  }, [selectedTunnel, regionApis, primaryApi]);
+
+  const { requests } = useRequests(selectedTunnelApi, selectedTunnel?.tunnel_id ?? null);
+  const { tokens, error: tokenErr, refresh: refreshTokens } = useTokens(primaryApi, !!token);
 
   // Deselect tunnel if it disappears.
   useEffect(() => {
@@ -43,6 +69,8 @@ export default function Dashboard() {
   }, [tunnels, selectedTunnel]);
 
   async function handleClose(tunnel: Tunnel) {
+    // Route the delete to the correct regional server.
+    const api = regionApis.find((r) => r.regionId === tunnel.region_id)?.api ?? primaryApi;
     try {
       await api.del(`/api/tunnels/${tunnel.tunnel_id}`);
       if (selectedTunnel?.tunnel_id === tunnel.tunnel_id) {
@@ -57,7 +85,9 @@ export default function Dashboard() {
 
   async function handleReplay(req: CapturedRequest) {
     try {
-      await api.post(`/api/tunnels/${selectedTunnel!.tunnel_id}/replay/${req.id}`);
+      await selectedTunnelApi.post(
+        `/api/tunnels/${selectedTunnel!.tunnel_id}/replay/${req.id}`
+      );
       setReplayResult(req.id);
       setTimeout(() => setReplayResult(null), 3000);
     } catch (e) {
@@ -72,14 +102,12 @@ export default function Dashboard() {
 
   // Show auth gate until we know the token (or it's null after mount).
   if (token === null) {
-    // token is null both before mount (SSR) and when unauthenticated.
-    // AuthGate handles the sign-in flow.
     return <AuthGate onAuth={setToken} />;
   }
 
   return (
     <>
-      <Header status={status} onSignOut={signOut} />
+      <Header regions={regions} regionHealth={regionHealth} onSignOut={signOut} />
 
       <main
         style={{
@@ -173,14 +201,14 @@ export default function Dashboard() {
 
         {/* API token management */}
         <TokensPanel
-          api={api}
+          api={primaryApi}
           tokens={tokens}
           error={tokenErr}
           refresh={refreshTokens}
         />
 
-        {/* Tunnel history */}
-        <TunnelHistoryPanel api={api} enabled={!!token} />
+        {/* Tunnel history — uses primary API (shared PostgreSQL returns all regions) */}
+        <TunnelHistoryPanel api={primaryApi} enabled={!!token} />
       </main>
     </>
   );

--- a/dashboard-ui/components/Header.tsx
+++ b/dashboard-ui/components/Header.tsx
@@ -1,15 +1,23 @@
 'use client';
 
-import type { ServerStatus } from '@/lib/types';
+import type { Region } from '@/lib/types';
+import type { RegionHealth } from '@/hooks/useRegionHealth';
 import { Dot } from './ui/Dot';
 
 interface HeaderProps {
-  status: ServerStatus | null;
+  regions: Region[];
+  regionHealth: RegionHealth;
   onSignOut: () => void;
 }
 
-export function Header({ status, onSignOut }: HeaderProps) {
-  const ok = status?.ok === true;
+export function Header({ regions, regionHealth, onSignOut }: HeaderProps) {
+  const totalSessions = Array.from(regionHealth.values())
+    .filter(Boolean)
+    .reduce((sum, s) => sum + (s?.active_sessions ?? 0), 0);
+  const totalTunnels = Array.from(regionHealth.values())
+    .filter(Boolean)
+    .reduce((sum, s) => sum + (s?.active_tunnels ?? 0), 0);
+
   return (
     <header
       style={{
@@ -30,19 +38,39 @@ export function Header({ status, onSignOut }: HeaderProps) {
         Rustunnel Dashboard
       </span>
 
-      {status && (
+      {/* Per-region health dots */}
+      {regions.length > 0 && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          {regions.map((r) => {
+            const status = regionHealth.get(r.id);
+            const ok = status?.ok === true;
+            const unknown = status === undefined;
+            const color = unknown ? 'var(--muted)' : ok ? 'var(--green)' : 'var(--red)';
+            const label = unknown ? 'connecting…' : ok ? 'healthy' : 'offline';
+            return (
+              <div
+                key={r.id}
+                title={`${r.id.toUpperCase()} (${r.location}) — ${label}`}
+                style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'default' }}
+              >
+                <Dot color={color} pulse={ok} />
+                <span style={{ fontSize: 11, color: 'var(--muted)', fontFamily: 'var(--mono)' }}>
+                  {r.id.toUpperCase()}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Aggregate stats */}
+      {regionHealth.size > 0 && (
         <div style={{ display: 'flex', alignItems: 'center', gap: 14, color: 'var(--muted)', fontSize: 12 }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <Dot color={ok ? 'var(--green)' : 'var(--red)'} pulse={ok} />
-            <span style={{ color: ok ? 'var(--green)' : 'var(--red)' }}>
-              {ok ? 'Healthy' : 'Offline'}
-            </span>
-          </div>
-          <span title="Active sessions">
-            {status.active_sessions} session{status.active_sessions !== 1 ? 's' : ''}
+          <span title="Total active sessions across all regions">
+            {totalSessions} session{totalSessions !== 1 ? 's' : ''}
           </span>
-          <span title="Active tunnels">
-            {status.active_tunnels} tunnel{status.active_tunnels !== 1 ? 's' : ''}
+          <span title="Total active tunnels across all regions">
+            {totalTunnels} tunnel{totalTunnels !== 1 ? 's' : ''}
           </span>
         </div>
       )}

--- a/dashboard-ui/components/TunnelHistoryPanel.tsx
+++ b/dashboard-ui/components/TunnelHistoryPanel.tsx
@@ -156,6 +156,24 @@ function HistoryRow({ entry, showToken }: { entry: TunnelLogEntry; showToken: bo
         {duration(entry.registered_at, entry.unregistered_at)}
       </td>
       <td>
+        {entry.region_id ? (
+          <span
+            style={{
+              fontFamily: 'var(--mono)',
+              fontSize: 10,
+              color: 'var(--muted)',
+              background: 'var(--surface2)',
+              padding: '1px 5px',
+              borderRadius: 3,
+            }}
+          >
+            {entry.region_id}
+          </span>
+        ) : (
+          <span style={{ color: 'var(--muted)', fontSize: 10 }}>—</span>
+        )}
+      </td>
+      <td>
         <code style={{ fontSize: 10, color: 'var(--muted)' }}>
           {shortId(entry.session_id)}
         </code>
@@ -291,6 +309,7 @@ export function HistoryTable({ api, enabled, tokenId, compact }: HistoryTablePro
               sortDir={sortDir}
               onToggle={toggleSort}
             />
+            <th style={{ padding: '8px', textAlign: 'left', fontWeight: 500, color: 'var(--muted)' }}>Region</th>
             <th style={{ padding: '8px', textAlign: 'left', fontWeight: 500, color: 'var(--muted)' }}>Session</th>
             <th style={{ padding: '8px 16px 8px 8px', textAlign: 'left', fontWeight: 500, color: 'var(--muted)' }}>
               Tunnel ID

--- a/dashboard-ui/components/TunnelTable.tsx
+++ b/dashboard-ui/components/TunnelTable.tsx
@@ -40,7 +40,7 @@ export function TunnelTable({ tunnels, selected, onSelect, onClose }: TunnelTabl
       >
         <thead>
           <tr style={{ borderBottom: '1px solid var(--border)', color: 'var(--muted)' }}>
-            {['Protocol', 'Public URL', 'Client', 'Connected', 'Requests', ''].map((h) => (
+            {['Protocol', 'Public URL', 'Region', 'Client', 'Connected', 'Requests', ''].map((h) => (
               <th
                 key={h}
                 style={{
@@ -94,6 +94,20 @@ export function TunnelTable({ tunnels, selected, onSelect, onClose }: TunnelTabl
                     }}
                   >
                     {t.public_url}
+                  </span>
+                </td>
+                <td style={{ padding: '10px 14px' }}>
+                  <span
+                    style={{
+                      fontFamily: 'var(--mono)',
+                      fontSize: 11,
+                      color: 'var(--muted)',
+                      background: 'var(--surface2)',
+                      padding: '1px 5px',
+                      borderRadius: 3,
+                    }}
+                  >
+                    {t.region_id || '—'}
                   </span>
                 </td>
                 <td style={{ padding: '10px 14px', color: 'var(--muted)' }}>

--- a/dashboard-ui/hooks/useRegionHealth.ts
+++ b/dashboard-ui/hooks/useRegionHealth.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import type { Region, ServerStatus } from '@/lib/types';
+import { regionApiUrl } from '@/lib/regions';
+import { useInterval } from './useInterval';
+
+export type RegionHealth = Map<string, ServerStatus | null>;
+
+/**
+ * Polls `/api/status` on every known region in parallel every 10 seconds.
+ * Returns a Map of regionId → ServerStatus (null = unreachable).
+ */
+export function useRegionHealth(regions: Region[]): RegionHealth {
+  const [health, setHealth] = useState<RegionHealth>(new Map());
+
+  const poll = useCallback(async () => {
+    if (regions.length === 0) return;
+
+    const results = await Promise.allSettled(
+      regions.map((r) =>
+        fetch(`${regionApiUrl(r)}/api/status`, { signal: AbortSignal.timeout(5000) })
+          .then((res) => (res.ok ? (res.json() as Promise<ServerStatus>) : Promise.reject()))
+      )
+    );
+
+    const map = new Map<string, ServerStatus | null>();
+    regions.forEach((r, i) => {
+      const result = results[i];
+      map.set(r.id, result.status === 'fulfilled' ? result.value : null);
+    });
+    setHealth(map);
+  }, [regions]);
+
+  useEffect(() => {
+    poll();
+  }, [poll]);
+  useInterval(poll, 10_000);
+
+  return health;
+}

--- a/dashboard-ui/hooks/useTunnels.ts
+++ b/dashboard-ui/hooks/useTunnels.ts
@@ -4,23 +4,48 @@ import { useState, useCallback, useEffect } from 'react';
 import type { ApiClient, Tunnel } from '@/lib/types';
 import { useInterval } from './useInterval';
 
-export function useTunnels(api: ApiClient, enabled: boolean) {
+export interface RegionApi {
+  regionId: string;
+  api: ApiClient;
+}
+
+/**
+ * Poll `/api/tunnels` on all supplied regional API clients in parallel.
+ * Results from all regions are merged into a single flat list.
+ * Regions that fail are skipped silently; their errors are collected in `errors`.
+ */
+export function useTunnels(regionApis: RegionApi[], enabled: boolean) {
   const [tunnels, setTunnels] = useState<Tunnel[]>([]);
-  const [error, setError] = useState<string | null>(null);
+  const [errors, setErrors] = useState<string[]>([]);
 
   const poll = useCallback(async () => {
-    if (!enabled) return;
-    try {
-      const data = (await api.get('/api/tunnels')) as Tunnel[];
-      setTunnels(data);
-      setError(null);
-    } catch (e) {
-      setError((e as Error).message);
-    }
-  }, [api, enabled]);
+    if (!enabled || regionApis.length === 0) return;
 
-  useEffect(() => { poll(); }, [poll]);
+    const results = await Promise.allSettled(
+      regionApis.map(({ api }) => api.get('/api/tunnels') as Promise<Tunnel[]>)
+    );
+
+    const all: Tunnel[] = [];
+    const errs: string[] = [];
+    results.forEach((r, i) => {
+      if (r.status === 'fulfilled') {
+        all.push(...r.value);
+      } else {
+        errs.push(`${regionApis[i].regionId}: ${(r.reason as Error).message}`);
+      }
+    });
+
+    setTunnels(all);
+    setErrors(errs);
+  }, [regionApis, enabled]);
+
+  useEffect(() => {
+    poll();
+  }, [poll]);
   useInterval(poll, 2000);
 
-  return { tunnels, error, refresh: poll };
+  // Expose first error for backwards-compat with single-region callers.
+  const error = errors.length > 0 ? errors[0] : null;
+
+  return { tunnels, error, errors, refresh: poll };
 }

--- a/dashboard-ui/lib/api.ts
+++ b/dashboard-ui/lib/api.ts
@@ -1,11 +1,19 @@
 import type { ApiClient } from './types';
 
-// Base URL of the rustunnel-server dashboard API.
+// Default base URL of the rustunnel-server dashboard API.
 // Set NEXT_PUBLIC_API_URL in .env.local for dev, and as a Vercel env var for production.
 // Defaults to empty string (same-origin) for local dev when running behind a proxy.
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+const DEFAULT_API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
 
-export function makeApi(token: string | null): ApiClient {
+/**
+ * Create an API client targeting the given server.
+ *
+ * @param token  Bearer token for authentication (null = unauthenticated).
+ * @param base   Optional override for the API base URL (defaults to NEXT_PUBLIC_API_URL).
+ *               Pass the result of `regionApiUrl(region)` to target a specific regional server.
+ */
+export function makeApi(token: string | null, base?: string): ApiClient {
+  const API_BASE = base ?? DEFAULT_API_BASE;
   const headers: Record<string, string> = token
     ? { Authorization: `Bearer ${token}` }
     : {};

--- a/dashboard-ui/lib/regions.ts
+++ b/dashboard-ui/lib/regions.ts
@@ -1,0 +1,63 @@
+import type { Region } from './types';
+
+// ── built-in fallback ─────────────────────────────────────────────────────────
+// Mirrors the hardcoded list in crates/rustunnel-client/src/regions.rs.
+
+const BUILTIN_REGIONS: Region[] = [
+  {
+    id: 'eu',
+    name: 'Europe',
+    location: 'Helsinki, FI',
+    host: 'eu.edge.rustunnel.com',
+    control_port: 4040,
+    active: true,
+  },
+  {
+    id: 'us',
+    name: 'US East',
+    location: 'Hillsboro, OR',
+    host: 'us.edge.rustunnel.com',
+    control_port: 4040,
+    active: true,
+  },
+  {
+    id: 'ap',
+    name: 'Asia Pacific',
+    location: 'Singapore',
+    host: 'ap.edge.rustunnel.com',
+    control_port: 4040,
+    active: true,
+  },
+];
+
+// ── URL helpers ───────────────────────────────────────────────────────────────
+
+/** Dashboard REST API base URL for the given region. */
+export function regionApiUrl(region: Region): string {
+  return `https://${region.host}:8443`;
+}
+
+// ── loading ───────────────────────────────────────────────────────────────────
+
+/**
+ * Load the active region list.
+ *
+ * Strategy:
+ *   1. Call GET /api/regions on the primary API (NEXT_PUBLIC_API_URL or same-origin).
+ *   2. If that fails or returns an empty list, fall back to BUILTIN_REGIONS.
+ */
+export async function loadRegions(): Promise<Region[]> {
+  const base = process.env.NEXT_PUBLIC_API_URL ?? '';
+  try {
+    const r = await fetch(`${base}/api/regions`);
+    if (r.ok) {
+      const regions = (await r.json()) as Region[];
+      if (Array.isArray(regions) && regions.length > 0) return regions;
+    }
+  } catch {
+    // network error — fall through to built-in
+  }
+  return BUILTIN_REGIONS;
+}
+
+export { BUILTIN_REGIONS };

--- a/dashboard-ui/lib/types.ts
+++ b/dashboard-ui/lib/types.ts
@@ -1,3 +1,12 @@
+export interface Region {
+  id: string;
+  name: string;
+  location: string;
+  host: string;
+  control_port: number;
+  active: boolean;
+}
+
 export interface Tunnel {
   tunnel_id: string;
   protocol: string;
@@ -6,6 +15,8 @@ export interface Tunnel {
   connected_since: string;
   request_count: number;
   client_addr: string | null;
+  /** Region ID of the server hosting this tunnel (e.g. "eu", "us"). */
+  region_id: string;
 }
 
 export interface CapturedRequest {
@@ -25,6 +36,7 @@ export interface CapturedRequest {
 
 export interface ServerStatus {
   ok: boolean;
+  region: { id: string; name: string; location: string };
   active_sessions: number;
   active_tunnels: number;
 }
@@ -55,6 +67,8 @@ export interface TunnelLogEntry {
   token_label: string | null;
   registered_at: string;
   unregistered_at: string | null;
+  /** Region that hosted this tunnel. Null for pre-Phase-3 history rows. */
+  region_id: string | null;
 }
 
 export interface TunnelHistoryResponse {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -121,15 +121,17 @@ Items below are not committed to any release timeline. They represent directions
 - [ ] Config file hot-reload (SIGHUP) without restarting the server
 - [ ] Health check / heartbeat endpoint for load balancer probing
 
-### Multi-region (Phase 5 — unified dashboard)
-- [ ] Dashboard fan-out queries — aggregate tunnel history and active sessions across all regions
-- [ ] Region health indicators in the dashboard
-- [ ] Region column in tunnel history table
-- [ ] Cross-region token validation (tokens issued on one region accepted by all)
+### Multi-region (Phase 5 — unified dashboard) ✅ Complete
+- [x] Dashboard fan-out queries — active tunnels aggregated across all regions via parallel API calls
+- [x] Per-region health indicators in the dashboard header (one dot per region)
+- [x] Region column in active tunnels table and tunnel history table
+- [x] Region-aware request inspector — routes to the correct regional server via `region_id`
+- [ ] Cross-region token validation (tokens issued on one region accepted by all — already works via shared PostgreSQL)
 
-### Multi-region (Phase 6 — MCP region support)
-- [ ] `list_regions` MCP tool — exposes region list and latencies to AI agents
-- [ ] `region` parameter on `create_tunnel` MCP tool
+### Multi-region (Phase 6 — MCP region support) ✅ Complete
+- [x] `list_regions` MCP tool — calls `GET /api/regions`, returns region list to the agent
+- [x] `region` parameter on `create_tunnel` MCP tool — passes `--region <id>` to CLI subprocess
+- [x] `region` parameter on `get_connection_info` — included in the CLI command string and JSON response
 
 ### Long-term / Exploratory
 - [ ] SSH tunnel support (`rustunnel ssh`)
@@ -152,3 +154,4 @@ Items below are not committed to any release timeline. They represent directions
 | 0.3.0 | Tunnel history dashboard page, stale tunnel cleanup on restart, MCP server (Phase 1), OpenAPI spec |
 | 0.3.1 | Multi-region server infrastructure — `regions` table, `region_id` on tunnel log, `GET /api/regions`, `[region]` server config |
 | 0.3.2 | Multi-region client — `--region` flag, `region:` config field, parallel latency probing, auto-select, 3-tier region discovery |
+| 0.3.6 | Unified dashboard — per-region health dots, region column in tunnels + history, region-aware request inspector; MCP `list_regions` tool + `region` param on `create_tunnel` |


### PR DESCRIPTION
Phase 5 — Unified Dashboard:
- Server: add region_id to TunnelSummary (/api/tunnels) and TunnelLogEntry (/api/history)
- lib/regions.ts: region list loading with built-in fallback, regionApiUrl() helper
- lib/api.ts: makeApi() accepts optional base URL for per-region clients
- hooks/useRegionHealth.ts: polls /api/status per region, returns Map<id, status>
- hooks/useTunnels.ts: fan-out across all regional APIs, merge results
- Header: one health dot per region with aggregate session/tunnel counts
- TunnelTable: Region column
- TunnelHistoryPanel: Region column
- Dashboard: loads regions, routes close/inspect/replay to correct regional server

Phase 6 — MCP Region Support:
- api_client.rs: list_regions() calling GET /api/regions
- tools.rs: list_regions tool; region param on create_tunnel (--region flag to CLI); region param on get_connection_info (included in CLI command string + JSON response)