### PR TITLE
feat(server): TUNNEL-8 Phase 3 — TCP load-balancing groups

### DIFF
--- a/crates/rustunnel-server/src/control/session.rs
+++ b/crates/rustunnel-server/src/control/session.rs
@@ -502,7 +502,7 @@ where
             // For the disabled-flag path we log so operators can see when
             // grouped clients are being downgraded (matches the warning the
             // *client* will eventually emit on a Phase-6 server-version probe).
-            let http_group_spec = match (
+            let group_spec = match (
                 config.load_balancing.enabled,
                 group.as_ref(),
                 group_key_hash.as_ref(),
@@ -629,7 +629,7 @@ where
                         &session_id,
                         subdomain,
                         protocol.clone(),
-                        http_group_spec,
+                        group_spec,
                     ) {
                         Ok((tunnel_id, sub)) => {
                             let scheme = if protocol == TunnelProtocol::Https {
@@ -728,7 +728,7 @@ where
                         .await?;
                     }
                 },
-                TunnelProtocol::Tcp => match core.register_tcp_tunnel(&session_id) {
+                TunnelProtocol::Tcp => match core.register_tcp_tunnel(&session_id, group_spec) {
                     Ok((tunnel_id, port)) => {
                         let public_url = format!("tcp://{}:{port}", config.server.domain);
                         let port_str = port.to_string();

--- a/crates/rustunnel-server/src/core/router.rs
+++ b/crates/rustunnel-server/src/core/router.rs
@@ -45,6 +45,16 @@ pub struct TunnelCore {
     /// (see plan §6); the `Arc<TunnelGroup>` wrapper keeps the dispatch path
     /// uniform with HTTP/TCP.
     pub udp_routes: DashMap<u16, Arc<TunnelGroup>>,
+    /// `(group_name, key_hash) → port` lookup for TCP groups (TUNNEL-7 Phase 3).
+    ///
+    /// HTTP groups dispatch off the user-supplied subdomain, so the routing
+    /// key is in the registration request. TCP ports are server-allocated, so
+    /// the second member of `group="ssh"` doesn't know which port to ask for
+    /// — this index lets the server resolve `(group, key_hash)` to the port
+    /// the first registration claimed. The entry is only present while the
+    /// group has at least one member; `remove_tunnel` cleans it up alongside
+    /// the route entry.
+    tcp_group_index: DashMap<(String, String), u16>,
     /// name → P2pPublisher  (P2P tunnels registered by publishers)
     pub p2p_tunnels: DashMap<String, P2pPublisher>,
     /// session_id → SessionInfo
@@ -134,6 +144,7 @@ impl TunnelCore {
             http_routes: DashMap::new(),
             tcp_routes: DashMap::new(),
             udp_routes: DashMap::new(),
+            tcp_group_index: DashMap::new(),
             p2p_tunnels: DashMap::new(),
             sessions: DashMap::new(),
             available_tcp_ports: Mutex::new(tcp_ports),
@@ -344,19 +355,28 @@ impl TunnelCore {
         Ok((tunnel_id, subdomain))
     }
 
-    /// Register a TCP tunnel for `session_id`, allocating the next available port.
+    /// Register a TCP tunnel for `session_id`.
+    ///
+    /// `group = None` (the historical case): allocate a fresh port and create
+    /// a solo group, mirroring the HTTP path.
+    ///
+    /// `group = Some` (TUNNEL-7 Phase 3): the first registration of a given
+    /// `(group_name, key_hash)` allocates a port; subsequent registrations
+    /// look up that port via `tcp_group_index` and reuse it. The TCP edge
+    /// listener fires `TcpTunnelEvent::Registered` only on the first member
+    /// — joins are no-ops at the listener layer (the port is already bound
+    /// from the first member's event).
+    ///
     /// Returns `(tunnel_id, port)`.
-    pub fn register_tcp_tunnel(&self, session_id: &Uuid) -> Result<(Uuid, u16)> {
+    pub fn register_tcp_tunnel(
+        &self,
+        session_id: &Uuid,
+        group: Option<GroupSpec>,
+    ) -> Result<(Uuid, u16)> {
         self.check_session_limit(session_id)?;
 
-        let port = self
-            .available_tcp_ports
-            .lock()
-            .pop()
-            .ok_or(Error::NoPortsAvailable)?;
-
         let tunnel_id = Uuid::new_v4();
-        let info = TunnelInfo {
+        let build_info = |port: u16| TunnelInfo {
             session_id: *session_id,
             tunnel_id,
             protocol: TunnelProtocol::Tcp,
@@ -368,15 +388,80 @@ impl TunnelCore {
             conn_semaphore: Arc::new(Semaphore::new(self.max_connections_per_tunnel)),
         };
 
-        let group = TunnelGroup::new_solo(port.to_string(), info);
-        self.tcp_routes.insert(port, group);
-        self.tunnel_index.insert(tunnel_id, TunnelKey::Tcp(port));
-        self.add_tunnel_to_session(session_id, tunnel_id);
-        let _ = self
-            .tcp_events
-            .send(TcpTunnelEvent::Registered { tunnel_id, port });
-
-        Ok((tunnel_id, port))
+        use dashmap::mapref::entry::Entry;
+        match group {
+            None => {
+                // Solo path — historical behaviour.
+                let port = self
+                    .available_tcp_ports
+                    .lock()
+                    .pop()
+                    .ok_or(Error::NoPortsAvailable)?;
+                let info = build_info(port);
+                let new_group = TunnelGroup::new_solo(port.to_string(), info);
+                self.tcp_routes.insert(port, new_group);
+                self.tunnel_index.insert(tunnel_id, TunnelKey::Tcp(port));
+                self.add_tunnel_to_session(session_id, tunnel_id);
+                let _ = self
+                    .tcp_events
+                    .send(TcpTunnelEvent::Registered { tunnel_id, port });
+                Ok((tunnel_id, port))
+            }
+            Some(spec) => {
+                let idx_key = (spec.group_name.clone(), spec.key_hash.clone());
+                // The index entry guard serialises every "creation or join"
+                // for this `(name, key_hash)` against every other one — and
+                // against the matching `remove_tunnel` path, which acquires
+                // the same entry to evict the index. Closes the
+                // concurrent-first-registration race for TCP groups.
+                match self.tcp_group_index.entry(idx_key) {
+                    Entry::Vacant(idx_vac) => {
+                        // First member of a brand-new TCP group.
+                        let port = self
+                            .available_tcp_ports
+                            .lock()
+                            .pop()
+                            .ok_or(Error::NoPortsAvailable)?;
+                        let info = build_info(port);
+                        let new_group = TunnelGroup::new_with_member(
+                            spec.group_name,
+                            Some(spec.key_hash),
+                            GroupMember::with_health_spec(info, spec.health_check),
+                        );
+                        self.tcp_routes.insert(port, new_group);
+                        idx_vac.insert(port);
+                        self.tunnel_index.insert(tunnel_id, TunnelKey::Tcp(port));
+                        self.add_tunnel_to_session(session_id, tunnel_id);
+                        let _ = self
+                            .tcp_events
+                            .send(TcpTunnelEvent::Registered { tunnel_id, port });
+                        Ok((tunnel_id, port))
+                    }
+                    Entry::Occupied(idx_occ) => {
+                        // Subsequent member: reuse the existing port. No new
+                        // allocation, no `Registered` event (the listener is
+                        // already up from the first member).
+                        let port = *idx_occ.get();
+                        let info = build_info(port);
+                        // Sanity: the route must exist while the index says
+                        // it does. If it doesn't, the index is stale — bail.
+                        let Some(existing) = self.tcp_routes.get(&port) else {
+                            return Err(Error::Tunnel(format!(
+                                "TCP group index points to missing port {port}; please retry"
+                            )));
+                        };
+                        existing.members.insert(
+                            tunnel_id,
+                            GroupMember::with_health_spec(info, spec.health_check),
+                        );
+                        drop(existing);
+                        self.tunnel_index.insert(tunnel_id, TunnelKey::Tcp(port));
+                        self.add_tunnel_to_session(session_id, tunnel_id);
+                        Ok((tunnel_id, port))
+                    }
+                }
+            }
+        }
     }
 
     /// Register a UDP tunnel for `session_id`, allocating the next available port.
@@ -515,16 +600,25 @@ impl TunnelCore {
                 }
             }
             TunnelKey::Tcp(port) => {
-                let group_empty = self
+                // Snapshot the group's identity *before* mutating its members
+                // — we need (name, key_hash) to find the index entry to evict
+                // when the last member leaves. We always remove the member;
+                // tcp_group_index cleanup only happens for grouped (key_hash
+                // is Some) and only when the group is now empty.
+                let (group_empty, idx_key) = self
                     .tcp_routes
                     .get(&port)
                     .map(|g| {
+                        let idx = g.key_hash.as_ref().map(|kh| (g.name.clone(), kh.clone()));
                         g.members.remove(tunnel_id);
-                        g.members.is_empty()
+                        (g.members.is_empty(), idx)
                     })
-                    .unwrap_or(true);
+                    .unwrap_or((true, None));
                 if group_empty {
                     self.tcp_routes.remove(&port);
+                    if let Some(k) = idx_key {
+                        self.tcp_group_index.remove(&k);
+                    }
                     self.available_tcp_ports.lock().push(port);
                     let _ = self.tcp_events.send(TcpTunnelEvent::Unregistered { port });
                 }
@@ -873,7 +967,7 @@ mod tests {
         let core = make_core();
         let (session_id, _rx) = dummy_session(&core);
 
-        let (tunnel_id, port) = core.register_tcp_tunnel(&session_id).unwrap();
+        let (tunnel_id, port) = core.register_tcp_tunnel(&session_id, None).unwrap();
 
         assert!((20000..=20009).contains(&port));
         assert!(core.tcp_routes.contains_key(&port));
@@ -890,13 +984,13 @@ mod tests {
         let core = TunnelCore::new([30000, 30000], [0, 0], 5, 100, 1000); // single-port range
         let (session_id, _rx) = dummy_session(&core);
 
-        let (tunnel_id, port) = core.register_tcp_tunnel(&session_id).unwrap();
+        let (tunnel_id, port) = core.register_tcp_tunnel(&session_id, None).unwrap();
         assert_eq!(port, 30000);
 
         // Pool is now empty — next allocation must fail.
         let (session2_id, _rx2) = dummy_session(&core);
         assert!(matches!(
-            core.register_tcp_tunnel(&session2_id),
+            core.register_tcp_tunnel(&session2_id, None),
             Err(Error::NoPortsAvailable)
         ));
 
@@ -904,7 +998,7 @@ mod tests {
         core.remove_tunnel(&tunnel_id);
 
         // Now allocation succeeds again.
-        let (_id2, port2) = core.register_tcp_tunnel(&session2_id).unwrap();
+        let (_id2, port2) = core.register_tcp_tunnel(&session2_id, None).unwrap();
         assert_eq!(port2, 30000);
     }
 
@@ -914,10 +1008,10 @@ mod tests {
         let (sid1, _rx1) = dummy_session(&core);
         let (sid2, _rx2) = dummy_session(&core);
 
-        core.register_tcp_tunnel(&sid1).unwrap();
+        core.register_tcp_tunnel(&sid1, None).unwrap();
 
         assert!(matches!(
-            core.register_tcp_tunnel(&sid2),
+            core.register_tcp_tunnel(&sid2, None),
             Err(Error::NoPortsAvailable)
         ));
     }
@@ -954,7 +1048,7 @@ mod tests {
         let core = make_core();
         let (session_id, _rx) = dummy_session(&core);
 
-        let (_, port) = core.register_tcp_tunnel(&session_id).unwrap();
+        let (_, port) = core.register_tcp_tunnel(&session_id, None).unwrap();
 
         let (info, _tx) = core.resolve_tcp(port).unwrap();
         assert_eq!(info.assigned_port, Some(port));
@@ -982,7 +1076,7 @@ mod tests {
                 None,
             )
             .unwrap();
-        let (_, port) = core.register_tcp_tunnel(&session_id).unwrap();
+        let (_, port) = core.register_tcp_tunnel(&session_id, None).unwrap();
 
         core.remove_session(&session_id);
 
@@ -1465,6 +1559,207 @@ mod tests {
             (200..=800).contains(&count_b),
             "expected ~500 hits on member B, got {count_b} (A got {count_a})"
         );
+    }
+
+    // ── TCP group registration (Phase 3 of TUNNEL-7) ─────────────────────
+    //
+    // Same shape as the HTTP truth table, plus the port-pool wrinkle:
+    // first member of a group allocates a port; subsequent members reuse
+    // it; only when the *last* member leaves does the port go back to the
+    // pool and the listener-Unregistered event fire.
+    //
+    // For these tests we use the dedicated event subscriber to assert the
+    // edge-listener event semantics — silence is the contract for joiners.
+
+    /// First TCP-grouped registration allocates a port from the pool;
+    /// `tcp_group_index` records the mapping; the listener gets a
+    /// `Registered` event so the edge knows to bind.
+    #[test]
+    fn tcp_group_first_registration_allocates_port_and_indexes() {
+        let core = make_core();
+        let (sid, _rx) = dummy_session(&core);
+        let mut events = core.subscribe_tcp_events();
+
+        let (tid, port) = core
+            .register_tcp_tunnel(&sid, Some(solo_group_spec("ssh", "hash-A")))
+            .unwrap();
+
+        // Routing entry is in place with the right key_hash.
+        let group = core.tcp_routes.get(&port).unwrap();
+        assert_eq!(group.name, "ssh");
+        assert_eq!(group.key_hash.as_deref(), Some("hash-A"));
+        assert_eq!(group.members.len(), 1);
+        assert!(group.members.contains_key(&tid));
+        drop(group);
+
+        // Index resolves the (name, key_hash) → port.
+        let idx_port = core
+            .tcp_group_index
+            .get(&("ssh".to_string(), "hash-A".to_string()))
+            .map(|v| *v);
+        assert_eq!(idx_port, Some(port));
+
+        // Edge listener got the Registered event for the first member.
+        let evt = events
+            .try_recv()
+            .expect("Registered event for first member");
+        match evt {
+            TcpTunnelEvent::Registered { tunnel_id, port: p } => {
+                assert_eq!(tunnel_id, tid);
+                assert_eq!(p, port);
+            }
+            other => panic!("expected Registered, got {other:?}"),
+        }
+    }
+
+    /// Second registration with the same `(group, key_hash)` reuses the
+    /// existing port and does NOT fire a new Registered event — the
+    /// listener is already bound.
+    #[test]
+    fn tcp_group_second_member_reuses_port_no_extra_event() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+        let mut events = core.subscribe_tcp_events();
+
+        let (_tid_a, port_a) = core
+            .register_tcp_tunnel(&sid_a, Some(solo_group_spec("ssh", "hash-A")))
+            .unwrap();
+        let (_tid_b, port_b) = core
+            .register_tcp_tunnel(&sid_b, Some(solo_group_spec("ssh", "hash-A")))
+            .unwrap();
+
+        assert_eq!(
+            port_a, port_b,
+            "second member must reuse the first member's port"
+        );
+
+        let group = core.tcp_routes.get(&port_a).unwrap();
+        assert_eq!(group.members.len(), 2);
+        drop(group);
+
+        // First Registered was for tid_a; nothing else.
+        let _first = events.try_recv().expect("Registered for first member");
+        assert!(
+            events.try_recv().is_err(),
+            "no Registered event must fire for join — the listener is already up"
+        );
+    }
+
+    /// Mismatched key on the same group name → rejected.
+    #[test]
+    fn tcp_group_mismatched_key_creates_a_separate_pool() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        let (_tid_a, port_a) = core
+            .register_tcp_tunnel(&sid_a, Some(solo_group_spec("ssh", "hash-A")))
+            .unwrap();
+        // Different key → different index entry → fresh port allocation.
+        // (FRP allows this since `(name, key)` is the pool identity.)
+        let (_tid_b, port_b) = core
+            .register_tcp_tunnel(&sid_b, Some(solo_group_spec("ssh", "hash-B")))
+            .unwrap();
+
+        assert_ne!(
+            port_a, port_b,
+            "different keys → different pools → different ports"
+        );
+        assert_eq!(core.tcp_routes.get(&port_a).unwrap().members.len(), 1);
+        assert_eq!(core.tcp_routes.get(&port_b).unwrap().members.len(), 1);
+    }
+
+    /// Removing one of two members keeps the route + the index entry; only
+    /// the *last* leave evicts everything and returns the port to the pool.
+    #[test]
+    fn tcp_group_removing_one_of_two_keeps_port_allocated() {
+        let core = TunnelCore::new([60000, 60001], [0, 0], 5, 100, 1000);
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+        let mut events = core.subscribe_tcp_events();
+
+        let (tid_a, port) = core
+            .register_tcp_tunnel(&sid_a, Some(solo_group_spec("ssh", "hash-A")))
+            .unwrap();
+        let (tid_b, port_b) = core
+            .register_tcp_tunnel(&sid_b, Some(solo_group_spec("ssh", "hash-A")))
+            .unwrap();
+        assert_eq!(port, port_b);
+
+        // Drain the Registered event from creation.
+        let _ = events.try_recv();
+
+        // Remove one member — port stays, index stays, no Unregistered event.
+        core.remove_tunnel(&tid_a);
+        assert!(core.tcp_routes.contains_key(&port));
+        assert!(core
+            .tcp_group_index
+            .contains_key(&("ssh".to_string(), "hash-A".to_string())));
+        assert!(events.try_recv().is_err());
+
+        // Remove the last member — port returns to pool, index clears,
+        // Unregistered fires.
+        core.remove_tunnel(&tid_b);
+        assert!(!core.tcp_routes.contains_key(&port));
+        assert!(!core
+            .tcp_group_index
+            .contains_key(&("ssh".to_string(), "hash-A".to_string())));
+        let evt = events.try_recv().expect("Unregistered for last leave");
+        assert!(matches!(evt, TcpTunnelEvent::Unregistered { port: p } if p == port));
+    }
+
+    /// Random dispatch across two TCP members — same property the HTTP test
+    /// pins down, exercised through `resolve_tcp(port)`.
+    #[test]
+    fn tcp_group_random_dispatch_distributes_across_members() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        let (tid_a, port) = core
+            .register_tcp_tunnel(&sid_a, Some(solo_group_spec("ssh", "hash-A")))
+            .unwrap();
+        let (tid_b, _) = core
+            .register_tcp_tunnel(&sid_b, Some(solo_group_spec("ssh", "hash-A")))
+            .unwrap();
+
+        const N: u64 = 1_000;
+        for _ in 0..N {
+            assert!(core.resolve_tcp(port).is_some());
+        }
+
+        let count_a = core.get_tunnel_request_count(&tid_a);
+        let count_b = core.get_tunnel_request_count(&tid_b);
+        assert_eq!(count_a + count_b, N);
+        assert!(
+            (200..=800).contains(&count_a),
+            "expected ~500 hits on member A, got {count_a} (B got {count_b})"
+        );
+        assert!(
+            (200..=800).contains(&count_b),
+            "expected ~500 hits on member B, got {count_b} (A got {count_a})"
+        );
+    }
+
+    /// Port pool is finite — when a brand-new TCP group can't allocate a
+    /// fresh port, registration fails with `NoPortsAvailable` (same as the
+    /// solo path).
+    #[test]
+    fn tcp_group_first_registration_respects_port_pool() {
+        let core = TunnelCore::new([60100, 60100], [0, 0], 5, 100, 1000);
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        // First grouped registration takes the only port.
+        core.register_tcp_tunnel(&sid_a, Some(solo_group_spec("ssh", "hash-A")))
+            .unwrap();
+
+        // A *different* group needs a different port — pool is empty.
+        assert!(matches!(
+            core.register_tcp_tunnel(&sid_b, Some(solo_group_spec("ssh", "hash-B"))),
+            Err(Error::NoPortsAvailable)
+        ));
     }
 
     /// A member registered with a `health_check` starts unhealthy and is

--- a/crates/rustunnel-server/src/edge/tcp.rs
+++ b/crates/rustunnel-server/src/edge/tcp.rs
@@ -271,7 +271,7 @@ mod tests {
         let mut rx = core.subscribe_tcp_events();
         let (sid, _ctrl_rx) = add_session(&core);
 
-        let (_tid, port) = core.register_tcp_tunnel(&sid).unwrap();
+        let (_tid, port) = core.register_tcp_tunnel(&sid, None).unwrap();
 
         let event = tokio::time::timeout(Duration::from_millis(100), rx.recv())
             .await
@@ -290,7 +290,7 @@ mod tests {
         let mut rx = core.subscribe_tcp_events();
         let (sid, _ctrl_rx) = add_session(&core);
 
-        let (tid, port) = core.register_tcp_tunnel(&sid).unwrap();
+        let (tid, port) = core.register_tcp_tunnel(&sid, None).unwrap();
         // consume the Registered event
         let _ = rx.recv().await;
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -58,3 +58,7 @@ path = "integration/p2p_tunnel.rs"
 [[test]]
 name = "http_groups"
 path = "integration/http_groups.rs"
+
+[[test]]
+name = "tcp_groups"
+path = "integration/tcp_groups.rs"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -645,6 +645,43 @@ impl TestClient {
         }
     }
 
+    /// Register a TCP tunnel as part of a load-balancing group.
+    /// Phase 3 of TUNNEL-7. The server returns the group's existing port
+    /// for the second-and-onwards member; the first allocates a fresh one.
+    /// Returns `(tunnel_id, assigned_port)`.
+    pub async fn register_tcp_tunnel_grouped(
+        &mut self,
+        group_name: &str,
+        group_key_hash: &str,
+    ) -> Result<(Uuid, u16), String> {
+        let req_id = Uuid::new_v4().to_string();
+        self.send(&ControlFrame::RegisterTunnel {
+            request_id: req_id,
+            protocol: TunnelProtocol::Tcp,
+            subdomain: None,
+            local_addr: "127.0.0.1:0".to_string(),
+            p2p_secret_hash: None,
+            p2p_name: None,
+            group: Some(group_name.to_string()),
+            group_key_hash: Some(group_key_hash.to_string()),
+            health_check: None,
+        })
+        .await?;
+
+        match self.recv_timeout(Duration::from_secs(5)).await? {
+            ControlFrame::TunnelRegistered {
+                tunnel_id,
+                assigned_port,
+                ..
+            } => {
+                let port = assigned_port.ok_or("missing assigned_port")?;
+                Ok((tunnel_id, port))
+            }
+            ControlFrame::TunnelError { message, .. } => Err(format!("TunnelError: {message}")),
+            other => Err(format!("unexpected frame: {other:?}")),
+        }
+    }
+
     /// Register a TCP tunnel.  Returns `(tunnel_id, assigned_port)`.
     pub async fn register_tcp_tunnel(&mut self) -> Result<(Uuid, u16), String> {
         let req_id = Uuid::new_v4().to_string();

--- a/tests/integration/tcp_groups.rs
+++ b/tests/integration/tcp_groups.rs
@@ -1,0 +1,208 @@
+//! TCP load-balancing group integration tests (TUNNEL-7 Phase 3).
+//!
+//! Same shape as the HTTP-groups suite, but exercising the TCP path:
+//! two clients register the same `(group, group_key_hash)` and the second
+//! reuses the first's allocated port. Connections to that port distribute
+//! across the two members at random.
+//!
+//! Each backend tags its responses with `A:` or `B:` so the test can count
+//! who served each connection (TCP has no obvious way to thread metadata
+//! through the proxy other than the application-level bytes).
+
+#[path = "../common/mod.rs"]
+mod common;
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use common::*;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::oneshot;
+
+/// TCP backend that prefixes every response with `who:` and counts requests.
+async fn start_tagged_echo_server(
+    who: &'static str,
+) -> (SocketAddr, Arc<AtomicU64>, oneshot::Sender<()>) {
+    let counter: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
+    let counter_clone = Arc::clone(&counter);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind tagged echo");
+    let addr = listener.local_addr().unwrap();
+
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => break,
+                result = listener.accept() => {
+                    let Ok((mut stream, _)) = result else { break };
+                    let counter = Arc::clone(&counter_clone);
+                    tokio::spawn(async move {
+                        // Read up to 32 bytes from the client, then reply
+                        // with `who:<echo>` and close. One request, one
+                        // tagged response — easy to count from the client.
+                        let mut buf = vec![0u8; 32];
+                        let n = match stream.read(&mut buf).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => n,
+                        };
+                        counter.fetch_add(1, Ordering::Relaxed);
+                        let mut response = format!("{who}:").into_bytes();
+                        response.extend_from_slice(&buf[..n]);
+                        let _ = stream.write_all(&response).await;
+                        let _ = stream.shutdown().await;
+                    });
+                }
+            }
+        }
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    (addr, counter, shutdown_tx)
+}
+
+// ── 1. Random dispatch across two TCP members ──────────────────────────────────
+
+#[tokio::test]
+async fn tcp_group_random_dispatch_distributes_across_two_members() {
+    init_tracing();
+
+    // Two tagged TCP backends.
+    let (addr_a, count_a, _hold_a) = start_tagged_echo_server("A").await;
+    let (addr_b, count_b, _hold_b) = start_tagged_echo_server("B").await;
+
+    let server = TestServer::start_with_load_balancing().await;
+
+    // Two clients on the same `(group, key)`.
+    let mut client_a = TestClient::connect(&server).await.expect("auth A");
+    let mut client_b = TestClient::connect(&server).await.expect("auth B");
+    let session_a = client_a.session_id.unwrap();
+    let session_b = client_b.session_id.unwrap();
+
+    let group = "ssh";
+    let key = "deadbeef".repeat(8);
+
+    let (_tid_a, port_a) = client_a
+        .register_tcp_tunnel_grouped(group, &key)
+        .await
+        .expect("client A grouped TCP registration");
+    let (_tid_b, port_b) = client_b
+        .register_tcp_tunnel_grouped(group, &key)
+        .await
+        .expect("client B grouped TCP registration");
+    assert_eq!(
+        port_a, port_b,
+        "second TCP group member must reuse the first's port"
+    );
+
+    // Each client bridges to its own backend.
+    connect_data_bridge(&server, session_a, addr_a)
+        .await
+        .expect("data bridge A ready");
+    connect_data_bridge(&server, session_b, addr_b)
+        .await
+        .expect("data bridge B ready");
+
+    // N TCP connections; count which backend served each.
+    const N: u64 = 60;
+    let tunnel_addr: SocketAddr = format!("127.0.0.1:{port_a}").parse().unwrap();
+    let mut hits_a = 0u64;
+    let mut hits_b = 0u64;
+    for i in 0..N {
+        let mut conn = tokio::net::TcpStream::connect(tunnel_addr)
+            .await
+            .expect("connect to tunnel TCP port");
+        let payload = format!("ping{i}");
+        conn.write_all(payload.as_bytes()).await.expect("write");
+        let mut response = Vec::new();
+        conn.read_to_end(&mut response).await.expect("read echo");
+        let prefix = response
+            .iter()
+            .position(|&b| b == b':')
+            .map(|idx| std::str::from_utf8(&response[..idx]).unwrap_or(""))
+            .unwrap_or("");
+        match prefix {
+            "A" => hits_a += 1,
+            "B" => hits_b += 1,
+            other => panic!("unexpected backend tag: {other:?} (full response: {response:?})"),
+        }
+    }
+
+    assert_eq!(hits_a + hits_b, N);
+    // 60 trials with p=0.5 — [12, 48] is a wide envelope that catches a
+    // "always picks the same member" regression with effectively zero flake.
+    assert!(
+        (12..=48).contains(&hits_a),
+        "expected dispatch to balance; got A={hits_a}, B={hits_b}"
+    );
+    assert!(
+        (12..=48).contains(&hits_b),
+        "expected dispatch to balance; got A={hits_a}, B={hits_b}"
+    );
+
+    // Per-backend hit counters must agree.
+    assert_eq!(count_a.load(Ordering::Relaxed), hits_a);
+    assert_eq!(count_b.load(Ordering::Relaxed), hits_b);
+}
+
+// ── 2. Different keys produce different ports ──────────────────────────────────
+
+#[tokio::test]
+async fn tcp_group_different_keys_get_separate_ports() {
+    init_tracing();
+    let server = TestServer::start_with_load_balancing().await;
+
+    let mut client_a = TestClient::connect(&server).await.expect("auth A");
+    let mut client_b = TestClient::connect(&server).await.expect("auth B");
+
+    let (_tid_a, port_a) = client_a
+        .register_tcp_tunnel_grouped("ssh", &"a".repeat(64))
+        .await
+        .expect("client A registers");
+    let (_tid_b, port_b) = client_b
+        .register_tcp_tunnel_grouped("ssh", &"b".repeat(64))
+        .await
+        .expect("client B registers (different key)");
+
+    assert_ne!(
+        port_a, port_b,
+        "different keys → different pools → different ports"
+    );
+}
+
+// ── 3. Disabled flag falls through to solo TCP allocation ──────────────────────
+
+#[tokio::test]
+async fn tcp_group_with_kill_switch_off_falls_through_to_solo() {
+    init_tracing();
+    // Default TestServer: load_balancing.enabled = false.
+    let server = TestServer::start().await;
+
+    let mut client_a = TestClient::connect(&server).await.expect("auth A");
+    let mut client_b = TestClient::connect(&server).await.expect("auth B");
+
+    // First grouped TCP registration is downgraded to solo (server logs warning).
+    let (_tid_a, port_a) = client_a
+        .register_tcp_tunnel_grouped("ssh", &"a".repeat(64))
+        .await
+        .expect("client A solo (kill switch off)");
+
+    // Second grouped registration is *also* solo — and TCP doesn't have
+    // the "subdomain in use" path; it simply gets a fresh port from the
+    // pool. So both clients end up on different ports, each with one
+    // member. This is the documented kill-switch-off behaviour: grouped
+    // fields are accepted but ignored.
+    let (_tid_b, port_b) = client_b
+        .register_tcp_tunnel_grouped("ssh", &"a".repeat(64))
+        .await
+        .expect("client B also solo");
+
+    assert_ne!(
+        port_a, port_b,
+        "kill switch off → grouped TCP registrations are downgraded to solo \
+         and each gets its own port"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 3 of the FRP-style load balancing plan. When `[load_balancing] enabled = true`, `RegisterTunnel.group` + `RegisterTunnel.group_key_hash` now also form a load-balanced **TCP** pool (Phase 2 did HTTP). The first registration of a given `(group, key_hash)` allocates a port from the configured pool; subsequent registrations reuse it via the new `tcp_group_index` lookup.

Phase 0 + 1 (v0.6.0) + Phase 2 (#61) are already on `main`. Same shape as Phase 2 — only the port-pool wrinkle is new.

## What changed

- **`tcp_group_index: DashMap<(String, String), u16>`** on `TunnelCore`. Resolves `(group_name, key_hash) → port` so the second-and-onwards member can find the pool. HTTP doesn't need this because the subdomain is the routing key the user supplies; TCP ports are server-allocated, so the joiner has no way to ask for the right port without a server-side index.
- **`register_tcp_tunnel`** now takes `Option<GroupSpec>`:
  - `None` (historical case): allocate fresh port, create solo group.
  - `Some` and index miss: allocate fresh port, create grouped pool, fire `TcpTunnelEvent::Registered`.
  - `Some` and index hit: reuse the existing port. **No** `Registered` event — the listener is already up. Just inserts a new member into the existing group.
  - Index entry guard makes the create/join/remove paths mutually atomic (closes the concurrent-first-registration race for TCP, same as Phase 2 did for HTTP).
- **`remove_tunnel`** snapshots `(group.name, group.key_hash)` before removing the member so it can evict `tcp_group_index` when the last member leaves. Solo TCP path is unchanged.
- **Kill switch off** (default): grouped fields accepted but ignored; each registration takes a fresh port. Wire-compatible with v0.6.x edges.

## Tests

- **Server lib**: 54 → 60. 6 new `tcp_group_*` tests pin down:
  - First-member index allocation + `Registered` event.
  - Second member reuses port; **no** new `Registered` event.
  - Different keys → different pools → different ports.
  - Removing one of two members keeps the route + index; last-leave evicts everything.
  - Random dispatch distributes (~500/500 over 1000 trials inside [200, 800]).
  - Port-pool exhaustion still rejects with `NoPortsAvailable`.
- **New integration suite** `tests/integration/tcp_groups.rs` (3 tests):
  - **`tcp_group_random_dispatch_distributes_across_two_members`** — 60 raw TCP connections through the full edge → yamux → tagged echo-server chain. Each backend prefixes responses with `A:` or `B:`; the test counts each in [12, 48].
  - **`tcp_group_different_keys_get_separate_ports`** — confirms `(name, key)` is the pool identity, not just `name`.
  - **`tcp_group_with_kill_switch_off_falls_through_to_solo`** — grouped TCP fields with the flag off get separate ports (no "subdomain in use" path exists for TCP).

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` (with PG): every suite green.

## Out of scope (next phases)

- **Phase 4** — client-side TCP/HTTP health probes that emit `TunnelHealthy` / `TunnelUnhealthy` and the server-side handler that flips `member.healthy` (in progress next).
- **Phase 5** — Prometheus group metrics, dashboard surfaces.
- **Phase 6** — `AuthOk.server_version` gate so newer clients only emit health frames to ≥ v0.6 servers.

## Test plan
- [x] cargo fmt + clippy clean
- [x] full workspace test suite green
- [ ] eyeball the index entry locking in `register_tcp_tunnel` and `remove_tunnel`
- [ ] confirm I'm OK with the kill-switch-off TCP semantics: each grouped registration gets a fresh port (no error), since TCP has no equivalent of the "subdomain in use" collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)