### PR TITLE
TUNNEL-8: load-balancing Phase 0 + Phase 1 (protocol + TunnelGroup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,9 +131,9 @@ Central shared state, `Arc`-wrapped and passed to all subsystems:
 
 ```rust
 pub struct TunnelCore {
-    http_routes: DashMap<String, TunnelInfo>,        // subdomain → tunnel
-    tcp_routes:  DashMap<u16, TunnelInfo>,           // port → tunnel
-    udp_routes:  DashMap<u16, TunnelInfo>,           // port → tunnel
+    http_routes: DashMap<String, Arc<TunnelGroup>>,  // subdomain → group of members
+    tcp_routes:  DashMap<u16, Arc<TunnelGroup>>,     // port → group of members
+    udp_routes:  DashMap<u16, Arc<TunnelGroup>>,     // port → group of members
     p2p_tunnels: DashMap<String, P2pPublisher>,      // name → P2P publisher
     sessions:    DashMap<Uuid, SessionInfo>,         // connected clients
     available_tcp_ports: Mutex<Vec<u16>>,            // free TCP port pool
@@ -146,6 +146,16 @@ pub struct TunnelCore {
     ip_limiter:   Arc<IpRateLimiter>,                // per-source-IP sliding window
 }
 ```
+
+Each route key resolves to a `TunnelGroup` of one or more `GroupMember`s
+(see `core/tunnel.rs`). Today every group has exactly one member — the route
+shape is in place ahead of TUNNEL-7 group-based load balancing (`see
+../rustunnel-private/docs/development/load-balancing-and-health-checks.md`).
+`resolve_http` / `resolve_tcp` / `resolve_udp` pick a healthy member uniformly
+at random; ungrouped registrations stay healthy for life. The
+`[load_balancing] enabled` flag in `server.toml` is the kill switch for
+honouring multi-member groups (defaults to `false`; flipped on per region
+during the EU → US → AP rollout).
 
 ### Protocol (`crates/rustunnel-protocol/src/frame.rs`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,6 +2621,7 @@ dependencies = [
  "hyper-util",
  "instant-acme",
  "parking_lot",
+ "rand 0.8.5",
  "rcgen",
  "reqwest 0.12.28",
  "rustls",

--- a/crates/rustunnel-client/src/control.rs
+++ b/crates/rustunnel-client/src/control.rs
@@ -303,6 +303,10 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
                 local_addr,
                 p2p_secret_hash: tunnel.p2p_secret_hash.clone(),
                 p2p_name: tunnel.p2p_name.clone(),
+                // Load-balancing fields are wired up in Phase 2/4 (TUNNEL-7).
+                group: None,
+                group_key_hash: None,
+                health_check: None,
             },
         )
         .await?;

--- a/crates/rustunnel-protocol/src/frame.rs
+++ b/crates/rustunnel-protocol/src/frame.rs
@@ -13,6 +13,43 @@ pub enum TunnelProtocol {
     P2p,
 }
 
