### PR TITLE
feat(admin): add plans, platform usage, and per-user tunnel/token end…

### DIFF
--- a/crates/rustunnel-server/src/dashboard/api.rs
+++ b/crates/rustunnel-server/src/dashboard/api.rs
@@ -80,6 +80,10 @@ pub fn router(state: ApiState) -> Router {
             "/api/admin/users/:id",
             axum::routing::put(admin_update_user),
         )
+        .route("/api/admin/plans", get(admin_list_plans))
+        .route("/api/admin/usage/platform", get(admin_platform_usage))
+        .route("/api/admin/users/:id/tunnels", get(admin_list_user_tunnels))
+        .route("/api/admin/users/:id/tokens", get(admin_list_user_tokens))
         .layer(cors)
         .with_state(state)
 }
@@ -707,6 +711,116 @@ async fn admin_update_user(
     match db::set_user_status(&state.db.pg, &user_id, &body.status).await {
         Ok(true) => StatusCode::NO_CONTENT.into_response(),
         Ok(false) => not_found("user not found").into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrBody {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+// ── admin plan / usage / per-user routes ──────────────────────────────────────
+
+/// `GET /api/admin/plans` — list all plans with their active subscriber counts.
+async fn admin_list_plans(headers: HeaderMap, State(state): State<ApiState>) -> impl IntoResponse {
+    if let Err(e) = require_admin(&headers, &state).await {
+        return e.into_response();
+    }
+    match db::list_admin_plans(&state.db.pg).await {
+        Ok(plans) => Json(plans).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrBody {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /api/admin/usage/platform` — platform-wide aggregate ops metrics.
+///
+/// Queries the shared PostgreSQL so the result covers all regions.
+async fn admin_platform_usage(
+    headers: HeaderMap,
+    State(state): State<ApiState>,
+) -> impl IntoResponse {
+    if let Err(e) = require_admin(&headers, &state).await {
+        return e.into_response();
+    }
+    match db::get_platform_usage(&state.db.pg).await {
+        Ok(usage) => Json(usage).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrBody {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct UserTunnelsQuery {
+    #[serde(default = "default_admin_limit")]
+    limit: i64,
+    #[serde(default)]
+    offset: i64,
+}
+
+#[derive(Serialize)]
+struct UserTunnelsResponse {
+    entries: Vec<db::AdminTunnelEntry>,
+    total: i64,
+}
+
+/// `GET /api/admin/users/:id/tunnels` — paginated tunnel history for one user.
+async fn admin_list_user_tunnels(
+    headers: HeaderMap,
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+    axum::extract::Query(q): axum::extract::Query<UserTunnelsQuery>,
+) -> impl IntoResponse {
+    if let Err(e) = require_admin(&headers, &state).await {
+        return e.into_response();
+    }
+    let user_id = match id.parse::<uuid::Uuid>() {
+        Ok(u) => u,
+        Err(_) => return not_found("invalid user id").into_response(),
+    };
+    let (entries, total) = tokio::join!(
+        db::list_user_tunnels(&state.db.pg, &user_id, q.limit, q.offset),
+        db::count_user_tunnels(&state.db.pg, &user_id),
+    );
+    match (entries, total) {
+        (Ok(entries), Ok(total)) => Json(UserTunnelsResponse { entries, total }).into_response(),
+        (Err(e), _) | (_, Err(e)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrBody {
+                error: e.to_string(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /api/admin/users/:id/tokens` — all tokens belonging to one user.
+async fn admin_list_user_tokens(
+    headers: HeaderMap,
+    State(state): State<ApiState>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if let Err(e) = require_admin(&headers, &state).await {
+        return e.into_response();
+    }
+    let user_id = match id.parse::<uuid::Uuid>() {
+        Ok(u) => u,
+        Err(_) => return not_found("invalid user id").into_response(),
+    };
+    match db::list_user_tokens(&state.db.pg, &user_id).await {
+        Ok(tokens) => Json(tokens).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrBody {

--- a/crates/rustunnel-server/src/db/mod.rs
+++ b/crates/rustunnel-server/src/db/mod.rs
@@ -61,6 +61,7 @@ use chrono::Utc;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+pub use models::{AdminPlan, AdminTunnelEntry};
 use models::{Region, Token, TokenWithCount, TunnelLogEntry};
 
 /// Hash a raw token value with SHA-256.
@@ -409,4 +410,128 @@ pub async fn set_user_status(pool: &PgPool, user_id: &uuid::Uuid, status: &str) 
         .await?
         .rows_affected();
     Ok(rows > 0)
+}
+
+// ── admin plan helpers ────────────────────────────────────────────────────────
+
+/// All plans with their live active-subscriber count.
+pub async fn list_admin_plans(pool: &PgPool) -> Result<Vec<AdminPlan>> {
+    let rows: Vec<AdminPlan> = sqlx::query_as(
+        "SELECT p.id, p.name, p.billing_model, p.monthly_price_cents,
+                p.max_tunnels, p.max_connections, p.rate_limit_rps,
+                p.bandwidth_limit_gb, p.history_days, p.is_active,
+                COUNT(s.id)::bigint AS subscriber_count
+         FROM plans p
+         LEFT JOIN subscriptions s ON s.plan_id = p.id AND s.status = 'active'
+         GROUP BY p.id
+         ORDER BY p.monthly_price_cents ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+// ── admin platform usage helpers ──────────────────────────────────────────────
+
+/// Platform-wide aggregate metrics drawn from the shared tunnel_log and users tables.
+/// Queries all regions via the shared PostgreSQL — no per-region fan-out needed.
+#[derive(Debug, serde::Serialize)]
+pub struct PlatformUsage {
+    /// Open tunnels across all regions right now.
+    pub active_tunnels_global: i64,
+    /// Tunnel registrations since midnight UTC today (all regions).
+    pub tunnels_today: i64,
+    /// Distinct users with at least one open tunnel right now.
+    pub active_users: i64,
+    /// Bytes proxied since midnight UTC today (all regions).
+    pub bandwidth_today_bytes: i64,
+    /// Total registered user accounts.
+    pub total_users: i64,
+}
+
+pub async fn get_platform_usage(pool: &PgPool) -> Result<PlatformUsage> {
+    let (active_tunnels, tunnels_today, active_users, bandwidth_today, total_users) = tokio::join!(
+        sqlx::query_as::<_, (i64,)>(
+            "SELECT COUNT(*)::bigint FROM tunnel_log WHERE unregistered_at IS NULL"
+        )
+        .fetch_one(pool),
+        sqlx::query_as::<_, (i64,)>(
+            "SELECT COUNT(*)::bigint FROM tunnel_log WHERE registered_at >= CURRENT_DATE"
+        )
+        .fetch_one(pool),
+        sqlx::query_as::<_, (i64,)>(
+            "SELECT COUNT(DISTINCT user_id)::bigint FROM tunnel_log \
+             WHERE unregistered_at IS NULL AND user_id IS NOT NULL"
+        )
+        .fetch_one(pool),
+        sqlx::query_as::<_, (i64,)>(
+            "SELECT COALESCE(SUM(bytes_proxied), 0)::bigint FROM tunnel_log \
+             WHERE registered_at >= CURRENT_DATE"
+        )
+        .fetch_one(pool),
+        sqlx::query_as::<_, (i64,)>("SELECT COUNT(*)::bigint FROM users").fetch_one(pool),
+    );
+    Ok(PlatformUsage {
+        active_tunnels_global: active_tunnels?.0,
+        tunnels_today: tunnels_today?.0,
+        active_users: active_users?.0,
+        bandwidth_today_bytes: bandwidth_today?.0,
+        total_users: total_users?.0,
+    })
+}
+
+// ── admin per-user tunnel / token helpers ─────────────────────────────────────
+
+/// Paginated tunnel history for a single user (newest first).
+pub async fn list_user_tunnels(
+    pool: &PgPool,
+    user_id: &uuid::Uuid,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<AdminTunnelEntry>> {
+    let rows: Vec<AdminTunnelEntry> = sqlx::query_as(
+        "SELECT tl.id, tl.tunnel_id, tl.protocol, tl.label, tl.session_id,
+                tl.token_id, t.label AS token_label,
+                tl.registered_at, tl.unregistered_at, tl.region_id,
+                tl.bytes_proxied, tl.request_count, tl.user_id
+         FROM tunnel_log tl
+         LEFT JOIN tokens t ON t.id::text = tl.token_id
+         WHERE tl.user_id = $1
+         ORDER BY tl.registered_at DESC
+         LIMIT $2 OFFSET $3",
+    )
+    .bind(user_id)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Total tunnel_log rows for a given user (for pagination).
+pub async fn count_user_tunnels(pool: &PgPool, user_id: &uuid::Uuid) -> Result<i64> {
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*)::bigint FROM tunnel_log WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_one(pool)
+            .await?;
+    Ok(count)
+}
+
+/// All tokens owned by a user with their historical tunnel registration counts.
+pub async fn list_user_tokens(pool: &PgPool, user_id: &uuid::Uuid) -> Result<Vec<TokenWithCount>> {
+    let rows: Vec<TokenWithCount> = sqlx::query_as(
+        "SELECT t.id, t.token_hash, t.label, t.created_at, t.last_used_at, t.scope,
+                t.user_id, t.expires_at, t.tier, t.tunnel_limit, t.status, t.unlimited,
+                COALESCE(COUNT(tl.id), 0)::bigint AS tunnel_count
+         FROM tokens t
+         LEFT JOIN tunnel_log tl ON tl.token_id = t.id::text
+         WHERE t.user_id = $1
+         GROUP BY t.id
+         ORDER BY t.created_at DESC",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
 }

--- a/crates/rustunnel-server/src/db/models.rs
+++ b/crates/rustunnel-server/src/db/models.rs
@@ -92,6 +92,44 @@ pub struct TunnelLogEntry {
     pub region_id: Option<String>,
 }
 
+/// A plan row with its live subscriber count.
+/// Returned by `GET /api/admin/plans`.
+#[derive(Debug, Clone, Serialize, FromRow)]
+pub struct AdminPlan {
+    pub id: Uuid,
+    pub name: String,
+    pub billing_model: String,
+    pub monthly_price_cents: i32,
+    pub max_tunnels: Option<i32>,
+    pub max_connections: i32,
+    pub rate_limit_rps: i32,
+    pub bandwidth_limit_gb: Option<i32>,
+    pub history_days: i32,
+    pub is_active: bool,
+    /// Number of subscriptions with `status = 'active'` on this plan.
+    pub subscriber_count: i64,
+}
+
+/// A tunnel_log row enriched with usage counters for admin inspection.
+/// Extends `TunnelLogEntry` with `bytes_proxied`, `request_count`, and `user_id`.
+/// Returned by `GET /api/admin/users/:id/tunnels`.
+#[derive(Debug, Clone, Serialize, FromRow)]
+pub struct AdminTunnelEntry {
+    pub id: String,
+    pub tunnel_id: String,
+    pub protocol: String,
+    pub label: String,
+    pub session_id: String,
+    pub token_id: Option<String>,
+    pub token_label: Option<String>,
+    pub registered_at: DateTime<Utc>,
+    pub unregistered_at: Option<DateTime<Utc>>,
+    pub region_id: Option<String>,
+    pub bytes_proxied: i64,
+    pub request_count: i64,
+    pub user_id: Option<Uuid>,
+}
+
 /// A row from the `regions` table.
 #[derive(Debug, Clone, Serialize, FromRow)]
 pub struct Region {


### PR DESCRIPTION
…points

Phase 2.5 admin API additions — four new routes all requiring the admin token:

  GET /api/admin/plans
    Lists all plans with live active-subscriber counts via LEFT JOIN on
    subscriptions. Used by the admin dashboard plan management page.

  GET /api/admin/usage/platform
    Platform-wide ops metrics aggregated from the shared PostgreSQL:
    active tunnels globally, tunnels opened today, active users (with open
    tunnels), bandwidth today (bytes), and total registered users.
    Five queries run in parallel via tokio::join!.

  GET /api/admin/users/:id/tunnels
    Paginated tunnel history for a single user — includes bytes_proxied,
    request_count, and region_id which the general /api/history endpoint
    omits. Useful for billing disputes and debugging.

  GET /api/admin/users/:id/tokens
    All tokens belonging to a user with their historical tunnel counts.
    Reuses TokenWithCount; filtered by user_id.

New models: AdminPlan, AdminTunnelEntry (db/models.rs). New DB helpers: list_admin_plans, get_platform_usage (PlatformUsage struct), list_user_tunnels, count_user_tunnels, list_user_tokens (db/mod.rs).