### PR TITLE
Feature: added migration to include system tokens

### DIFF
--- a/crates/rustunnel-server/migrations/pg/0013_system_tokens.sql
+++ b/crates/rustunnel-server/migrations/pg/0013_system_tokens.sql
@@ -1,0 +1,7 @@
+-- System tokens are non-billable; used for synthetic monitoring tunnels
+-- driven by the public status page (status.rustunnel.com). PAYG metering
+-- and dashboards filter `WHERE system = FALSE` once that aggregation ships.
+
+ALTER TABLE tokens ADD COLUMN IF NOT EXISTS system BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_tokens_system ON tokens (system) WHERE system = TRUE;


### PR DESCRIPTION
New migration crates/rustunnel-server/migrations/pg/0013_system_tokens.sql — adds tokens.system BOOLEAN NOT NULL DEFAULT FALSE + partial index. Existing rows default to FALSE. Future PAYG metering will filter WHERE system = FALSE.