### PR TITLE
chore: auto-bump semver in bump-version.sh (TUNNEL-3)

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -2,28 +2,46 @@
 # bump-version.sh — update version in all crate Cargo.toml files
 #
 # Usage:
-#   ./scripts/bump-version.sh <new-version>
+#   ./scripts/bump-version.sh                 # auto-bump patch (with rollover)
+#   ./scripts/bump-version.sh patch           # auto-bump patch (with rollover)
+#   ./scripts/bump-version.sh minor           # bump minor, reset patch
+#   ./scripts/bump-version.sh major           # bump major, reset minor and patch
+#   ./scripts/bump-version.sh 1.2.3           # set explicit version
 #
-# Example:
-#   ./scripts/bump-version.sh 0.3.0
+# Rollover thresholds (configurable via env):
+#   MAX_PATCH (default 99) — when bumping patch, if new patch > MAX_PATCH, rollover to minor
+#   MAX_MINOR (default 99) — when bumping minor, if new minor > MAX_MINOR, rollover to major
+#
+# Examples (with defaults MAX_PATCH=99, MAX_MINOR=99):
+#   0.5.1   → patch → 0.5.2
+#   0.5.99  → patch → 0.6.0   (patch rollover)
+#   0.99.99 → patch → 1.0.0   (cascading rollover)
+#   1.2.3   → minor → 1.3.0
 
 set -euo pipefail
 
-# ── validate argument ──────────────────────────────────────────────────────────
+# ── configurable thresholds ────────────────────────────────────────────────────
 
-if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 <new-version>"
-    echo "Example: $0 0.3.0"
+MAX_PATCH="${MAX_PATCH:-99}"
+MAX_MINOR="${MAX_MINOR:-99}"
+
+if ! [[ "$MAX_PATCH" =~ ^[0-9]+$ ]] || (( MAX_PATCH < 0 )); then
+    echo "Error: MAX_PATCH must be a non-negative integer (got: $MAX_PATCH)"
+    exit 1
+fi
+if ! [[ "$MAX_MINOR" =~ ^[0-9]+$ ]] || (( MAX_MINOR < 0 )); then
+    echo "Error: MAX_MINOR must be a non-negative integer (got: $MAX_MINOR)"
     exit 1
 fi
 
-NEW_VERSION="$1"
+# ── parse argument ─────────────────────────────────────────────────────────────
 
-# Validate semver format (major.minor.patch, each part numeric)
-if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Error: version must be in semver format (e.g. 1.2.3), got: $NEW_VERSION"
+if [[ $# -gt 1 ]]; then
+    echo "Usage: $0 [patch|minor|major|<X.Y.Z>]"
     exit 1
 fi
+
+ARG="${1:-patch}"
 
 # ── locate repo root ───────────────────────────────────────────────────────────
 
@@ -37,12 +55,72 @@ CRATES=(
     "crates/rustunnel-protocol/Cargo.toml"
 )
 
-# ── show current versions ──────────────────────────────────────────────────────
+# ── read current version from the first crate ─────────────────────────────────
 
-echo "Bumping version to $NEW_VERSION"
+FIRST_FILE="$REPO_ROOT/${CRATES[0]}"
+if [[ ! -f "$FIRST_FILE" ]]; then
+    echo "Error: $FIRST_FILE not found"
+    exit 1
+fi
+OLD_VERSION=$(grep '^version' "$FIRST_FILE" | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+if ! [[ "$OLD_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    echo "Error: could not parse current version '$OLD_VERSION' from $FIRST_FILE"
+    exit 1
+fi
+CUR_MAJOR="${BASH_REMATCH[1]}"
+CUR_MINOR="${BASH_REMATCH[2]}"
+CUR_PATCH="${BASH_REMATCH[3]}"
+
+# ── compute new version ────────────────────────────────────────────────────────
+
+case "$ARG" in
+    patch)
+        NEW_MAJOR="$CUR_MAJOR"
+        NEW_MINOR="$CUR_MINOR"
+        NEW_PATCH=$((CUR_PATCH + 1))
+        if (( NEW_PATCH > MAX_PATCH )); then
+            NEW_PATCH=0
+            NEW_MINOR=$((CUR_MINOR + 1))
+            if (( NEW_MINOR > MAX_MINOR )); then
+                NEW_MINOR=0
+                NEW_MAJOR=$((CUR_MAJOR + 1))
+            fi
+        fi
+        NEW_VERSION="${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+        ;;
+    minor)
+        NEW_MAJOR="$CUR_MAJOR"
+        NEW_MINOR=$((CUR_MINOR + 1))
+        NEW_PATCH=0
+        if (( NEW_MINOR > MAX_MINOR )); then
+            NEW_MINOR=0
+            NEW_MAJOR=$((CUR_MAJOR + 1))
+        fi
+        NEW_VERSION="${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+        ;;
+    major)
+        NEW_MAJOR=$((CUR_MAJOR + 1))
+        NEW_MINOR=0
+        NEW_PATCH=0
+        NEW_VERSION="${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+        ;;
+    *)
+        if [[ "$ARG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            NEW_VERSION="$ARG"
+        else
+            echo "Error: argument must be 'patch', 'minor', 'major', or a semver (e.g. 1.2.3); got: $ARG"
+            exit 1
+        fi
+        ;;
+esac
+
+# ── show plan ──────────────────────────────────────────────────────────────────
+
+echo "Current version: $OLD_VERSION"
+echo "New version:     $NEW_VERSION  (bump: $ARG; MAX_PATCH=$MAX_PATCH, MAX_MINOR=$MAX_MINOR)"
 echo ""
 
-OLD_VERSION=""
 for CRATE in "${CRATES[@]}"; do
     FILE="$REPO_ROOT/$CRATE"
     if [[ ! -f "$FILE" ]]; then
@@ -50,9 +128,6 @@ for CRATE in "${CRATES[@]}"; do
         exit 1
     fi
     CURRENT=$(grep '^version' "$FILE" | head -1 | sed 's/version = "\(.*\)"/\1/')
-    if [[ -z "$OLD_VERSION" ]]; then
-        OLD_VERSION="$CURRENT"
-    fi
     echo "  $CRATE  ($CURRENT → $NEW_VERSION)"
 done
 


### PR DESCRIPTION
Make the version argument optional. Default action is to bump the patch with cascading rollover to minor/major when MAX_PATCH/MAX_MINOR (default 99) are exceeded. Also accepts patch/minor/major keywords; explicit X.Y.Z still works for backward compatibility.