+// ── Health-check spec (load balancing — TUNNEL-7) ─────────────────────────────
+
+/// Probe type for client-side health checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HealthCheckKind {
+    /// Open a TCP connection to the local service; success = connect within timeout.
+    Tcp,
+    /// `GET <http_path>` on the local service; success = 2xx within timeout.
+    Http,
+}
+
+/// Health-check configuration sent by the client at registration.
+///
+/// The server stores this per member so dashboards can surface what's being
+/// probed, but probes themselves run on the client (FRP-style trust model).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HealthCheckSpec {
+    pub kind: HealthCheckKind,
+    /// Probe interval in seconds.
+    pub interval_secs: u32,
+    /// Per-probe timeout in seconds.
+    pub timeout_secs: u32,
+    /// Consecutive failures required before reporting `TunnelUnhealthy`.
+    pub max_failed: u32,
+    /// Path used by HTTP probes (required when `kind = Http`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_path: Option<String>,
+    /// When true (default), only HTTP 2xx responses count as healthy.
+    #[serde(default = "default_http_expect_2xx")]
+    pub http_expect_2xx: bool,
+}
+
+fn default_http_expect_2xx() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ControlFrame {
@@ -38,6 +75,18 @@ pub enum ControlFrame {
         /// Human-readable tunnel name for P2P discovery (P2P publisher only).
         #[serde(skip_serializing_if = "Option::is_none")]
         p2p_name: Option<String>,
+        /// Load-balancing group name. Tunnels sharing the same group + key
+        /// form one logical pool dispatched at random. Omitted by older clients.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        group: Option<String>,
+        /// SHA-256 of the shared `group_key` (never the raw key). Required when
+        /// `group` is set — used by the server to authorise group joins.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        group_key_hash: Option<String>,
+        /// Optional client-side health-check spec. When present, the client
+        /// probes its local service and reports `TunnelHealthy`/`TunnelUnhealthy`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        health_check: Option<HealthCheckSpec>,
     },
     TunnelRegistered {
         request_id: String,
@@ -68,6 +117,23 @@ pub enum ControlFrame {
     },
     Pong {
         timestamp: u64,
+    },
+
+    // ── Load-balancing health reports (TUNNEL-7) ─────────────────────────
+    /// Client reports that a previously-registered tunnel's upstream is healthy
+    /// again (sent on the first probe success after a failure streak, and as
+    /// the initial signal for tunnels that registered with a `health_check`).
+    /// New clients should only emit this when the server's advertised version
+    /// supports load balancing; older servers will log a decode error otherwise.
+    TunnelHealthy {
+        tunnel_id: Uuid,
+    },
+    /// Client reports that a tunnel's upstream has failed `max_failed`
+    /// consecutive probes. The server excludes the member from dispatch until
+    /// a `TunnelHealthy` arrives.
+    TunnelUnhealthy {
+        tunnel_id: Uuid,
+        reason: String,
     },
 
     // ── P2P frames ───────────────────────────────────────────────────────
@@ -129,4 +195,103 @@ pub fn encode_frame(frame: &ControlFrame) -> Vec<u8> {
 
 pub fn decode_frame(data: &[u8]) -> Result<ControlFrame> {
     serde_json::from_slice(data).map_err(|e| Error::Protocol(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Old clients (pre-load-balancing) never emit the new fields. The wire
+    /// shape they produce — and parse — must continue to round-trip exactly.
+    #[test]
+    fn legacy_register_tunnel_round_trip_unchanged() {
+        // The literal payload an old client produced before this change.
+        let legacy = r#"{"type":"register_tunnel","request_id":"req-1","protocol":"http","subdomain":"foo","local_addr":"127.0.0.1:3000"}"#;
+        let frame = decode_frame(legacy.as_bytes()).expect("decode legacy");
+        match &frame {
+            ControlFrame::RegisterTunnel {
+                group,
+                group_key_hash,
+                health_check,
+                ..
+            } => {
+                assert!(group.is_none());
+                assert!(group_key_hash.is_none());
+                assert!(health_check.is_none());
+            }
+            other => panic!("unexpected frame: {other:?}"),
+        }
+        // Re-encoding must not introduce keys for the optional new fields —
+        // older servers must keep parsing it cleanly.
+        let reencoded = String::from_utf8(encode_frame(&frame)).unwrap();
+        assert!(!reencoded.contains("\"group\""));
+        assert!(!reencoded.contains("\"group_key_hash\""));
+        assert!(!reencoded.contains("\"health_check\""));
+    }
+
+    #[test]
+    fn register_tunnel_with_group_round_trip() {
+        let frame = ControlFrame::RegisterTunnel {
+            request_id: "req-2".into(),
+            protocol: TunnelProtocol::Tcp,
+            subdomain: None,
+            local_addr: "127.0.0.1:8080".into(),
+            p2p_secret_hash: None,
+            p2p_name: None,
+            group: Some("web".into()),
+            group_key_hash: Some("a".repeat(64)),
+            health_check: Some(HealthCheckSpec {
+                kind: HealthCheckKind::Http,
+                interval_secs: 10,
+                timeout_secs: 3,
+                max_failed: 3,
+                http_path: Some("/status".into()),
+                http_expect_2xx: true,
+            }),
+        };
+        let bytes = encode_frame(&frame);
+        let decoded = decode_frame(&bytes).expect("decode round-trip");
+        match decoded {
+            ControlFrame::RegisterTunnel {
+                group,
+                group_key_hash,
+                health_check,
+                ..
+            } => {
+                assert_eq!(group.as_deref(), Some("web"));
+                assert_eq!(group_key_hash.as_deref(), Some(&*"a".repeat(64)));
+                let spec = health_check.expect("health spec preserved");
+                assert_eq!(spec.kind, HealthCheckKind::Http);
+                assert_eq!(spec.http_path.as_deref(), Some("/status"));
+            }
+            other => panic!("unexpected frame: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tunnel_healthy_unhealthy_round_trip() {
+        let id = uuid::Uuid::new_v4();
+        let healthy = ControlFrame::TunnelHealthy { tunnel_id: id };
+        let unhealthy = ControlFrame::TunnelUnhealthy {
+            tunnel_id: id,
+            reason: "connection refused".into(),
+        };
+        for f in [healthy, unhealthy] {
+            let bytes = encode_frame(&f);
+            // Re-decoding must not fail.
+            decode_frame(&bytes).expect("decode round-trip");
+        }
+    }
+
+    /// An old server receiving a payload that *omits* `health_check` must
+    /// still parse it; the new field defaults to `None` even though we do not
+    /// emit `#[serde(default)]` (Option<T> is implicitly defaulting in serde).
+    #[test]
+    fn forward_compat_old_server_decodes_new_field_absence() {
+        // Construct a minimal payload as a byte string (server's perspective).
+        let payload =
+            r#"{"type":"tunnel_healthy","tunnel_id":"00000000-0000-0000-0000-000000000000"}"#;
+        let frame = decode_frame(payload.as_bytes()).expect("decode tunnel_healthy");
+        assert!(matches!(frame, ControlFrame::TunnelHealthy { .. }));
+    }
 }

--- a/crates/rustunnel-protocol/src/lib.rs
+++ b/crates/rustunnel-protocol/src/lib.rs
@@ -2,4 +2,6 @@ pub mod error;
 pub mod frame;
 
 pub use error::{Error, Result};
-pub use frame::{decode_frame, encode_frame, ControlFrame, TunnelProtocol};
+pub use frame::{
+    decode_frame, encode_frame, ControlFrame, HealthCheckKind, HealthCheckSpec, TunnelProtocol,
+};

--- a/crates/rustunnel-server/Cargo.toml
+++ b/crates/rustunnel-server/Cargo.toml
@@ -50,3 +50,4 @@ x509-parser = { workspace = true }
 socket2 = { workspace = true }
 sentry = { workspace = true }
 sentry-tracing = { workspace = true }
+rand = { workspace = true }

--- a/crates/rustunnel-server/src/config.rs
+++ b/crates/rustunnel-server/src/config.rs
@@ -17,6 +17,26 @@ pub struct ServerConfig {
     /// P2P direct connection settings.
     #[serde(default)]
     pub p2p: P2pSection,
+    /// Load-balancing kill switch (TUNNEL-7, Phase 6 of the plan).
+    /// When `false` (default), grouped registrations fall through and behave
+    /// as solo tunnels exactly like today — protocol fields are accepted but
+    /// not honoured. Flip per region during the EU → US → AP rollout.
+    #[serde(default)]
+    pub load_balancing: LoadBalancingSection,
+}
+
+/// Per-region kill switch and tunables for group-based load balancing.
+///
+/// The default (`enabled = false`) is intentional — Phase 0 / Phase 1 ship
+/// the protocol and routing-table refactor without changing any user-visible
+/// behaviour. Phase 2/3 of the plan will start honouring this flag.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct LoadBalancingSection {
+    /// Master switch. `false` → group/group_key_hash are accepted on
+    /// `RegisterTunnel` but ignored; `true` → registrations with the same
+    /// `(subdomain, group_key_hash)` form one pool with random dispatch.
+    #[serde(default)]
+    pub enabled: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -298,6 +318,7 @@ impl Default for ServerConfig {
                 location: "localhost".to_string(),
             },
             p2p: P2pSection::default(),
+            load_balancing: LoadBalancingSection::default(),
         }
     }
 }

--- a/crates/rustunnel-server/src/control/session.rs
+++ b/crates/rustunnel-server/src/control/session.rs
@@ -482,6 +482,12 @@ where
             local_addr: _,
             p2p_secret_hash,
             p2p_name,
+            // Phase 0: accept the new load-balancing fields on the wire so old
+            // clients keep working unchanged. Server-side handling lands in
+            // later phases of TUNNEL-7.
+            group: _,
+            group_key_hash: _,
+            health_check: _,
         } => {
             tracing::debug!(%session_id, %request_id, ?protocol, "register tunnel");
 
@@ -1088,6 +1094,20 @@ where
             );
             // Store for dashboard visibility. These are informational only —
             // not used for billing (direct P2P traffic can't be verified).
+        }
+
+        // Phase 0 of TUNNEL-7: accept the new health-report frames so newer
+        // clients connecting to this server don't trip a `decode_frame`
+        // warning. Behaviour wires up in Phase 4 (group dispatch + healthy
+        // bit). Until then the only effect is a debug-level log line.
+        ControlFrame::TunnelHealthy { tunnel_id } => {
+            tracing::debug!(%session_id, %tunnel_id, "tunnel reported healthy (no-op pre-Phase-4)");
+        }
+        ControlFrame::TunnelUnhealthy { tunnel_id, reason } => {
+            tracing::debug!(
+                %session_id, %tunnel_id, %reason,
+                "tunnel reported unhealthy (no-op pre-Phase-4)"
+            );
         }
 
         other => {

--- a/crates/rustunnel-server/src/core/mod.rs
+++ b/crates/rustunnel-server/src/core/mod.rs
@@ -6,4 +6,7 @@ pub mod tunnel;
 pub use ip_limiter::IpRateLimiter;
 pub use limiter::RateLimiter;
 pub use router::{classify_nat_pair, P2pPublisher, TunnelCore};
-pub use tunnel::{ControlMessage, SessionInfo, TcpTunnelEvent, TunnelInfo, UdpTunnelEvent};
+pub use tunnel::{
+    ControlMessage, GroupMember, SessionInfo, TcpTunnelEvent, TunnelGroup, TunnelInfo,
+    UdpTunnelEvent,
+};

--- a/crates/rustunnel-server/src/core/router.rs
+++ b/crates/rustunnel-server/src/core/router.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use dashmap::DashMap;
 use parking_lot::Mutex;
+use rand::seq::IteratorRandom;
 use tokio::io::DuplexStream;
 use tokio::sync::{broadcast, mpsc, oneshot, Semaphore};
 use uuid::Uuid;
@@ -15,7 +16,9 @@ use crate::error::{Error, Result};
 
 use super::ip_limiter::IpRateLimiter;
 use super::limiter::RateLimiter;
-use super::tunnel::{ControlMessage, SessionInfo, TcpTunnelEvent, TunnelInfo, UdpTunnelEvent};
+use super::tunnel::{
+    ControlMessage, SessionInfo, TcpTunnelEvent, TunnelGroup, TunnelInfo, UdpTunnelEvent,
+};
 
 /// Broadcast channel capacity for TCP/UDP tunnel lifecycle events.
 const TCP_EVENT_CAPACITY: usize = 64;
@@ -28,12 +31,19 @@ const UDP_EVENT_CAPACITY: usize = 64;
 /// All public methods are designed to be called from many async tasks concurrently;
 /// interior mutability is provided by `DashMap` and `parking_lot::Mutex`.
 pub struct TunnelCore {
-    /// subdomain → TunnelInfo  (HTTP / HTTPS tunnels)
-    pub http_routes: DashMap<String, TunnelInfo>,
-    /// port → TunnelInfo  (TCP tunnels)
-    pub tcp_routes: DashMap<u16, TunnelInfo>,
-    /// port → TunnelInfo  (UDP tunnels)
-    pub udp_routes: DashMap<u16, TunnelInfo>,
+    /// subdomain → group of HTTP/HTTPS members.
+    ///
+    /// In Phase 1 every group has exactly one member (degenerate case);
+    /// Phase 2 of TUNNEL-7 lifts the cap so multiple clients can register the
+    /// same subdomain with a shared `group_key` and share traffic.
+    pub http_routes: DashMap<String, Arc<TunnelGroup>>,
+    /// port → group of TCP members. Same shape as `http_routes` — Phase 3
+    /// allows multiple clients on the same port via groups.
+    pub tcp_routes: DashMap<u16, Arc<TunnelGroup>>,
+    /// port → group of UDP members. UDP grouping isn't on the roadmap yet
+    /// (see plan §6); the `Arc<TunnelGroup>` wrapper keeps the dispatch path
+    /// uniform with HTTP/TCP.
+    pub udp_routes: DashMap<u16, Arc<TunnelGroup>>,
     /// name → P2pPublisher  (P2P tunnels registered by publishers)
     pub p2p_tunnels: DashMap<String, P2pPublisher>,
     /// session_id → SessionInfo
@@ -263,7 +273,8 @@ impl TunnelCore {
             conn_semaphore: Arc::new(Semaphore::new(self.max_connections_per_tunnel)),
         };
 
-        self.http_routes.insert(subdomain.clone(), info);
+        let group = TunnelGroup::new_solo(subdomain.clone(), info);
+        self.http_routes.insert(subdomain.clone(), group);
         self.tunnel_index
             .insert(tunnel_id, TunnelKey::Http(subdomain.clone()));
         self.add_tunnel_to_session(session_id, tunnel_id);
@@ -295,7 +306,8 @@ impl TunnelCore {
             conn_semaphore: Arc::new(Semaphore::new(self.max_connections_per_tunnel)),
         };
 
-        self.tcp_routes.insert(port, info);
+        let group = TunnelGroup::new_solo(port.to_string(), info);
+        self.tcp_routes.insert(port, group);
         self.tunnel_index.insert(tunnel_id, TunnelKey::Tcp(port));
         self.add_tunnel_to_session(session_id, tunnel_id);
         let _ = self
@@ -329,7 +341,8 @@ impl TunnelCore {
             conn_semaphore: Arc::new(Semaphore::new(self.max_connections_per_tunnel)),
         };
 
-        self.udp_routes.insert(port, info);
+        let group = TunnelGroup::new_solo(port.to_string(), info);
+        self.udp_routes.insert(port, group);
         self.tunnel_index.insert(tunnel_id, TunnelKey::Udp(port));
         self.add_tunnel_to_session(session_id, tunnel_id);
         let _ = self
@@ -415,23 +428,59 @@ impl TunnelCore {
     }
 
     /// Remove a tunnel by ID, returning any allocated TCP/UDP port to the pool.
+    ///
+    /// For grouped routes the member is removed from its `TunnelGroup`; the
+    /// group itself (and the associated route entry, port allocation, and
+    /// edge listener) only goes away when the *last* member leaves.
+    /// Phase 1 has one-member-per-group, so every removal is the last one;
+    /// this shape keeps Phase 2/3 from having to revisit the removal path.
     pub fn remove_tunnel(&self, tunnel_id: &Uuid) {
         let Some((_, key)) = self.tunnel_index.remove(tunnel_id) else {
             return;
         };
         match key {
             TunnelKey::Http(subdomain) => {
-                self.http_routes.remove(&subdomain);
+                let group_empty = self
+                    .http_routes
+                    .get(&subdomain)
+                    .map(|g| {
+                        g.members.remove(tunnel_id);
+                        g.members.is_empty()
+                    })
+                    .unwrap_or(true);
+                if group_empty {
+                    self.http_routes.remove(&subdomain);
+                }
             }
             TunnelKey::Tcp(port) => {
-                self.tcp_routes.remove(&port);
-                self.available_tcp_ports.lock().push(port);
-                let _ = self.tcp_events.send(TcpTunnelEvent::Unregistered { port });
+                let group_empty = self
+                    .tcp_routes
+                    .get(&port)
+                    .map(|g| {
+                        g.members.remove(tunnel_id);
+                        g.members.is_empty()
+                    })
+                    .unwrap_or(true);
+                if group_empty {
+                    self.tcp_routes.remove(&port);
+                    self.available_tcp_ports.lock().push(port);
+                    let _ = self.tcp_events.send(TcpTunnelEvent::Unregistered { port });
+                }
             }
             TunnelKey::Udp(port) => {
-                self.udp_routes.remove(&port);
-                self.available_udp_ports.lock().push(port);
-                let _ = self.udp_events.send(UdpTunnelEvent::Unregistered { port });
+                let group_empty = self
+                    .udp_routes
+                    .get(&port)
+                    .map(|g| {
+                        g.members.remove(tunnel_id);
+                        g.members.is_empty()
+                    })
+                    .unwrap_or(true);
+                if group_empty {
+                    self.udp_routes.remove(&port);
+                    self.available_udp_ports.lock().push(port);
+                    let _ = self.udp_events.send(UdpTunnelEvent::Unregistered { port });
+                }
             }
             TunnelKey::P2p(name) => {
                 self.p2p_tunnels.remove(&name);
@@ -439,24 +488,38 @@ impl TunnelCore {
         }
     }
 
-    /// Return the current proxied-request count for a tunnel without removing it.
+    /// Return the current proxied-request count for the *specific* member
+    /// identified by `tunnel_id`. Per-member counters keep billing and
+    /// dashboards honest; aggregate at the group level when displaying.
     /// Returns 0 if the tunnel is unknown.
     pub fn get_tunnel_request_count(&self, tunnel_id: &Uuid) -> u64 {
         match self.tunnel_index.get(tunnel_id).as_deref() {
             Some(TunnelKey::Http(sub)) => self
                 .http_routes
                 .get(sub)
-                .map(|t| t.request_count.load(Ordering::Relaxed))
+                .and_then(|g| {
+                    g.members
+                        .get(tunnel_id)
+                        .map(|m| m.info.request_count.load(Ordering::Relaxed))
+                })
                 .unwrap_or(0),
             Some(TunnelKey::Tcp(port)) => self
                 .tcp_routes
                 .get(port)
-                .map(|t| t.request_count.load(Ordering::Relaxed))
+                .and_then(|g| {
+                    g.members
+                        .get(tunnel_id)
+                        .map(|m| m.info.request_count.load(Ordering::Relaxed))
+                })
                 .unwrap_or(0),
             Some(TunnelKey::Udp(port)) => self
                 .udp_routes
                 .get(port)
-                .map(|t| t.request_count.load(Ordering::Relaxed))
+                .and_then(|g| {
+                    g.members
+                        .get(tunnel_id)
+                        .map(|m| m.info.request_count.load(Ordering::Relaxed))
+                })
                 .unwrap_or(0),
             Some(TunnelKey::P2p(name)) => self
                 .p2p_tunnels
@@ -467,24 +530,36 @@ impl TunnelCore {
         }
     }
 
-    /// Return the current bytes-proxied counter for a tunnel without removing it.
+    /// Return the current bytes-proxied counter for a member.
     /// Returns 0 if the tunnel is unknown.
     pub fn get_tunnel_bytes_proxied(&self, tunnel_id: &Uuid) -> u64 {
         match self.tunnel_index.get(tunnel_id).as_deref() {
             Some(TunnelKey::Http(sub)) => self
                 .http_routes
                 .get(sub)
-                .map(|t| t.bytes_proxied.load(Ordering::Relaxed))
+                .and_then(|g| {
+                    g.members
+                        .get(tunnel_id)
+                        .map(|m| m.info.bytes_proxied.load(Ordering::Relaxed))
+                })
                 .unwrap_or(0),
             Some(TunnelKey::Tcp(port)) => self
                 .tcp_routes
                 .get(port)
-                .map(|t| t.bytes_proxied.load(Ordering::Relaxed))
+                .and_then(|g| {
+                    g.members
+                        .get(tunnel_id)
+                        .map(|m| m.info.bytes_proxied.load(Ordering::Relaxed))
+                })
                 .unwrap_or(0),
             Some(TunnelKey::Udp(port)) => self
                 .udp_routes
                 .get(port)
-                .map(|t| t.bytes_proxied.load(Ordering::Relaxed))
+                .and_then(|g| {
+                    g.members
+                        .get(tunnel_id)
+                        .map(|m| m.info.bytes_proxied.load(Ordering::Relaxed))
+                })
                 .unwrap_or(0),
             Some(TunnelKey::P2p(name)) => self
                 .p2p_tunnels
@@ -498,30 +573,53 @@ impl TunnelCore {
     // ── resolution (hot path) ─────────────────────────────────────────────────
 
     /// Look up the tunnel and its session's control channel by subdomain.
+    ///
+    /// Picks a healthy member uniformly at random. In Phase 1 every group
+    /// has exactly one (always-healthy) member, so this degenerates to the
+    /// previous behaviour. Once Phase 2 lands, the random pick gives us
+    /// FRP-style group dispatch with no further routing-layer changes.
     pub fn resolve_http(
         &self,
         subdomain: &str,
     ) -> Option<(TunnelInfo, mpsc::Sender<ControlMessage>)> {
-        let tunnel = self.http_routes.get(subdomain)?.clone();
-        let tx = self.sessions.get(&tunnel.session_id)?.control_tx.clone();
-        tunnel.request_count.fetch_add(1, Ordering::Relaxed);
-        Some((tunnel, tx))
+        let group = self.http_routes.get(subdomain)?.clone();
+        self.dispatch_member(&group)
     }
 
     /// Look up the tunnel and its session's control channel by TCP port.
     pub fn resolve_tcp(&self, port: u16) -> Option<(TunnelInfo, mpsc::Sender<ControlMessage>)> {
-        let tunnel = self.tcp_routes.get(&port)?.clone();
-        let tx = self.sessions.get(&tunnel.session_id)?.control_tx.clone();
-        tunnel.request_count.fetch_add(1, Ordering::Relaxed);
-        Some((tunnel, tx))
+        let group = self.tcp_routes.get(&port)?.clone();
+        self.dispatch_member(&group)
     }
 
     /// Look up the tunnel and its session's control channel by UDP port.
     pub fn resolve_udp(&self, port: u16) -> Option<(TunnelInfo, mpsc::Sender<ControlMessage>)> {
-        let tunnel = self.udp_routes.get(&port)?.clone();
-        let tx = self.sessions.get(&tunnel.session_id)?.control_tx.clone();
-        tunnel.request_count.fetch_add(1, Ordering::Relaxed);
-        Some((tunnel, tx))
+        let group = self.udp_routes.get(&port)?.clone();
+        self.dispatch_member(&group)
+    }
+
+    /// Pick one healthy member of `group` and return its tunnel info plus
+    /// the owning session's control channel. Returns `None` when no member
+    /// is healthy or the picked member's session has gone away.
+    fn dispatch_member(
+        &self,
+        group: &TunnelGroup,
+    ) -> Option<(TunnelInfo, mpsc::Sender<ControlMessage>)> {
+        // Pick uniformly at random among healthy members. We snapshot the
+        // chosen member's TunnelInfo (cheap — it's mostly Arc-wrapped
+        // counters) and drop the DashMap iter so we don't hold a shard lock
+        // across the session lookup.
+        let mut rng = rand::thread_rng();
+        let info = group
+            .members
+            .iter()
+            .filter(|m| m.healthy.load(Ordering::Acquire))
+            .map(|m| m.info.clone())
+            .choose(&mut rng)?;
+
+        let tx = self.sessions.get(&info.session_id)?.control_tx.clone();
+        info.request_count.fetch_add(1, Ordering::Relaxed);
+        Some((info, tx))
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
@@ -928,5 +1026,76 @@ mod tests {
         let (strategy, attempt) = classify_nat_pair(None, None);
         assert_eq!(strategy, "relay");
         assert!(!attempt);
+    }
+
+    // ── group sanity (Phase 1 of TUNNEL-7) ───────────────────────────────
+
+    /// Every solo registration is wrapped in a degenerate one-member group;
+    /// dispatch must still return that single member.
+    #[test]
+    fn http_solo_registration_creates_one_member_group() {
+        let core = make_core();
+        let (sid, _rx) = dummy_session(&core);
+        let (tid, _) = core
+            .register_http_tunnel(&sid, Some("solo".into()), TunnelProtocol::Http)
+            .unwrap();
+
+        let group = core.http_routes.get("solo").unwrap();
+        assert_eq!(group.members.len(), 1);
+        assert!(group.members.contains_key(&tid));
+        assert!(
+            group.key_hash.is_none(),
+            "no group_key on solo registrations"
+        );
+        assert_eq!(group.name, "solo");
+    }
+
+    /// Removing the only member of a group also removes the group itself
+    /// (and, for TCP, returns the port to the pool — exercised by the
+    /// existing `remove_tcp_tunnel_returns_port_to_pool` test).
+    #[test]
+    fn last_member_removal_evicts_group() {
+        let core = make_core();
+        let (sid, _rx) = dummy_session(&core);
+        let (tid, _) = core
+            .register_http_tunnel(&sid, Some("ephemeral".into()), TunnelProtocol::Http)
+            .unwrap();
+        assert!(core.http_routes.contains_key("ephemeral"));
+
+        core.remove_tunnel(&tid);
+        assert!(!core.http_routes.contains_key("ephemeral"));
+    }
+
+    /// Members marked unhealthy must be skipped by dispatch even though
+    /// they're still in the routing table. Phase 4 will be the first place
+    /// this bit gets flipped on a real `TunnelUnhealthy` frame; the dispatch
+    /// path is already wired so we lock it in with a test now.
+    #[test]
+    fn unhealthy_member_is_excluded_from_dispatch() {
+        let core = make_core();
+        let (sid, _rx) = dummy_session(&core);
+        let (tid, _) = core
+            .register_http_tunnel(&sid, Some("toggle".into()), TunnelProtocol::Http)
+            .unwrap();
+
+        // Flip the lone member to unhealthy.
+        {
+            let group = core.http_routes.get("toggle").unwrap();
+            let member = group.members.get(&tid).unwrap();
+            member.healthy.store(false, Ordering::Release);
+        }
+
+        assert!(
+            core.resolve_http("toggle").is_none(),
+            "no healthy members → resolve must return None"
+        );
+
+        // Mark healthy again → dispatch resumes.
+        {
+            let group = core.http_routes.get("toggle").unwrap();
+            let member = group.members.get(&tid).unwrap();
+            member.healthy.store(true, Ordering::Release);
+        }
+        assert!(core.resolve_http("toggle").is_some());
     }
 }

--- a/crates/rustunnel-server/src/core/tunnel.rs
+++ b/crates/rustunnel-server/src/core/tunnel.rs
@@ -1,14 +1,15 @@
 use std::net::SocketAddr;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64};
 use std::sync::Arc;
 use std::time::Instant;
 
+use dashmap::DashMap;
 use parking_lot::RwLock;
 use tokio::io::DuplexStream;
 use tokio::sync::{mpsc, Semaphore};
 use uuid::Uuid;
 
-use rustunnel_protocol::TunnelProtocol;
+use rustunnel_protocol::{HealthCheckSpec, TunnelProtocol};
 
 // ── TCP tunnel events (edge ↔ core) ───────────────────────────────────────────
 
@@ -63,6 +64,76 @@ pub struct TunnelInfo {
     /// Limits concurrent proxied connections for this tunnel.
     /// Shared across all clones so every proxy task draws from the same pool.
     pub conn_semaphore: Arc<Semaphore>,
+}
+
+// ── Load-balancing groups (TUNNEL-7) ──────────────────────────────────────────
+//
+// A `TunnelGroup` is the routing entry for an HTTP subdomain or a TCP/UDP
+// port. It holds one or more `GroupMember`s — each backed by a separate
+// `RegisterTunnel` from a separate client. Phase 1 only ever has a single
+// member per group (the "degenerate" case); multi-member registration arrives
+// in Phase 2/3.
+//
+// Storing this on the routing-table value side (instead of a separate map of
+// pools) makes resolution a single DashMap lookup and lets remove-on-last-leave
+// happen atomically next to the existing route-removal code.
+
+/// One backend in a `TunnelGroup`.
+///
+/// `healthy` defaults to `true` when no `health_spec` is set (we trust the
+/// client's presence) and to `false` when a spec exists, until the first
+/// `TunnelHealthy` arrives.
+#[derive(Debug)]
+pub struct GroupMember {
+    pub info: TunnelInfo,
+    pub healthy: AtomicBool,
+    /// Health-check spec from `RegisterTunnel.health_check`; `None` if the
+    /// client didn't ask for probes.
+    pub health_spec: Option<HealthCheckSpec>,
+    /// Tracked server-side for surfacing on the dashboard. Probe failures are
+    /// detected on the client; this counter is incremented on each
+    /// `TunnelUnhealthy` frame.
+    pub consecutive_failures: AtomicU32,
+}
+
+impl GroupMember {
+    /// Create a member that's immediately considered healthy. Used for the
+    /// Phase 1 path where no health-check spec is attached.
+    pub fn healthy_with(info: TunnelInfo) -> Self {
+        Self {
+            info,
+            healthy: AtomicBool::new(true),
+            health_spec: None,
+            consecutive_failures: AtomicU32::new(0),
+        }
+    }
+}
+
+/// A pool of one or more members serving the same subdomain or port.
+#[derive(Debug)]
+pub struct TunnelGroup {
+    /// Display name (== subdomain for HTTP, port-as-string for TCP/UDP, or
+    /// the user-supplied `group` from `RegisterTunnel` once Phase 2 lands).
+    pub name: String,
+    /// SHA-256 of the user-supplied `group_key`. `None` for ungrouped /
+    /// degenerate single-member registrations (Phase 1).
+    pub key_hash: Option<String>,
+    /// Members keyed by their `tunnel_id`.
+    pub members: DashMap<Uuid, GroupMember>,
+}
+
+impl TunnelGroup {
+    pub fn new_solo(name: String, info: TunnelInfo) -> Arc<Self> {
+        let group = Arc::new(Self {
+            name,
+            key_hash: None,
+            members: DashMap::new(),
+        });
+        group
+            .members
+            .insert(info.tunnel_id, GroupMember::healthy_with(info));
+        group
+    }
 }
 
 // ── per-session state ─────────────────────────────────────────────────────────

--- a/crates/rustunnel-server/src/dashboard/api.rs
+++ b/crates/rustunnel-server/src/dashboard/api.rs
@@ -180,7 +180,20 @@ async fn status_handler(State(state): State<ApiState>) -> impl IntoResponse {
             location: state.region.location.clone(),
         },
         active_sessions: state.core.sessions.len(),
-        active_tunnels: state.core.http_routes.len() + state.core.tcp_routes.len(),
+        // Count members, not groups — Phase 1 has 1 member per group so the
+        // numbers match historical data; later phases may diverge.
+        active_tunnels: state
+            .core
+            .http_routes
+            .iter()
+            .map(|g| g.members.len())
+            .sum::<usize>()
+            + state
+                .core
+                .tcp_routes
+                .iter()
+                .map(|g| g.members.len())
+                .sum::<usize>(),
     })
 }
 
@@ -253,70 +266,82 @@ async fn list_tunnels(headers: HeaderMap, State(state): State<ApiState>) -> impl
 
     let mut tunnels: Vec<TunnelSummary> = Vec::new();
 
+    // One row per member. For Phase 1 every group has a single member, so
+    // the row shape is unchanged from before. Phase 5 of TUNNEL-7 will add
+    // group-aware fields (member_count, healthy pill, etc.) on top.
     for entry in state.core.http_routes.iter() {
-        let info = entry.value();
-        let client_addr = state
-            .core
-            .sessions
-            .get(&info.session_id)
-            .map(|s| s.client_addr.to_string())
-            .unwrap_or_default();
-        tunnels.push(TunnelSummary {
-            tunnel_id: info.tunnel_id.to_string(),
-            protocol: "http".into(),
-            label: entry.key().clone(),
-            public_url: format!("https://{}", entry.key()),
-            connected_since: instant_to_iso(info.created_at),
-            request_count: info.request_count.load(Ordering::Relaxed),
-            client_addr,
-            region_id: state.region.id.clone(),
-            nat_type: None,
-            mapped_addrs: None,
-        });
+        let subdomain = entry.key().clone();
+        for member in entry.value().members.iter() {
+            let info = &member.info;
+            let client_addr = state
+                .core
+                .sessions
+                .get(&info.session_id)
+                .map(|s| s.client_addr.to_string())
+                .unwrap_or_default();
+            tunnels.push(TunnelSummary {
+                tunnel_id: info.tunnel_id.to_string(),
+                protocol: "http".into(),
+                label: subdomain.clone(),
+                public_url: format!("https://{subdomain}"),
+                connected_since: instant_to_iso(info.created_at),
+                request_count: info.request_count.load(Ordering::Relaxed),
+                client_addr,
+                region_id: state.region.id.clone(),
+                nat_type: None,
+                mapped_addrs: None,
+            });
+        }
     }
 
     for entry in state.core.tcp_routes.iter() {
-        let info = entry.value();
-        let client_addr = state
-            .core
-            .sessions
-            .get(&info.session_id)
-            .map(|s| s.client_addr.to_string())
-            .unwrap_or_default();
-        tunnels.push(TunnelSummary {
-            tunnel_id: info.tunnel_id.to_string(),
-            protocol: "tcp".into(),
-            label: entry.key().to_string(),
-            public_url: format!("tcp://:{}", entry.key()),
-            connected_since: instant_to_iso(info.created_at),
-            request_count: info.request_count.load(Ordering::Relaxed),
-            client_addr,
-            region_id: state.region.id.clone(),
-            nat_type: None,
-            mapped_addrs: None,
-        });
+        let port = *entry.key();
+        for member in entry.value().members.iter() {
+            let info = &member.info;
+            let client_addr = state
+                .core
+                .sessions
+                .get(&info.session_id)
+                .map(|s| s.client_addr.to_string())
+                .unwrap_or_default();
+            tunnels.push(TunnelSummary {
+                tunnel_id: info.tunnel_id.to_string(),
+                protocol: "tcp".into(),
+                label: port.to_string(),
+                public_url: format!("tcp://:{port}"),
+                connected_since: instant_to_iso(info.created_at),
+                request_count: info.request_count.load(Ordering::Relaxed),
+                client_addr,
+                region_id: state.region.id.clone(),
+                nat_type: None,
+                mapped_addrs: None,
+            });
+        }
     }
 
     for entry in state.core.udp_routes.iter() {
-        let info = entry.value();
-        let client_addr = state
-            .core
-            .sessions
-            .get(&info.session_id)
-            .map(|s| s.client_addr.to_string())
-            .unwrap_or_default();
-        tunnels.push(TunnelSummary {
-            tunnel_id: info.tunnel_id.to_string(),
-            protocol: "udp".into(),
-            label: entry.key().to_string(),
-            public_url: format!("udp://:{}", entry.key()),
-            connected_since: instant_to_iso(info.created_at),
-            request_count: info.request_count.load(Ordering::Relaxed),
-            client_addr,
-            region_id: state.region.id.clone(),
-            nat_type: None,
-            mapped_addrs: None,
-        });
+        let port = *entry.key();
+        for member in entry.value().members.iter() {
+            let info = &member.info;
+            let client_addr = state
+                .core
+                .sessions
+                .get(&info.session_id)
+                .map(|s| s.client_addr.to_string())
+                .unwrap_or_default();
+            tunnels.push(TunnelSummary {
+                tunnel_id: info.tunnel_id.to_string(),
+                protocol: "udp".into(),
+                label: port.to_string(),
+                public_url: format!("udp://:{port}"),
+                connected_since: instant_to_iso(info.created_at),
+                request_count: info.request_count.load(Ordering::Relaxed),
+                client_addr,
+                region_id: state.region.id.clone(),
+                nat_type: None,
+                mapped_addrs: None,
+            });
+        }
     }
 
     for entry in state.core.p2p_tunnels.iter() {
@@ -378,79 +403,88 @@ async fn get_tunnel(
 
     // Search HTTP routes first.
     for entry in state.core.http_routes.iter() {
-        if entry.value().tunnel_id.to_string() == id {
-            let info = entry.value();
-            let client_addr = state
-                .core
-                .sessions
-                .get(&info.session_id)
-                .map(|s| s.client_addr.to_string())
-                .unwrap_or_default();
-            return Json(TunnelSummary {
-                tunnel_id: info.tunnel_id.to_string(),
-                protocol: "http".into(),
-                label: entry.key().clone(),
-                public_url: format!("https://{}", entry.key()),
-                connected_since: instant_to_iso(info.created_at),
-                request_count: info.request_count.load(Ordering::Relaxed),
-                client_addr,
-                region_id: state.region.id.clone(),
-                nat_type: None,
-                mapped_addrs: None,
-            })
-            .into_response();
+        let subdomain = entry.key().clone();
+        for member in entry.value().members.iter() {
+            let info = &member.info;
+            if info.tunnel_id.to_string() == id {
+                let client_addr = state
+                    .core
+                    .sessions
+                    .get(&info.session_id)
+                    .map(|s| s.client_addr.to_string())
+                    .unwrap_or_default();
+                return Json(TunnelSummary {
+                    tunnel_id: info.tunnel_id.to_string(),
+                    protocol: "http".into(),
+                    label: subdomain.clone(),
+                    public_url: format!("https://{subdomain}"),
+                    connected_since: instant_to_iso(info.created_at),
+                    request_count: info.request_count.load(Ordering::Relaxed),
+                    client_addr,
+                    region_id: state.region.id.clone(),
+                    nat_type: None,
+                    mapped_addrs: None,
+                })
+                .into_response();
+            }
         }
     }
 
     // Then TCP routes.
     for entry in state.core.tcp_routes.iter() {
-        if entry.value().tunnel_id.to_string() == id {
-            let info = entry.value();
-            let client_addr = state
-                .core
-                .sessions
-                .get(&info.session_id)
-                .map(|s| s.client_addr.to_string())
-                .unwrap_or_default();
-            return Json(TunnelSummary {
-                tunnel_id: info.tunnel_id.to_string(),
-                protocol: "tcp".into(),
-                label: entry.key().to_string(),
-                public_url: format!("tcp://:{}", entry.key()),
-                connected_since: instant_to_iso(info.created_at),
-                request_count: info.request_count.load(Ordering::Relaxed),
-                client_addr,
-                region_id: state.region.id.clone(),
-                nat_type: None,
-                mapped_addrs: None,
-            })
-            .into_response();
+        let port = *entry.key();
+        for member in entry.value().members.iter() {
+            let info = &member.info;
+            if info.tunnel_id.to_string() == id {
+                let client_addr = state
+                    .core
+                    .sessions
+                    .get(&info.session_id)
+                    .map(|s| s.client_addr.to_string())
+                    .unwrap_or_default();
+                return Json(TunnelSummary {
+                    tunnel_id: info.tunnel_id.to_string(),
+                    protocol: "tcp".into(),
+                    label: port.to_string(),
+                    public_url: format!("tcp://:{port}"),
+                    connected_since: instant_to_iso(info.created_at),
+                    request_count: info.request_count.load(Ordering::Relaxed),
+                    client_addr,
+                    region_id: state.region.id.clone(),
+                    nat_type: None,
+                    mapped_addrs: None,
+                })
+                .into_response();
+            }
         }
     }
 
     // Then UDP routes.
     for entry in state.core.udp_routes.iter() {
-        if entry.value().tunnel_id.to_string() == id {
-            let info = entry.value();
-            let client_addr = state
-                .core
-                .sessions
-                .get(&info.session_id)
-                .map(|s| s.client_addr.to_string())
-                .unwrap_or_default();
-            return Json(TunnelSummary {
-                tunnel_id: info.tunnel_id.to_string(),
-                protocol: "udp".into(),
-                label: entry.key().to_string(),
-                public_url: format!("udp://:{}", entry.key()),
-                connected_since: instant_to_iso(info.created_at),
-                request_count: info.request_count.load(Ordering::Relaxed),
-                client_addr,
-                region_id: state.region.id.clone(),
-                nat_type: None,
-                mapped_addrs: None,
-            })
-            .into_response();
+        let port = *entry.key();
+        for member in entry.value().members.iter() {
+            let info = &member.info;
+            if info.tunnel_id.to_string() == id {
+                let client_addr = state
+                    .core
+                    .sessions
+                    .get(&info.session_id)
+                    .map(|s| s.client_addr.to_string())
+                    .unwrap_or_default();
+                return Json(TunnelSummary {
+                    tunnel_id: info.tunnel_id.to_string(),
+                    protocol: "udp".into(),
+                    label: port.to_string(),
+                    public_url: format!("udp://:{port}"),
+                    connected_since: instant_to_iso(info.created_at),
+                    request_count: info.request_count.load(Ordering::Relaxed),
+                    client_addr,
+                    region_id: state.region.id.clone(),
+                    nat_type: None,
+                    mapped_addrs: None,
+                })
+                .into_response();
+            }
         }
     }
 
@@ -878,8 +912,20 @@ async fn admin_platform_usage(
     if let Err(e) = require_admin(&headers, &state).await {
         return e.into_response();
     }
-    // Count live tunnels from in-memory state (matches the Tunnels tab source of truth).
-    let live_tunnels = (state.core.http_routes.len() + state.core.tcp_routes.len()) as i64;
+    // Count live tunnels from in-memory state (matches the Tunnels tab source
+    // of truth). Members, not groups — keeps the historical metric meaning.
+    let live_tunnels = (state
+        .core
+        .http_routes
+        .iter()
+        .map(|g| g.members.len())
+        .sum::<usize>()
+        + state
+            .core
+            .tcp_routes
+            .iter()
+            .map(|g| g.members.len())
+            .sum::<usize>()) as i64;
 
     match db::get_platform_usage(&state.db.pg).await {
         Ok(mut usage) => {
@@ -1254,17 +1300,20 @@ async fn tunnel_udp_sessions(
 
     // Find the UDP tunnel by ID.
     for entry in state.core.udp_routes.iter() {
-        let info = entry.value();
-        if info.tunnel_id.to_string() == id {
-            return Json(UdpSessionInfo {
-                tunnel_id: info.tunnel_id.to_string(),
-                port: *entry.key(),
-                protocol: "udp".into(),
-                request_count: info.request_count.load(Ordering::Relaxed),
-                bytes_proxied: info.bytes_proxied.load(Ordering::Relaxed),
-                connected_since: instant_to_iso(info.created_at),
-            })
-            .into_response();
+        let port = *entry.key();
+        for member in entry.value().members.iter() {
+            let info = &member.info;
+            if info.tunnel_id.to_string() == id {
+                return Json(UdpSessionInfo {
+                    tunnel_id: info.tunnel_id.to_string(),
+                    port,
+                    protocol: "udp".into(),
+                    request_count: info.request_count.load(Ordering::Relaxed),
+                    bytes_proxied: info.bytes_proxied.load(Ordering::Relaxed),
+                    connected_since: instant_to_iso(info.created_at),
+                })
+                .into_response();
+            }
         }
     }
 

--- a/crates/rustunnel-server/src/main.rs
+++ b/crates/rustunnel-server/src/main.rs
@@ -331,38 +331,37 @@ async fn run_metrics(addr: SocketAddr, core: Arc<TunnelCore>) -> Result<()> {
 }
 
 async fn metrics_handler(State(core): State<Arc<TunnelCore>>) -> Response {
+    use std::sync::atomic::Ordering;
+
     let sessions = core.sessions.len();
-    let http_tunnels = core.http_routes.len();
-    let tcp_tunnels = core.tcp_routes.len();
-    let udp_tunnels = core.udp_routes.len();
+    // Existing gauges count *members* (i.e. registered tunnels) so the
+    // numbers stay comparable with pre-load-balancing data. Phase 5 will add
+    // separate `rustunnel_group_members{...}` metrics keyed by group.
+    let http_tunnels: usize = core.http_routes.iter().map(|g| g.members.len()).sum();
+    let tcp_tunnels: usize = core.tcp_routes.iter().map(|g| g.members.len()).sum();
+    let udp_tunnels: usize = core.udp_routes.iter().map(|g| g.members.len()).sum();
     let p2p_tunnels = core.p2p_tunnels.len();
 
     // Compute aggregate bytes and request counts across all tunnel types.
     let mut total_bytes: u64 = 0;
     let mut total_requests: u64 = 0;
-    for entry in core.http_routes.iter() {
-        total_bytes += entry
-            .bytes_proxied
-            .load(std::sync::atomic::Ordering::Relaxed);
-        total_requests += entry
-            .request_count
-            .load(std::sync::atomic::Ordering::Relaxed);
+    for group in core.http_routes.iter() {
+        for member in group.members.iter() {
+            total_bytes += member.info.bytes_proxied.load(Ordering::Relaxed);
+            total_requests += member.info.request_count.load(Ordering::Relaxed);
+        }
     }
-    for entry in core.tcp_routes.iter() {
-        total_bytes += entry
-            .bytes_proxied
-            .load(std::sync::atomic::Ordering::Relaxed);
-        total_requests += entry
-            .request_count
-            .load(std::sync::atomic::Ordering::Relaxed);
+    for group in core.tcp_routes.iter() {
+        for member in group.members.iter() {
+            total_bytes += member.info.bytes_proxied.load(Ordering::Relaxed);
+            total_requests += member.info.request_count.load(Ordering::Relaxed);
+        }
     }
-    for entry in core.udp_routes.iter() {
-        total_bytes += entry
-            .bytes_proxied
-            .load(std::sync::atomic::Ordering::Relaxed);
-        total_requests += entry
-            .request_count
-            .load(std::sync::atomic::Ordering::Relaxed);
+    for group in core.udp_routes.iter() {
+        for member in group.members.iter() {
+            total_bytes += member.info.bytes_proxied.load(Ordering::Relaxed);
+            total_requests += member.info.request_count.load(Ordering::Relaxed);
+        }
     }
     for entry in core.p2p_tunnels.iter() {
         total_bytes += entry

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -271,6 +271,7 @@ impl TestServer {
                 enabled: true,
                 ..rustunnel_server::config::P2pSection::default()
             },
+            load_balancing: rustunnel_server::config::LoadBalancingSection::default(),
         });
 
         // Database.
@@ -519,6 +520,9 @@ impl TestClient {
             local_addr: "127.0.0.1:0".to_string(), // advisory only
             p2p_secret_hash: None,
             p2p_name: None,
+            group: None,
+            group_key_hash: None,
+            health_check: None,
         })
         .await?;
 
@@ -552,6 +556,9 @@ impl TestClient {
             local_addr: "127.0.0.1:0".to_string(),
             p2p_secret_hash: None,
             p2p_name: None,
+            group: None,
+            group_key_hash: None,
+            health_check: None,
         })
         .await?;
 
@@ -579,6 +586,9 @@ impl TestClient {
             local_addr: "127.0.0.1:0".to_string(),
             p2p_secret_hash: None,
             p2p_name: None,
+            group: None,
+            group_key_hash: None,
+            health_check: None,
         })
         .await?;
 
@@ -610,6 +620,9 @@ impl TestClient {
             local_addr: "127.0.0.1:0".to_string(),
             p2p_secret_hash: Some(secret_hash.to_string()),
             p2p_name: Some(name.to_string()),
+            group: None,
+            group_key_hash: None,
+            health_check: None,
         })
         .await?;
 


### PR DESCRIPTION
## Summary

Phase 0 + Phase 1 of the FRP-style load-balancing plan ([rustunnel-private design doc](https://github.com/joaoh82/rustunnel-private/blob/main/docs/development/load-balancing-and-health-checks.md), TUNNEL-7 / TUNNEL-8). Both phases are explicitly called out as independently shippable in the plan; this PR is **wire- and behaviour-compatible with v0.5.x clients** and ships no user-visible changes — it lays the foundation for Phase 2/3 multi-member registration.

### Phase 0 — protocol surface (additive, fully backwards-compatible)
- `RegisterTunnel` gains optional `group` / `group_key_hash` / `health_check` fields. Old clients omit them; the re-encoded JSON contains no extra keys (proven by `legacy_register_tunnel_round_trip_unchanged`).
- New `HealthCheckSpec` / `HealthCheckKind` types in `rustunnel-protocol`.
- New `TunnelHealthy` / `TunnelUnhealthy` frames. Server logs them as a debug-level no-op pre-Phase-4 so newer clients never trip a `decode_frame` warning on this release.

### Phase 1 — `TunnelGroup` routing
- `http_routes` / `tcp_routes` / `udp_routes` now hold `Arc<TunnelGroup>` whose `members: DashMap<Uuid, GroupMember>` always has exactly one member today (the "degenerate" case from §4.2 of the plan).
- New `dispatch_member` picks a healthy member uniformly at random — single-member groups behave identically to today.
- `remove_tunnel` removes a member from its group and only frees the route entry (and TCP/UDP port back to the pool) when the **last** member leaves; Phase 2/3 won't have to revisit the removal path.
- Iteration sites (Prometheus aggregation, `/api/tunnels`, `/api/admin/usage/platform`, UDP-sessions endpoint) walk members; counters stay member-grained so existing Grafana panels stay accurate.

### Phase 6 precondition — kill switch
- `[load_balancing] enabled = false` config flag in `server.toml`. `#[serde(default)]` so existing TOMLs across all three regions keep parsing. Phase 2/3 will gate multi-member group registration on this flag during the EU → US → AP rollout.

### Out of scope (next phases)
- Phase 2/3: client-side opt-in to groups + multi-member registration semantics + group-key hash validation.
- Phase 4: client-side TCP / HTTP probes + wiring `TunnelHealthy` / `TunnelUnhealthy` into `member.healthy`.
- Phase 5: dashboard / `/api/groups` / Prometheus metrics / website surfaces.
- Phase 6 wire-compat: `AuthOk.server_version` gating so newer clients only emit health frames against ≥ 0.6 servers.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p rustunnel-protocol` — 4 round-trip tests (legacy unchanged / new fields / healthy-unhealthy / forward-compat decode) all pass
- [x] `cargo test -p rustunnel-server --lib` — 45 server lib tests, including 30 router tests (27 pre-existing unmodified + 3 new: degenerate-group shape, last-member-evicts-group, unhealthy-member-excluded-from-dispatch)
- [x] `cargo test --workspace` (with PG up via `make db-start`) — full integration suite passes: auth, http_tunnel, tcp_tunnel, udp_tunnel, p2p_tunnel, reconnect, data_ws_reconnect
- [ ] EU canary deploy: confirm tunnel registration and proxy traffic are byte-identical (counters in Grafana shouldn't visibly change since Phase 1 doesn't move traffic)
- [ ] Soak 24h on EU before flipping `[load_balancing] enabled` anywhere (which is a Phase 2/3 follow-up, not this PR)

## Companion PR
A matching decision-log entry is opened against `rustunnel-private`: <https://github.com/joaoh82/rustunnel-private/pull/new/tunnel-8-load-balancing-phase-0-1-decision-log>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)