### PR TITLE
feat(server): TUNNEL-8 Phase 2 — HTTP load-balancing groups

### DIFF
--- a/crates/rustunnel-server/src/control/session.rs
+++ b/crates/rustunnel-server/src/control/session.rs
@@ -482,14 +482,54 @@ where
             local_addr: _,
             p2p_secret_hash,
             p2p_name,
-            // Phase 0: accept the new load-balancing fields on the wire so old
-            // clients keep working unchanged. Server-side handling lands in
-            // later phases of TUNNEL-7.
-            group: _,
-            group_key_hash: _,
-            health_check: _,
+            // TUNNEL-7 load-balancing inputs. Phase 0 accepted these silently;
+            // Phase 2 honours them for HTTP groups (TCP follows in Phase 3)
+            // when `[load_balancing] enabled = true` on this region.
+            group,
+            group_key_hash,
+            health_check,
         } => {
             tracing::debug!(%session_id, %request_id, ?protocol, "register tunnel");
+
+            // Build the per-tunnel GroupSpec for HTTP/TCP registration.
+            //
+            // Three guard clauses turn into None (= solo registration):
+            //   - The kill switch is off on this region.
+            //   - The client did not request a group.
+            //   - The client requested a group but didn't supply a key hash
+            //     (we never autogenerate one — the whole point is mutual auth).
+            //
+            // For the disabled-flag path we log so operators can see when
+            // grouped clients are being downgraded (matches the warning the
+            // *client* will eventually emit on a Phase-6 server-version probe).
+            let http_group_spec = match (
+                config.load_balancing.enabled,
+                group.as_ref(),
+                group_key_hash.as_ref(),
+            ) {
+                (true, Some(name), Some(hash)) => Some(crate::core::GroupSpec {
+                    group_name: name.clone(),
+                    key_hash: hash.clone(),
+                    health_check: health_check.clone(),
+                }),
+                (false, Some(name), _) => {
+                    tracing::warn!(
+                        %session_id, %request_id, group = %name,
+                        "client requested load-balancing group but [load_balancing] is disabled on this region; \
+                         registering as solo tunnel"
+                    );
+                    None
+                }
+                (true, Some(name), None) => {
+                    tracing::warn!(
+                        %session_id, %request_id, group = %name,
+                        "client requested load-balancing group without a key hash; \
+                         registering as solo tunnel"
+                    );
+                    None
+                }
+                _ => None,
+            };
 
             // ── Token limit enforcement ────────────────────────────────────
             // status is always checked; limit/expiry checks are skipped for
@@ -585,7 +625,12 @@ where
             let token_user_id = db_token.as_ref().and_then(|t| t.user_id);
             match &protocol {
                 TunnelProtocol::Http | TunnelProtocol::Https => {
-                    match core.register_http_tunnel(&session_id, subdomain, protocol.clone()) {
+                    match core.register_http_tunnel(
+                        &session_id,
+                        subdomain,
+                        protocol.clone(),
+                        http_group_spec,
+                    ) {
                         Ok((tunnel_id, sub)) => {
                             let scheme = if protocol == TunnelProtocol::Https {
                                 "https"

--- a/crates/rustunnel-server/src/core/mod.rs
+++ b/crates/rustunnel-server/src/core/mod.rs
@@ -7,6 +7,6 @@ pub use ip_limiter::IpRateLimiter;
 pub use limiter::RateLimiter;
 pub use router::{classify_nat_pair, P2pPublisher, TunnelCore};
 pub use tunnel::{
-    ControlMessage, GroupMember, SessionInfo, TcpTunnelEvent, TunnelGroup, TunnelInfo,
+    ControlMessage, GroupMember, GroupSpec, SessionInfo, TcpTunnelEvent, TunnelGroup, TunnelInfo,
     UdpTunnelEvent,
 };

--- a/crates/rustunnel-server/src/core/router.rs
+++ b/crates/rustunnel-server/src/core/router.rs
@@ -17,7 +17,8 @@ use crate::error::{Error, Result};
 use super::ip_limiter::IpRateLimiter;
 use super::limiter::RateLimiter;
 use super::tunnel::{
-    ControlMessage, SessionInfo, TcpTunnelEvent, TunnelGroup, TunnelInfo, UdpTunnelEvent,
+    ControlMessage, GroupMember, GroupSpec, SessionInfo, TcpTunnelEvent, TunnelGroup, TunnelInfo,
+    UdpTunnelEvent,
 };
 
 /// Broadcast channel capacity for TCP/UDP tunnel lifecycle events.
@@ -236,12 +237,26 @@ impl TunnelCore {
     /// If `subdomain` is `None` an 8-character random hex label is generated.
     /// User-supplied subdomains are validated: alphanumeric + hyphens only,
     /// 3–63 characters, no leading or trailing hyphens.
+    ///
+    /// When `group` is `None` (the only case before TUNNEL-7 Phase 2): the
+    /// subdomain is owned by exactly one tunnel, mirroring historical
+    /// behaviour. A duplicate subdomain registration is rejected.
+    ///
+    /// When `group` is `Some`: the subdomain becomes a load-balanced pool.
+    /// The first registration with a given `(subdomain, key_hash)` creates
+    /// the group; subsequent registrations join it iff their `key_hash`
+    /// matches and their `protocol` (Http/Https) matches the existing
+    /// members. A solo (no-group) registration on top of an existing group
+    /// — or a grouped registration on top of an existing solo — is
+    /// rejected. See plan §4.3.
+    ///
     /// Returns `(tunnel_id, public_subdomain)`.
     pub fn register_http_tunnel(
         &self,
         session_id: &Uuid,
         subdomain: Option<String>,
         protocol: TunnelProtocol,
+        group: Option<GroupSpec>,
     ) -> Result<(Uuid, String)> {
         self.check_session_limit(session_id)?;
 
@@ -253,18 +268,11 @@ impl TunnelCore {
             None => random_subdomain(),
         };
 
-        // Reject duplicate subdomain registrations.
-        if self.http_routes.contains_key(&subdomain) {
-            return Err(Error::Tunnel(format!(
-                "subdomain '{subdomain}' is already in use"
-            )));
-        }
-
         let tunnel_id = Uuid::new_v4();
         let info = TunnelInfo {
             session_id: *session_id,
             tunnel_id,
-            protocol,
+            protocol: protocol.clone(),
             subdomain: Some(subdomain.clone()),
             assigned_port: None,
             created_at: std::time::Instant::now(),
@@ -273,8 +281,62 @@ impl TunnelCore {
             conn_semaphore: Arc::new(Semaphore::new(self.max_connections_per_tunnel)),
         };
 
-        let group = TunnelGroup::new_solo(subdomain.clone(), info);
-        self.http_routes.insert(subdomain.clone(), group);
+        // Atomic upsert via the entry API — closes the get-then-insert race
+        // that two concurrent first-registrations could otherwise hit (plan
+        // §7 risk #4). The shard lock is held for the duration of this
+        // match block.
+        use dashmap::mapref::entry::Entry;
+        match self.http_routes.entry(subdomain.clone()) {
+            Entry::Vacant(vac) => {
+                let new_group = match group {
+                    None => TunnelGroup::new_solo(subdomain.clone(), info),
+                    Some(spec) => TunnelGroup::new_with_member(
+                        spec.group_name,
+                        Some(spec.key_hash),
+                        GroupMember::with_health_spec(info, spec.health_check),
+                    ),
+                };
+                vac.insert(new_group);
+            }
+            Entry::Occupied(occ) => {
+                let existing = occ.get();
+                let Some(spec) = group else {
+                    // Solo registration on a subdomain that's already
+                    // registered (solo or grouped) — historical behaviour.
+                    return Err(Error::Tunnel(format!(
+                        "subdomain '{subdomain}' is already in use"
+                    )));
+                };
+                // Grouped registration: existing must already be a group
+                // with a matching key.
+                let existing_key = existing.key_hash.as_deref();
+                if existing_key != Some(spec.key_hash.as_str()) {
+                    return Err(Error::Tunnel(format!(
+                        "group key does not match existing group for subdomain '{subdomain}'"
+                    )));
+                }
+                // Identity check: protocol (Http vs Https) must match the
+                // existing members. FRP enforces the same on
+                // customDomains/subdomain/locations; protocol is the only
+                // field where mismatch is meaningful for us.
+                let existing_protocol = existing
+                    .members
+                    .iter()
+                    .next()
+                    .map(|m| m.info.protocol.clone());
+                if existing_protocol.as_ref() != Some(&protocol) {
+                    return Err(Error::Tunnel(format!(
+                        "group member protocol mismatch for subdomain '{subdomain}': existing={:?}, new={:?}",
+                        existing_protocol, protocol,
+                    )));
+                }
+                existing.members.insert(
+                    tunnel_id,
+                    GroupMember::with_health_spec(info, spec.health_check),
+                );
+            }
+        }
+
         self.tunnel_index
             .insert(tunnel_id, TunnelKey::Http(subdomain.clone()));
         self.add_tunnel_to_session(session_id, tunnel_id);
@@ -730,7 +792,12 @@ mod tests {
         let (session_id, _rx) = dummy_session(&core);
 
         let (tunnel_id, subdomain) = core
-            .register_http_tunnel(&session_id, Some("myapp".to_string()), TunnelProtocol::Http)
+            .register_http_tunnel(
+                &session_id,
+                Some("myapp".to_string()),
+                TunnelProtocol::Http,
+                None,
+            )
             .unwrap();
 
         assert_eq!(subdomain, "myapp");
@@ -749,7 +816,7 @@ mod tests {
         let (session_id, _rx) = dummy_session(&core);
 
         let (_, subdomain) = core
-            .register_http_tunnel(&session_id, None, TunnelProtocol::Http)
+            .register_http_tunnel(&session_id, None, TunnelProtocol::Http, None)
             .unwrap();
 
         assert_eq!(subdomain.len(), 8);
@@ -761,11 +828,20 @@ mod tests {
         let core = make_core();
         let (session_id, _rx) = dummy_session(&core);
 
-        core.register_http_tunnel(&session_id, Some("clash".to_string()), TunnelProtocol::Http)
-            .unwrap();
+        core.register_http_tunnel(
+            &session_id,
+            Some("clash".to_string()),
+            TunnelProtocol::Http,
+            None,
+        )
+        .unwrap();
 
-        let result =
-            core.register_http_tunnel(&session_id, Some("clash".to_string()), TunnelProtocol::Http);
+        let result = core.register_http_tunnel(
+            &session_id,
+            Some("clash".to_string()),
+            TunnelProtocol::Http,
+            None,
+        );
 
         assert!(matches!(result, Err(Error::Tunnel(_))));
     }
@@ -776,7 +852,12 @@ mod tests {
         let (session_id, _rx) = dummy_session(&core);
 
         let (tunnel_id, _) = core
-            .register_http_tunnel(&session_id, Some("gone".to_string()), TunnelProtocol::Http)
+            .register_http_tunnel(
+                &session_id,
+                Some("gone".to_string()),
+                TunnelProtocol::Http,
+                None,
+            )
             .unwrap();
 
         core.remove_tunnel(&tunnel_id);
@@ -848,8 +929,13 @@ mod tests {
         let core = make_core();
         let (session_id, _rx) = dummy_session(&core);
 
-        core.register_http_tunnel(&session_id, Some("web".to_string()), TunnelProtocol::Http)
-            .unwrap();
+        core.register_http_tunnel(
+            &session_id,
+            Some("web".to_string()),
+            TunnelProtocol::Http,
+            None,
+        )
+        .unwrap();
 
         let (info, _tx) = core.resolve_http("web").unwrap();
         assert_eq!(info.subdomain.as_deref(), Some("web"));
@@ -889,7 +975,12 @@ mod tests {
         let (session_id, _rx) = dummy_session(&core);
 
         let (tid, _) = core
-            .register_http_tunnel(&session_id, Some("bye".to_string()), TunnelProtocol::Http)
+            .register_http_tunnel(
+                &session_id,
+                Some("bye".to_string()),
+                TunnelProtocol::Http,
+                None,
+            )
             .unwrap();
         let (_, port) = core.register_tcp_tunnel(&session_id).unwrap();
 
@@ -908,12 +999,12 @@ mod tests {
         let core = TunnelCore::new([50000, 50009], [0, 0], 2, 100, 1000);
         let (session_id, _rx) = dummy_session(&core);
 
-        core.register_http_tunnel(&session_id, None, TunnelProtocol::Http)
+        core.register_http_tunnel(&session_id, None, TunnelProtocol::Http, None)
             .unwrap();
-        core.register_http_tunnel(&session_id, None, TunnelProtocol::Http)
+        core.register_http_tunnel(&session_id, None, TunnelProtocol::Http, None)
             .unwrap();
 
-        let result = core.register_http_tunnel(&session_id, None, TunnelProtocol::Http);
+        let result = core.register_http_tunnel(&session_id, None, TunnelProtocol::Http, None);
         assert!(matches!(result, Err(Error::LimitExceeded(_))));
     }
 
@@ -923,7 +1014,7 @@ mod tests {
         let ghost = Uuid::new_v4();
 
         assert!(matches!(
-            core.register_http_tunnel(&ghost, None, TunnelProtocol::Http),
+            core.register_http_tunnel(&ghost, None, TunnelProtocol::Http, None),
             Err(Error::SessionNotFound(_))
         ));
     }
@@ -935,7 +1026,8 @@ mod tests {
         let core = make_core();
         let (sid, _rx) = dummy_session(&core);
         for s in &["abc", "my-app", "foo123", "a-b-c", "aaa"] {
-            let r = core.register_http_tunnel(&sid, Some(s.to_string()), TunnelProtocol::Http);
+            let r =
+                core.register_http_tunnel(&sid, Some(s.to_string()), TunnelProtocol::Http, None);
             assert!(r.is_ok(), "expected '{s}' to be valid, got {r:?}");
         }
     }
@@ -945,7 +1037,7 @@ mod tests {
         let core = make_core();
         let (sid, _rx) = dummy_session(&core);
         assert!(matches!(
-            core.register_http_tunnel(&sid, Some("ab".to_string()), TunnelProtocol::Http),
+            core.register_http_tunnel(&sid, Some("ab".to_string()), TunnelProtocol::Http, None),
             Err(Error::Tunnel(_))
         ));
     }
@@ -955,7 +1047,7 @@ mod tests {
         let core = make_core();
         let (sid, _rx) = dummy_session(&core);
         assert!(matches!(
-            core.register_http_tunnel(&sid, Some("-bad".to_string()), TunnelProtocol::Http),
+            core.register_http_tunnel(&sid, Some("-bad".to_string()), TunnelProtocol::Http, None),
             Err(Error::Tunnel(_))
         ));
     }
@@ -965,7 +1057,7 @@ mod tests {
         let core = make_core();
         let (sid, _rx) = dummy_session(&core);
         assert!(matches!(
-            core.register_http_tunnel(&sid, Some("bad-".to_string()), TunnelProtocol::Http),
+            core.register_http_tunnel(&sid, Some("bad-".to_string()), TunnelProtocol::Http, None),
             Err(Error::Tunnel(_))
         ));
     }
@@ -975,11 +1067,21 @@ mod tests {
         let core = make_core();
         let (sid, _rx) = dummy_session(&core);
         assert!(matches!(
-            core.register_http_tunnel(&sid, Some("bad_name".to_string()), TunnelProtocol::Http),
+            core.register_http_tunnel(
+                &sid,
+                Some("bad_name".to_string()),
+                TunnelProtocol::Http,
+                None
+            ),
             Err(Error::Tunnel(_))
         ));
         assert!(matches!(
-            core.register_http_tunnel(&sid, Some("bad.name".to_string()), TunnelProtocol::Http),
+            core.register_http_tunnel(
+                &sid,
+                Some("bad.name".to_string()),
+                TunnelProtocol::Http,
+                None
+            ),
             Err(Error::Tunnel(_))
         ));
     }
@@ -1037,7 +1139,7 @@ mod tests {
         let core = make_core();
         let (sid, _rx) = dummy_session(&core);
         let (tid, _) = core
-            .register_http_tunnel(&sid, Some("solo".into()), TunnelProtocol::Http)
+            .register_http_tunnel(&sid, Some("solo".into()), TunnelProtocol::Http, None)
             .unwrap();
 
         let group = core.http_routes.get("solo").unwrap();
@@ -1058,7 +1160,7 @@ mod tests {
         let core = make_core();
         let (sid, _rx) = dummy_session(&core);
         let (tid, _) = core
-            .register_http_tunnel(&sid, Some("ephemeral".into()), TunnelProtocol::Http)
+            .register_http_tunnel(&sid, Some("ephemeral".into()), TunnelProtocol::Http, None)
             .unwrap();
         assert!(core.http_routes.contains_key("ephemeral"));
 
@@ -1075,7 +1177,7 @@ mod tests {
         let core = make_core();
         let (sid, _rx) = dummy_session(&core);
         let (tid, _) = core
-            .register_http_tunnel(&sid, Some("toggle".into()), TunnelProtocol::Http)
+            .register_http_tunnel(&sid, Some("toggle".into()), TunnelProtocol::Http, None)
             .unwrap();
 
         // Flip the lone member to unhealthy.
@@ -1097,5 +1199,304 @@ mod tests {
             member.healthy.store(true, Ordering::Release);
         }
         assert!(core.resolve_http("toggle").is_some());
+    }
+
+    // ── HTTP group registration (Phase 2 of TUNNEL-7) ────────────────────
+    //
+    // These tests pin down the four cells of plan §4.3's truth table:
+    //   subdomain free + solo  →  create solo group  (already covered above)
+    //   subdomain free + group →  create new group with key_hash
+    //   subdomain taken + solo →  reject (legacy "in use")
+    //   subdomain taken + group + matching key + matching protocol →  join
+    //   subdomain taken + group + mismatched key →  reject
+    //   subdomain taken + group + mismatched protocol →  reject
+    // Plus dispatch-distributes-across-members which is the whole point.
+
+    fn solo_group_spec(name: &str, key: &str) -> GroupSpec {
+        GroupSpec {
+            group_name: name.to_string(),
+            key_hash: key.to_string(),
+            health_check: None,
+        }
+    }
+
+    /// First grouped registration creates a multi-member-shaped group
+    /// (still one member at this point) with the supplied key_hash.
+    #[test]
+    fn http_group_first_registration_sets_key_hash() {
+        let core = make_core();
+        let (sid, _rx) = dummy_session(&core);
+
+        let (tid, _) = core
+            .register_http_tunnel(
+                &sid,
+                Some("pool".into()),
+                TunnelProtocol::Http,
+                Some(solo_group_spec("web", "hash-A")),
+            )
+            .unwrap();
+
+        let group = core.http_routes.get("pool").unwrap();
+        assert_eq!(group.name, "web");
+        assert_eq!(group.key_hash.as_deref(), Some("hash-A"));
+        assert_eq!(group.members.len(), 1);
+        assert!(group.members.contains_key(&tid));
+    }
+
+    /// Two clients with the same `(subdomain, key_hash)` form one pool.
+    /// Sessions are distinct; tunnels are distinct; the routing entry is shared.
+    #[test]
+    fn http_group_second_member_with_matching_key_joins() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        let (tid_a, _) = core
+            .register_http_tunnel(
+                &sid_a,
+                Some("pool".into()),
+                TunnelProtocol::Http,
+                Some(solo_group_spec("web", "hash-A")),
+            )
+            .unwrap();
+        let (tid_b, _) = core
+            .register_http_tunnel(
+                &sid_b,
+                Some("pool".into()),
+                TunnelProtocol::Http,
+                Some(solo_group_spec("web", "hash-A")),
+            )
+            .unwrap();
+
+        let group = core.http_routes.get("pool").unwrap();
+        assert_eq!(group.members.len(), 2);
+        assert!(group.members.contains_key(&tid_a));
+        assert!(group.members.contains_key(&tid_b));
+        // tunnel_index points each tunnel_id to the same Http(subdomain) key,
+        // so per-tunnel counter lookup keeps working.
+        assert_eq!(core.get_tunnel_request_count(&tid_a), 0);
+        assert_eq!(core.get_tunnel_request_count(&tid_b), 0);
+    }
+
+    /// A second registration with the right subdomain but wrong key is
+    /// rejected — this is the auth check that prevents one tenant from
+    /// hijacking another's pool on a shared edge.
+    #[test]
+    fn http_group_mismatched_key_is_rejected() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        core.register_http_tunnel(
+            &sid_a,
+            Some("pool".into()),
+            TunnelProtocol::Http,
+            Some(solo_group_spec("web", "hash-A")),
+        )
+        .unwrap();
+
+        let result = core.register_http_tunnel(
+            &sid_b,
+            Some("pool".into()),
+            TunnelProtocol::Http,
+            Some(solo_group_spec("web", "hash-B")),
+        );
+
+        assert!(
+            matches!(result, Err(Error::Tunnel(ref msg)) if msg.contains("group key does not match"))
+        );
+        // Group must still hold only the original member.
+        assert_eq!(core.http_routes.get("pool").unwrap().members.len(), 1);
+    }
+
+    /// Joining an existing group with a matching key but a mismatched
+    /// protocol (Http vs Https) is rejected.
+    #[test]
+    fn http_group_protocol_mismatch_is_rejected() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        core.register_http_tunnel(
+            &sid_a,
+            Some("pool".into()),
+            TunnelProtocol::Http,
+            Some(solo_group_spec("web", "hash-A")),
+        )
+        .unwrap();
+
+        let result = core.register_http_tunnel(
+            &sid_b,
+            Some("pool".into()),
+            TunnelProtocol::Https,
+            Some(solo_group_spec("web", "hash-A")),
+        );
+
+        assert!(matches!(result, Err(Error::Tunnel(ref msg)) if msg.contains("protocol mismatch")));
+        assert_eq!(core.http_routes.get("pool").unwrap().members.len(), 1);
+    }
+
+    /// A solo registration on top of an existing grouped pool is rejected
+    /// (preserves historical "subdomain in use" semantics for non-group
+    /// callers — and prevents accidentally bypassing the group key check).
+    #[test]
+    fn http_solo_on_existing_group_is_rejected() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        core.register_http_tunnel(
+            &sid_a,
+            Some("pool".into()),
+            TunnelProtocol::Http,
+            Some(solo_group_spec("web", "hash-A")),
+        )
+        .unwrap();
+
+        let result =
+            core.register_http_tunnel(&sid_b, Some("pool".into()), TunnelProtocol::Http, None);
+
+        assert!(matches!(result, Err(Error::Tunnel(ref msg)) if msg.contains("already in use")));
+    }
+
+    /// Conversely: a grouped registration on top of an existing solo
+    /// registration is rejected (`key_hash = None` on the existing group
+    /// won't match anything the joiner can supply).
+    #[test]
+    fn http_group_on_existing_solo_is_rejected() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        core.register_http_tunnel(&sid_a, Some("pool".into()), TunnelProtocol::Http, None)
+            .unwrap();
+
+        let result = core.register_http_tunnel(
+            &sid_b,
+            Some("pool".into()),
+            TunnelProtocol::Http,
+            Some(solo_group_spec("web", "hash-A")),
+        );
+
+        assert!(
+            matches!(result, Err(Error::Tunnel(ref msg)) if msg.contains("group key does not match"))
+        );
+    }
+
+    /// Removing one member of a multi-member group leaves the route in
+    /// place with the remaining members — only the *last* leave evicts it.
+    #[test]
+    fn http_group_removing_one_of_two_members_keeps_route() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        let (tid_a, _) = core
+            .register_http_tunnel(
+                &sid_a,
+                Some("pool".into()),
+                TunnelProtocol::Http,
+                Some(solo_group_spec("web", "hash-A")),
+            )
+            .unwrap();
+        let (tid_b, _) = core
+            .register_http_tunnel(
+                &sid_b,
+                Some("pool".into()),
+                TunnelProtocol::Http,
+                Some(solo_group_spec("web", "hash-A")),
+            )
+            .unwrap();
+
+        core.remove_tunnel(&tid_a);
+
+        // Route still exists, group has one member left.
+        let group = core.http_routes.get("pool").unwrap();
+        assert_eq!(group.members.len(), 1);
+        assert!(group.members.contains_key(&tid_b));
+        assert!(core.resolve_http("pool").is_some());
+    }
+
+    /// Random dispatch across two healthy members must hit each one with
+    /// non-trivial frequency over many resolves. This is the load-balancing
+    /// promise of Phase 2.
+    #[test]
+    fn http_group_random_dispatch_distributes_across_members() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        let (tid_a, _) = core
+            .register_http_tunnel(
+                &sid_a,
+                Some("lbpool".into()),
+                TunnelProtocol::Http,
+                Some(solo_group_spec("web", "hash-A")),
+            )
+            .unwrap();
+        let (tid_b, _) = core
+            .register_http_tunnel(
+                &sid_b,
+                Some("lbpool".into()),
+                TunnelProtocol::Http,
+                Some(solo_group_spec("web", "hash-A")),
+            )
+            .unwrap();
+
+        // Drive resolve_http() many times. resolve_http internally bumps
+        // the chosen member's request_count, so we read those counters.
+        const N: u64 = 1_000;
+        for _ in 0..N {
+            assert!(core.resolve_http("lbpool").is_some());
+        }
+
+        let count_a = core.get_tunnel_request_count(&tid_a);
+        let count_b = core.get_tunnel_request_count(&tid_b);
+        assert_eq!(count_a + count_b, N);
+
+        // With uniform random over 1000 trials and p=0.5, both should land
+        // well inside [200, 800] — this gives effectively zero flake rate
+        // while still catching a "always picks the same one" regression.
+        assert!(
+            (200..=800).contains(&count_a),
+            "expected ~500 hits on member A, got {count_a} (B got {count_b})"
+        );
+        assert!(
+            (200..=800).contains(&count_b),
+            "expected ~500 hits on member B, got {count_b} (A got {count_a})"
+        );
+    }
+
+    /// A member registered with a `health_check` starts unhealthy and is
+    /// excluded from dispatch until the first `TunnelHealthy` flips the
+    /// bit. Phase 4 wires the frame plumbing; the bit semantics belong here.
+    #[test]
+    fn http_group_member_with_health_check_starts_unhealthy() {
+        let core = make_core();
+        let (sid, _rx) = dummy_session(&core);
+
+        let spec = GroupSpec {
+            group_name: "web".into(),
+            key_hash: "hash-A".into(),
+            health_check: Some(rustunnel_protocol::HealthCheckSpec {
+                kind: rustunnel_protocol::HealthCheckKind::Tcp,
+                interval_secs: 10,
+                timeout_secs: 3,
+                max_failed: 3,
+                http_path: None,
+                http_expect_2xx: true,
+            }),
+        };
+        let (tid, _) = core
+            .register_http_tunnel(&sid, Some("await".into()), TunnelProtocol::Http, Some(spec))
+            .unwrap();
+
+        // Member exists but is unhealthy → no healthy member to dispatch to.
+        let group = core.http_routes.get("await").unwrap();
+        let member = group.members.get(&tid).unwrap();
+        assert!(!member.healthy.load(Ordering::Acquire));
+        drop(member);
+        drop(group);
+        assert!(core.resolve_http("await").is_none());
     }
 }

--- a/crates/rustunnel-server/src/core/tunnel.rs
+++ b/crates/rustunnel-server/src/core/tunnel.rs
@@ -107,6 +107,23 @@ impl GroupMember {
             consecutive_failures: AtomicU32::new(0),
         }
     }
+
+    /// Create a member with an optional health-check spec.
+    ///
+    /// Initial `healthy` follows §4.5 of the plan: a member with no spec is
+    /// trusted (presence ⇒ healthy); a member that *did* opt into probes
+    /// starts unhealthy and only flips to healthy on the first
+    /// `TunnelHealthy` frame from the client. This prevents routing real
+    /// traffic to a backend whose upstream we haven't probed yet.
+    pub fn with_health_spec(info: TunnelInfo, spec: Option<HealthCheckSpec>) -> Self {
+        let initially_healthy = spec.is_none();
+        Self {
+            info,
+            healthy: AtomicBool::new(initially_healthy),
+            health_spec: spec,
+            consecutive_failures: AtomicU32::new(0),
+        }
+    }
 }
 
 /// A pool of one or more members serving the same subdomain or port.
@@ -134,6 +151,46 @@ impl TunnelGroup {
             .insert(info.tunnel_id, GroupMember::healthy_with(info));
         group
     }
+
+    /// Create a fresh group seeded with `member`. Phase 2 of TUNNEL-7 uses
+    /// this for the first registration of a multi-member HTTP group; Phase
+    /// 3 will reuse it for TCP. `key_hash` is `Some` for grouped pools and
+    /// `None` for ungrouped/solo registrations (use `new_solo` in that
+    /// case for clarity).
+    pub fn new_with_member(
+        name: String,
+        key_hash: Option<String>,
+        member: GroupMember,
+    ) -> Arc<Self> {
+        let tunnel_id = member.info.tunnel_id;
+        let group = Arc::new(Self {
+            name,
+            key_hash,
+            members: DashMap::new(),
+        });
+        group.members.insert(tunnel_id, member);
+        group
+    }
+}
+
+/// User-supplied parameters for joining or creating a load-balancing group.
+///
+/// Built by the session frame handler from `RegisterTunnel.group` /
+/// `RegisterTunnel.group_key_hash` / `RegisterTunnel.health_check` once the
+/// `[load_balancing] enabled = true` kill switch is on. Passed into
+/// `TunnelCore::register_http_tunnel` (Phase 2) and
+/// `register_tcp_tunnel` (Phase 3, future).
+#[derive(Debug, Clone)]
+pub struct GroupSpec {
+    /// User-supplied display name (sets `TunnelGroup.name` on the first
+    /// registration; subsequent joiners can supply any value, the existing
+    /// name wins — same as FRP).
+    pub group_name: String,
+    /// SHA-256 hash of the user-supplied `group_key`. Must match across
+    /// every member of the group.
+    pub key_hash: String,
+    /// Optional health-check spec for this member.
+    pub health_check: Option<HealthCheckSpec>,
 }
 
 // ── per-session state ─────────────────────────────────────────────────────────

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -54,3 +54,7 @@ path = "integration/udp_tunnel.rs"
 [[test]]
 name = "p2p_tunnel"
 path = "integration/p2p_tunnel.rs"
+
+[[test]]
+name = "http_groups"
+path = "integration/http_groups.rs"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -198,6 +198,31 @@ impl TestServer {
         .await
     }
 
+    /// Start a server with the TUNNEL-7 load-balancing kill switch on.
+    /// Used by the Phase 2 / Phase 3 group integration tests.
+    pub async fn start_with_load_balancing() -> Self {
+        let control_port = free_port();
+        let http_port = free_port();
+        let https_port = free_port();
+        let dashboard_port = free_port();
+        let tcp_low = alloc_tcp_port_range(10);
+        let tcp_high = tcp_low + 9;
+        let udp_low = alloc_tcp_port_range(10);
+        let udp_high = udp_low + 9;
+        Self::start_on_ports_with_load_balancing(
+            control_port,
+            http_port,
+            https_port,
+            dashboard_port,
+            [tcp_low, tcp_high],
+            [udp_low, udp_high],
+            true,
+            "integration-test-token",
+            true,
+        )
+        .await
+    }
+
     /// Start a server on specific pre-allocated ports.
     /// Used by reconnect tests to restart on the same port set.
     #[allow(clippy::too_many_arguments)]
@@ -210,6 +235,36 @@ impl TestServer {
         udp_port_range: [u16; 2],
         require_auth: bool,
         admin_token: &str,
+    ) -> Self {
+        Self::start_on_ports_with_load_balancing(
+            control_port,
+            http_port,
+            https_port,
+            dashboard_port,
+            tcp_port_range,
+            udp_port_range,
+            require_auth,
+            admin_token,
+            false,
+        )
+        .await
+    }
+
+    /// Most-flexible entry point: caller sets every port + the load-balancing
+    /// kill switch. Existing callers go through `start_on_ports` (which
+    /// defaults `load_balancing.enabled` to `false`); only the Phase 2 group
+    /// tests flip it on.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn start_on_ports_with_load_balancing(
+        control_port: u16,
+        http_port: u16,
+        https_port: u16,
+        dashboard_port: u16,
+        tcp_port_range: [u16; 2],
+        udp_port_range: [u16; 2],
+        require_auth: bool,
+        admin_token: &str,
+        load_balancing_enabled: bool,
     ) -> Self {
         let [tcp_low, tcp_high] = tcp_port_range;
 
@@ -271,7 +326,9 @@ impl TestServer {
                 enabled: true,
                 ..rustunnel_server::config::P2pSection::default()
             },
-            load_balancing: rustunnel_server::config::LoadBalancingSection::default(),
+            load_balancing: rustunnel_server::config::LoadBalancingSection {
+                enabled: load_balancing_enabled,
+            },
         });
 
         // Database.
@@ -506,6 +563,48 @@ impl TestClient {
     }
 
     // ── tunnel registration ───────────────────────────────────────────────────
+
+    /// Register an HTTP tunnel as part of a load-balancing group.
+    /// Phase 2 of TUNNEL-7. The server only honours the group fields when
+    /// `[load_balancing] enabled = true`. Returns `(tunnel_id, subdomain, public_url)`.
+    pub async fn register_http_tunnel_grouped(
+        &mut self,
+        subdomain: Option<&str>,
+        group_name: &str,
+        group_key_hash: &str,
+    ) -> Result<(Uuid, String, String), String> {
+        let req_id = Uuid::new_v4().to_string();
+        self.send(&ControlFrame::RegisterTunnel {
+            request_id: req_id.clone(),
+            protocol: TunnelProtocol::Http,
+            subdomain: subdomain.map(str::to_string),
+            local_addr: "127.0.0.1:0".to_string(),
+            p2p_secret_hash: None,
+            p2p_name: None,
+            group: Some(group_name.to_string()),
+            group_key_hash: Some(group_key_hash.to_string()),
+            health_check: None,
+        })
+        .await?;
+
+        match self.recv_timeout(Duration::from_secs(5)).await? {
+            ControlFrame::TunnelRegistered {
+                tunnel_id,
+                public_url,
+                ..
+            } => {
+                let sub = public_url
+                    .trim_start_matches("http://")
+                    .split('.')
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+                Ok((tunnel_id, sub, public_url))
+            }
+            ControlFrame::TunnelError { message, .. } => Err(format!("TunnelError: {message}")),
+            other => Err(format!("unexpected frame: {other:?}")),
+        }
+    }
 
     /// Register an HTTP tunnel.  Returns `(tunnel_id, subdomain, public_url)`.
     pub async fn register_http_tunnel(

--- a/tests/integration/http_groups.rs
+++ b/tests/integration/http_groups.rs
@@ -1,0 +1,215 @@
+//! HTTP load-balancing group integration tests (TUNNEL-7 Phase 2).
+//!
+//! # What these tests pin down
+//!
+//! 1. **Random dispatch across two members.** Two clients register the same
+//!    subdomain with the same `(group, group_key_hash)`. Each terminates at
+//!    its own local backend that tags responses with its identity. We hit
+//!    the tunnel with N requests and assert that *both* backends served a
+//!    non-trivial share — the load-balancing promise of Phase 2.
+//!
+//! 2. **`group_key_hash` mismatch is rejected.** A second client trying to
+//!    join the same subdomain with a different key gets `TunnelError`. This
+//!    is the auth boundary that prevents one tenant from inserting itself
+//!    into another's pool on a shared edge.
+//!
+//! 3. **Kill switch (`[load_balancing] enabled = false`).** When the flag
+//!    is off, the server logs a warning and falls through to solo
+//!    registration — which then rejects the duplicate subdomain. Confirms
+//!    the rollout's safe-default story (plan §6).
+
+#[path = "../common/mod.rs"]
+mod common;
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::{routing::get, Router};
+use common::*;
+use tokio::sync::oneshot;
+
+/// Hello-world server tagged with `who` — every response includes
+/// `X-Backend: who` so the test can count which member served it.
+async fn start_tagged_server(
+    who: &'static str,
+) -> (SocketAddr, Arc<AtomicU64>, oneshot::Sender<()>) {
+    let counter: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
+    let counter_clone = Arc::clone(&counter);
+
+    let app = Router::new().route(
+        "/",
+        get(move || {
+            let counter = Arc::clone(&counter_clone);
+            async move {
+                counter.fetch_add(1, Ordering::Relaxed);
+                axum::http::Response::builder()
+                    .header("X-Backend", who)
+                    .body(format!("hello from {who}"))
+                    .unwrap()
+            }
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind tagged server");
+    let addr = listener.local_addr().unwrap();
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .ok();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    (addr, counter, shutdown_tx)
+}
+
+// ── 1. Random dispatch distributes across two members ──────────────────────────
+
+#[tokio::test]
+async fn http_group_random_dispatch_distributes_across_two_members() {
+    init_tracing();
+
+    // Two backends, each tagging its responses.
+    let (addr_a, count_a, _hold_a) = start_tagged_server("A").await;
+    let (addr_b, count_b, _hold_b) = start_tagged_server("B").await;
+
+    // Server with the kill switch on.
+    let server = TestServer::start_with_load_balancing().await;
+
+    // Two independent client sessions on the same subdomain + key.
+    let mut client_a = TestClient::connect(&server).await.expect("auth A");
+    let mut client_b = TestClient::connect(&server).await.expect("auth B");
+    let session_a = client_a.session_id.unwrap();
+    let session_b = client_b.session_id.unwrap();
+
+    let group = "web";
+    let key = "deadbeef".repeat(8); // 64-char hex placeholder for SHA-256
+
+    let (_tid_a, sub_a, _) = client_a
+        .register_http_tunnel_grouped(Some("pool"), group, &key)
+        .await
+        .expect("client A grouped registration");
+    let (_tid_b, sub_b, _) = client_b
+        .register_http_tunnel_grouped(Some("pool"), group, &key)
+        .await
+        .expect("client B grouped registration");
+    assert_eq!(sub_a, "pool");
+    assert_eq!(sub_b, "pool");
+
+    // Each client bridges to its own backend.
+    connect_data_bridge(&server, session_a, addr_a)
+        .await
+        .expect("data bridge A ready");
+    connect_data_bridge(&server, session_b, addr_b)
+        .await
+        .expect("data bridge B ready");
+
+    // Hammer the tunnel with N requests; sum-by-backend via X-Backend header.
+    const N: u64 = 200;
+    let https_url = format!("https://127.0.0.1:{}/", server.https_port);
+    let host = format!("pool.{}", server.domain);
+    let client = insecure_http_client();
+
+    let mut hits_a = 0u64;
+    let mut hits_b = 0u64;
+    for _ in 0..N {
+        let resp = client
+            .get(&https_url)
+            .header("Host", &host)
+            .send()
+            .await
+            .expect("HTTPS request");
+        assert_eq!(resp.status(), 200);
+        let backend = resp
+            .headers()
+            .get("X-Backend")
+            .map(|v| v.to_str().unwrap_or("").to_string())
+            .unwrap_or_default();
+        match backend.as_str() {
+            "A" => hits_a += 1,
+            "B" => hits_b += 1,
+            other => panic!("unexpected backend tag: {other:?}"),
+        }
+    }
+
+    assert_eq!(hits_a + hits_b, N);
+
+    // Generous bounds — 200 trials, p=0.5, the [40, 160] envelope catches
+    // "always picks the same one" while keeping flake rate effectively zero.
+    assert!(
+        (40..=160).contains(&hits_a),
+        "expected dispatch to balance across both members; got A={hits_a}, B={hits_b}"
+    );
+    assert!(
+        (40..=160).contains(&hits_b),
+        "expected dispatch to balance across both members; got A={hits_a}, B={hits_b}"
+    );
+
+    // The per-backend hit counters must agree with what we observed at the edge.
+    assert_eq!(count_a.load(Ordering::Relaxed), hits_a);
+    assert_eq!(count_b.load(Ordering::Relaxed), hits_b);
+}
+
+// ── 2. Mismatched group_key_hash is rejected ───────────────────────────────────
+
+#[tokio::test]
+async fn http_group_mismatched_key_is_rejected() {
+    init_tracing();
+    let server = TestServer::start_with_load_balancing().await;
+
+    let mut client_a = TestClient::connect(&server).await.expect("auth A");
+    let mut client_b = TestClient::connect(&server).await.expect("auth B");
+
+    client_a
+        .register_http_tunnel_grouped(Some("pool"), "web", &"a".repeat(64))
+        .await
+        .expect("client A registers first with key A");
+
+    let err = client_b
+        .register_http_tunnel_grouped(Some("pool"), "web", &"b".repeat(64))
+        .await
+        .expect_err("client B with different key must be rejected");
+
+    assert!(
+        err.contains("TunnelError") && err.contains("group key does not match"),
+        "expected key-mismatch TunnelError; got: {err}"
+    );
+}
+
+// ── 3. Disabled flag falls through to solo registration ────────────────────────
+
+#[tokio::test]
+async fn http_group_with_kill_switch_off_falls_through_to_solo() {
+    init_tracing();
+    // Default TestServer: load_balancing.enabled = false.
+    let server = TestServer::start().await;
+
+    let mut client_a = TestClient::connect(&server).await.expect("auth A");
+    let mut client_b = TestClient::connect(&server).await.expect("auth B");
+
+    // First grouped registration is downgraded to solo (server logs a warning).
+    client_a
+        .register_http_tunnel_grouped(Some("pool"), "web", &"a".repeat(64))
+        .await
+        .expect("client A registers solo (kill switch off)");
+
+    // Second grouped registration on the same subdomain is also solo →
+    // collides on the existing solo entry → rejected with the legacy
+    // "subdomain already in use" error.
+    let err = client_b
+        .register_http_tunnel_grouped(Some("pool"), "web", &"a".repeat(64))
+        .await
+        .expect_err("second registration must fail when load balancing is off");
+
+    assert!(
+        err.contains("TunnelError") && err.contains("already in use"),
+        "expected solo-collision TunnelError; got: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2 of the FRP-style load balancing plan ([rustunnel-private/docs/development/load-balancing-and-health-checks.md](https://github.com/joaoh82/rustunnel-private/blob/main/docs/development/load-balancing-and-health-checks.md)). When `[load_balancing] enabled = true`, `RegisterTunnel.group` + `RegisterTunnel.group_key_hash` now form a load-balanced HTTP pool — multiple clients sharing the same `(subdomain, key_hash)` register as distinct members of one `TunnelGroup`, and `resolve_http` dispatches new connections to a healthy member uniformly at random.

Phases 0+1 already shipped in v0.6.0 (this is the follow-up that makes the flag actually do something).

## What changed

- **Protocol path**: session.rs translates `RegisterTunnel.group` / `group_key_hash` / `health_check` into a `GroupSpec` only when `config.load_balancing.enabled`; otherwise logs a warning and falls through to solo registration. Wire-compatible with v0.5.x / v0.6.0 edges either way.
- **`register_http_tunnel`** now takes `Option<GroupSpec>` and uses DashMap's `entry()` API for atomic upsert — closes plan §7 risk #4 (concurrent first-registration race that the old `contains_key`-then-`insert` sequence was latently vulnerable to).
- **§4.3 truth table** fully implemented:
  - free + solo → create solo group
  - free + group → create new group with `key_hash`
  - taken + solo → reject (legacy "subdomain in use")
  - taken + group + matching `(key, protocol)` → join
  - taken + group + mismatched key → reject ("group key does not match")
  - taken + group + mismatched protocol → reject ("protocol mismatch")
- **Health-check seeding**: `GroupMember::with_health_spec` defaults `healthy = false` when a probe spec is attached (per §4.5; Phase 4 will flip it on `TunnelHealthy`).

## Tests

- **Server lib**: 45 → 54. 8 new `http_group_*` tests in `core/router.rs` covering each cell of §4.3, dispatch distribution over 1000 trials (~500 each within [200, 800]), and the unhealthy-on-attach case.
- **New integration suite** `tests/integration/http_groups.rs` (3 tests):
  - **`http_group_random_dispatch_distributes_across_two_members`** — two clients on the same subdomain, each bridging to its own backend tagged via `X-Backend: A|B`. 200 HTTPS requests through the full edge → yamux → local-server chain; assert both backends served between [40, 160] requests.
  - **`http_group_mismatched_key_is_rejected`** — second registration with a different `group_key_hash` fails with `TunnelError`.
  - **`http_group_with_kill_switch_off_falls_through_to_solo`** — default `[load_balancing] enabled = false` server downgrades grouped registrations to solo, second registration collides on the legacy "in use" path.
- `TestServer::start_with_load_balancing()` + `TestClient::register_http_tunnel_grouped()` helpers added.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` (with PG): every suite green.

## Out of scope (next phases)

- **Phase 3** — TCP groups (mostly mirrors this PR; allocates one port per group rather than per member, returns the port to the pool only when the last member leaves).
- **Phase 4** — client-side TCP/HTTP probes that emit `TunnelHealthy` / `TunnelUnhealthy`.
- **Phase 5** — Prometheus group metrics, dashboard surfaces, marketing-site updates.
- **Phase 6** — `AuthOk.server_version` gate so newer clients only emit health frames to ≥ v0.6 servers.

## Test plan
- [x] cargo fmt + clippy clean
- [x] full workspace test suite green
- [ ] eyeball the §4.3 logic in `register_http_tunnel`
- [ ] confirm I'm OK with `(name, key_hash)` semantics — first joiner sets `TunnelGroup.name`, subsequent joiners can supply any value (matches FRP)
- [ ] decide whether to bump 0.6.0 → 0.6.1 (additive, kill switch off by default) or 0.7.0 (new feature, even if gated) before tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)