### PR TITLE
docs: add group-based load balancing to roadmap (TUNNEL-7)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -146,6 +146,7 @@ Items below are not committed to any release timeline. They represent directions
 - [ ] Windows support for the client binary
 - [ ] Config file hot-reload (SIGHUP) without restarting the server
 - [ ] Health check / heartbeat endpoint for load balancer probing
+- [ ] Group-based load balancing across multiple backends — multiple clients register against the same HTTP subdomain or TCP port under a shared group + group key, and inbound connections are dispatched at random to a healthy member. Includes built-in TCP and HTTP health checks (interval / timeout / max-failed) so unhealthy backends are removed from the pool automatically. Modeled on FRP's `loadBalancer.group` / `healthCheck` config; see [TUNNEL-7]
 
 ### Multi-region (Phase 5 — unified dashboard) ✅ Complete
 - [x] Dashboard fan-out queries — active tunnels aggregated across all regions via parallel API calls


### PR DESCRIPTION
## Summary

- Adds a Medium-term ROADMAP entry for group-based load balancing across multiple backends with built-in TCP + HTTP health checks, modeled on FRP's `loadBalancer.group` / `healthCheck` config.
- Detailed design plan lives in the private dev-docs repo (TUNNEL-7).

Linear: TUNNEL-7

## Test plan

- [ ] Render the rendered ROADMAP.md on GitHub and confirm formatting / link
- [ ] No code changes — pre-push hooks (fmt + clippy + unit tests) ran green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)