### PR TITLE
feat: TUNNEL-8 Phase 4 — health checks (server bit + client probes)

### DIFF
--- a/crates/rustunnel-client/src/config.rs
+++ b/crates/rustunnel-client/src/config.rs
@@ -60,6 +60,59 @@ pub struct TunnelDef {
     /// Tunnel ID assigned by the server after registration (runtime only, not serialized).
     #[serde(skip)]
     pub registered_tunnel_id: Option<uuid::Uuid>,
+    /// Load-balancing group name (TUNNEL-7 Phase 2/3). Tunnels sharing the
+    /// same `(group, group_key)` form a load-balanced pool on the server.
+    /// Honoured only when the edge has `[load_balancing] enabled = true`.
+    pub group: Option<String>,
+    /// Shared secret for the load-balancing group; the client never
+    /// transmits this raw value, it sends the SHA-256 hash on registration.
+    pub group_key: Option<String>,
+    /// Optional client-side health probe spec (TUNNEL-7 Phase 4). When set,
+    /// the client probes its local service and reports
+    /// `TunnelHealthy` / `TunnelUnhealthy` so the edge can route around a
+    /// sick upstream. Defaults to no probing — the edge trusts the
+    /// client's presence (matches FRP).
+    #[serde(default)]
+    pub health_check: Option<HealthCheckConfig>,
+}
+
+/// User-facing health-check configuration (parsed from `~/.rustunnel/config.yml`).
+///
+/// The wire-level shape (`rustunnel_protocol::HealthCheckSpec`) is built
+/// from this on registration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HealthCheckConfig {
+    /// `"tcp"` or `"http"`. TCP probes dial the local service; HTTP probes
+    /// `GET <path>` against it.
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// Probe interval in seconds (default 10).
+    #[serde(default = "default_interval")]
+    pub interval_secs: u32,
+    /// Per-probe timeout in seconds (default 3).
+    #[serde(default = "default_timeout")]
+    pub timeout_secs: u32,
+    /// Consecutive failures before reporting `TunnelUnhealthy` (default 3).
+    #[serde(default = "default_max_failed")]
+    pub max_failed: u32,
+    /// HTTP probe path (required when `kind = "http"`).
+    pub path: Option<String>,
+    /// Whether HTTP probes accept only 2xx (default `true`).
+    #[serde(default = "default_expect_2xx")]
+    pub expect_2xx: bool,
+}
+
+fn default_interval() -> u32 {
+    10
+}
+fn default_timeout() -> u32 {
+    3
+}
+fn default_max_failed() -> u32 {
+    3
+}
+fn default_expect_2xx() -> bool {
+    true
 }
 
 fn default_local_host() -> String {
@@ -79,6 +132,9 @@ impl TunnelDef {
             p2p_target: None,
             p2p_secret: None,
             registered_tunnel_id: None,
+            group: None,
+            group_key: None,
+            health_check: None,
         }
     }
 
@@ -96,6 +152,9 @@ impl TunnelDef {
             p2p_target: None,
             p2p_secret: Some(secret),
             registered_tunnel_id: None,
+            group: None,
+            group_key: None,
+            health_check: None,
         }
     }
 
@@ -113,6 +172,9 @@ impl TunnelDef {
             p2p_target: Some(target),
             p2p_secret: Some(secret),
             registered_tunnel_id: None,
+            group: None,
+            group_key: None,
+            health_check: None,
         }
     }
 }

--- a/crates/rustunnel-client/src/control.rs
+++ b/crates/rustunnel-client/src/control.rs
@@ -294,6 +294,21 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
         let protocol = proto_to_enum(&tunnel.proto)?;
         let local_addr = format!("{}:{}", tunnel.local_host, tunnel.local_port);
 
+        // Hash the user-supplied group_key (never transmit the raw value —
+        // matches the existing p2p_secret_hash convention).
+        let group_key_hash = tunnel.group_key.as_ref().map(|raw| {
+            use sha2::{Digest, Sha256};
+            hex::encode(Sha256::digest(raw.as_bytes()))
+        });
+
+        // Convert the user's HealthCheckConfig into the wire-level
+        // HealthCheckSpec. Done here so a malformed config (HTTP without a
+        // path, unknown kind) fails fast at registration time.
+        let health_check_wire = match &tunnel.health_check {
+            Some(cfg) => Some(health_check_to_wire(cfg)?),
+            None => None,
+        };
+
         send_frame(
             &mut ctrl_ws,
             &ControlFrame::RegisterTunnel {
@@ -303,10 +318,9 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
                 local_addr,
                 p2p_secret_hash: tunnel.p2p_secret_hash.clone(),
                 p2p_name: tunnel.p2p_name.clone(),
-                // Load-balancing fields are wired up in Phase 2/4 (TUNNEL-7).
-                group: None,
-                group_key_hash: None,
-                health_check: None,
+                group: tunnel.group.clone(),
+                group_key_hash,
+                health_check: health_check_wire,
             },
         )
         .await?;
@@ -448,7 +462,39 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
         .collect();
     display::print_startup_box(&display_tunnels);
 
-    // 6. Main event loop ——————————————————————————————————————————————————
+    // 6. Spawn health-probe tasks for tunnels with a health_check ─────────
+    //    Each probe task writes `TunnelHealthy` / `TunnelUnhealthy` frames
+    //    into `outbound_frame_tx`; main_loop drains that channel and writes
+    //    to the control WS. Probe tasks die when the channel closes.
+    let (outbound_frame_tx, outbound_frame_rx) =
+        mpsc::channel::<rustunnel_protocol::ControlFrame>(32);
+    for (tunnel, _url) in &registered {
+        let Some(cfg) = &tunnel.health_check else {
+            continue;
+        };
+        let Some(tunnel_id) = tunnel.registered_tunnel_id else {
+            continue;
+        };
+        let spec = match crate::health::ProbeSpec::from_config(cfg) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(%tunnel_id, "invalid health_check config: {e}; skipping probe");
+                continue;
+            }
+        };
+        let local_addr = format!("{}:{}", tunnel.local_host, tunnel.local_port);
+        let tx = outbound_frame_tx.clone();
+        info!(
+            %tunnel_id, ?spec.kind, interval_ms = spec.interval.as_millis() as u64,
+            "starting client-side health probe"
+        );
+        tokio::spawn(crate::health::run_probe_loop(
+            tunnel_id, local_addr, spec, tx,
+        ));
+    }
+    drop(outbound_frame_tx); // probe tasks own clones; main holder dropped so the channel closes when they exit
+
+    // 7. Main event loop ——————————————————————————————————————————————————
     main_loop(
         &mut ctrl_ws,
         stream_rx,
@@ -458,6 +504,7 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
         config.insecure,
         p2p_accept_rx,
         p2p_sub_info,
+        outbound_frame_rx,
     )
     .await
 }
@@ -474,6 +521,7 @@ async fn main_loop(
     insecure: bool,
     mut p2p_accept_rx: Option<mpsc::Receiver<tokio::net::TcpStream>>,
     p2p_sub_info: Option<(String, String, Vec<u8>)>, // (target_name, secret_hash, raw_secret)
+    mut outbound_frame_rx: mpsc::Receiver<ControlFrame>,
 ) -> Result<()> {
     let mut ping_interval = tokio::time::interval(PING_INTERVAL);
     ping_interval.tick().await; // skip the immediate first tick
@@ -538,6 +586,14 @@ async fn main_loop(
                 let ts = now_ms();
                 send_frame(ctrl_ws, &ControlFrame::Ping { timestamp: ts }).await?;
                 awaiting_pong = true;
+            }
+
+            // ── Outbound frame from a probe task ──────────────────────────
+            //    Health-probe tasks (TUNNEL-7 Phase 4) push TunnelHealthy /
+            //    TunnelUnhealthy frames here. The select arm serialises all
+            //    writes to the WS — probe tasks never touch ctrl_ws directly.
+            Some(frame) = outbound_frame_rx.recv() => {
+                send_frame(ctrl_ws, &frame).await?;
             }
 
             // ── Inbound yamux stream from background driver ───────────────
@@ -810,6 +866,37 @@ fn proto_to_enum(proto: &str) -> Result<TunnelProtocol> {
         "p2p" => Ok(TunnelProtocol::P2p),
         other => Err(Error::Config(format!("unknown protocol: {other}"))),
     }
+}
+
+/// Convert the user-facing `HealthCheckConfig` into the wire-level
+/// `HealthCheckSpec` carried by `RegisterTunnel`. Validates that
+/// `kind = "http"` includes a path. Used by the registration loop above.
+fn health_check_to_wire(
+    cfg: &crate::config::HealthCheckConfig,
+) -> Result<rustunnel_protocol::HealthCheckSpec> {
+    use rustunnel_protocol::{HealthCheckKind, HealthCheckSpec};
+    let kind = match cfg.kind.as_str() {
+        "tcp" => HealthCheckKind::Tcp,
+        "http" => HealthCheckKind::Http,
+        other => {
+            return Err(Error::Config(format!(
+                "unknown health_check kind '{other}' (expected 'tcp' or 'http')"
+            )));
+        }
+    };
+    if matches!(kind, HealthCheckKind::Http) && cfg.path.is_none() {
+        return Err(Error::Config(
+            "health_check kind='http' requires a path".into(),
+        ));
+    }
+    Ok(HealthCheckSpec {
+        kind,
+        interval_secs: cfg.interval_secs.max(1),
+        timeout_secs: cfg.timeout_secs.max(1),
+        max_failed: cfg.max_failed.max(1),
+        http_path: cfg.path.clone(),
+        http_expect_2xx: cfg.expect_2xx,
+    })
 }
 
 /// Find the local address string (`"host:port"`) for a registered tunnel

--- a/crates/rustunnel-client/src/health.rs
+++ b/crates/rustunnel-client/src/health.rs
@@ -1,0 +1,355 @@
+//! Client-side health probes (TUNNEL-7 Phase 4).
+//!
+//! For each tunnel registered with a `HealthCheckConfig`, the client spawns
+//! a background task that periodically probes the local service and reports
+//! state changes back to the server via the control channel:
+//!
+//!   - First probe success after a streak of failures (or the first probe
+//!     of a freshly-registered tunnel) → `TunnelHealthy`
+//!   - `max_failed` consecutive failures → `TunnelUnhealthy`
+//!
+//! TCP probe: open a connection, success = connect within `timeout_secs`.
+//! HTTP probe: `GET <path>`, success = response within `timeout_secs` and
+//! 2xx (when `expect_2xx`).
+//!
+//! The probe loop is deliberately small and self-contained: it owns no
+//! shared state, mutates nothing on the client side, and writes to the
+//! server via an `mpsc::Sender<ControlFrame>` that the main control loop
+//! drains. Probe tasks die naturally when the channel closes (i.e. when
+//! the session ends).
+
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+use tokio::sync::mpsc;
+use tokio::time::{self, timeout};
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+use rustunnel_protocol::ControlFrame;
+
+use crate::config::HealthCheckConfig;
+use crate::error::{Error, Result};
+
+/// What kind of probe to run.
+#[derive(Debug, Clone)]
+pub enum ProbeKind {
+    Tcp,
+    Http { path: String, expect_2xx: bool },
+}
+
+/// Resolved per-tunnel health-probe spec.
+///
+/// `HealthCheckConfig` is the user-facing TOML/YAML shape; this is the
+/// validated runtime shape. Conversion happens in `from_config`.
+#[derive(Debug, Clone)]
+pub struct ProbeSpec {
+    pub kind: ProbeKind,
+    pub interval: Duration,
+    pub timeout: Duration,
+    pub max_failed: u32,
+}
+
+impl ProbeSpec {
+    /// Build a runtime `ProbeSpec` from the user's `HealthCheckConfig`.
+    /// Returns an error for unknown kinds or for HTTP without a `path`.
+    pub fn from_config(cfg: &HealthCheckConfig) -> Result<Self> {
+        let kind = match cfg.kind.as_str() {
+            "tcp" => ProbeKind::Tcp,
+            "http" => {
+                let path = cfg.path.clone().ok_or_else(|| {
+                    Error::Config("health_check kind='http' requires a path".into())
+                })?;
+                ProbeKind::Http {
+                    path,
+                    expect_2xx: cfg.expect_2xx,
+                }
+            }
+            other => {
+                return Err(Error::Config(format!(
+                    "unknown health_check kind '{other}' (expected 'tcp' or 'http')"
+                )));
+            }
+        };
+        Ok(Self {
+            kind,
+            interval: Duration::from_secs(cfg.interval_secs.max(1) as u64),
+            timeout: Duration::from_secs(cfg.timeout_secs.max(1) as u64),
+            max_failed: cfg.max_failed.max(1),
+        })
+    }
+}
+
+/// Run one TCP probe against `addr`.
+pub async fn probe_tcp(addr: &str, probe_timeout: Duration) -> bool {
+    matches!(
+        timeout(probe_timeout, TcpStream::connect(addr)).await,
+        Ok(Ok(_))
+    )
+}
+
+/// Run one HTTP probe: `GET <path>` over plain HTTP/1.0 against `addr`.
+///
+/// We hand-roll a minimal request rather than pulling reqwest into the
+/// probe path — this makes the probe latency-insensitive to TLS, redirects,
+/// or connection pooling. `expect_2xx` controls whether 3xx/4xx/5xx counts
+/// as a failure.
+pub async fn probe_http(addr: &str, path: &str, probe_timeout: Duration, expect_2xx: bool) -> bool {
+    let request = format!(
+        "GET {} HTTP/1.0\r\nHost: {}\r\nConnection: close\r\nUser-Agent: rustunnel-healthcheck\r\n\r\n",
+        path, addr
+    );
+    let result = async {
+        let mut stream = TcpStream::connect(addr).await.ok()?;
+        stream.write_all(request.as_bytes()).await.ok()?;
+        // We only need the first ~16 bytes — `HTTP/1.X NNN ...`.
+        let mut buf = [0u8; 32];
+        let mut total = 0;
+        while total < buf.len() {
+            let n = match tokio::io::AsyncReadExt::read(&mut stream, &mut buf[total..]).await {
+                Ok(0) | Err(_) => break,
+                Ok(n) => n,
+            };
+            total += n;
+            if buf[..total].contains(&b'\n') {
+                break;
+            }
+        }
+        let line = std::str::from_utf8(&buf[..total]).ok()?;
+        // "HTTP/1.x SSS ..." — pluck the status code.
+        let mut parts = line.split_ascii_whitespace();
+        let _version = parts.next()?;
+        let status: u16 = parts.next()?.parse().ok()?;
+        Some(if expect_2xx {
+            (200..300).contains(&status)
+        } else {
+            status >= 100
+        })
+    };
+    matches!(timeout(probe_timeout, result).await, Ok(Some(true)))
+}
+
+/// Run the per-tunnel probe loop forever (until the channel closes).
+///
+/// `local_addr` is what the client is forwarding to (e.g. `127.0.0.1:3000`).
+/// `frame_tx` is an `mpsc::Sender<ControlFrame>` that the main control loop
+/// drains and writes to the WebSocket; we send `TunnelHealthy` /
+/// `TunnelUnhealthy` through it.
+///
+/// The very first probe success emits a `TunnelHealthy` so the server can
+/// flip the bit on a freshly-registered member with `health_check` set
+/// (which starts unhealthy by design, plan §4.5).
+pub async fn run_probe_loop(
+    tunnel_id: Uuid,
+    local_addr: String,
+    spec: ProbeSpec,
+    frame_tx: mpsc::Sender<ControlFrame>,
+) {
+    let mut consecutive_failures: u32 = 0;
+    // `was_healthy` starts None so the first probe — pass or fail — emits a
+    // frame. After that, we only emit on edges (healthy → unhealthy or
+    // unhealthy → healthy).
+    let mut was_healthy: Option<bool> = None;
+    let mut ticker = time::interval(spec.interval);
+    // First tick fires immediately so we don't wait an interval before
+    // sending the first health report.
+    loop {
+        ticker.tick().await;
+        let healthy = match &spec.kind {
+            ProbeKind::Tcp => probe_tcp(&local_addr, spec.timeout).await,
+            ProbeKind::Http { path, expect_2xx } => {
+                probe_http(&local_addr, path, spec.timeout, *expect_2xx).await
+            }
+        };
+
+        let edge = match (was_healthy, healthy) {
+            (None, true) => Some(true),
+            (None, false) => {
+                // First probe is a failure — track consecutive count, only
+                // emit Unhealthy once we cross max_failed. (Don't emit
+                // Healthy: the server has the member as unhealthy already,
+                // we just don't disagree yet.)
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                if consecutive_failures >= spec.max_failed {
+                    Some(false)
+                } else {
+                    None
+                }
+            }
+            (Some(true), true) => {
+                consecutive_failures = 0;
+                None
+            }
+            (Some(true), false) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                if consecutive_failures >= spec.max_failed {
+                    Some(false)
+                } else {
+                    None
+                }
+            }
+            (Some(false), true) => {
+                consecutive_failures = 0;
+                Some(true)
+            }
+            (Some(false), false) => {
+                consecutive_failures = consecutive_failures.saturating_add(1);
+                None
+            }
+        };
+
+        if let Some(now_healthy) = edge {
+            let frame = if now_healthy {
+                ControlFrame::TunnelHealthy { tunnel_id }
+            } else {
+                ControlFrame::TunnelUnhealthy {
+                    tunnel_id,
+                    reason: format!("{} consecutive probe failures", consecutive_failures),
+                }
+            };
+            if frame_tx.send(frame).await.is_err() {
+                debug!(%tunnel_id, "control channel closed — probe loop exiting");
+                return;
+            }
+            was_healthy = Some(now_healthy);
+            if !now_healthy {
+                warn!(
+                    %tunnel_id, %local_addr,
+                    "health probe reported unhealthy after {consecutive_failures} consecutive failures"
+                );
+            }
+        } else if was_healthy.is_none() {
+            // We probed but didn't cross any edge — first probe was a
+            // failure under max_failed. Don't update was_healthy yet so the
+            // next probe still treats this as the "first run" path.
+        } else {
+            // Steady state — same as before. Nothing to send.
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// `probe_tcp` succeeds against a listening socket and fails against
+    /// a closed port.
+    #[tokio::test]
+    async fn tcp_probe_basics() {
+        // Spawn a dummy listener; the probe should connect.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            // Accept exactly one connection then drop the listener.
+            let _ = listener.accept().await;
+        });
+        assert!(probe_tcp(&addr, Duration::from_millis(500)).await);
+
+        // Closed port — should fail. Bind a fresh socket then drop it
+        // immediately so the OS frees the port; the probe will see
+        // refused/timeout depending on platform.
+        let l2 = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let dead_addr = l2.local_addr().unwrap().to_string();
+        drop(l2);
+        // Tiny delay so the kernel releases the listener cleanly.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!probe_tcp(&dead_addr, Duration::from_millis(500)).await);
+    }
+
+    /// `probe_http` recognises 2xx as healthy and 5xx as unhealthy
+    /// (when `expect_2xx = true`). We hand-roll a minimal HTTP responder
+    /// rather than pull axum into the client crate just for tests — the
+    /// probe is HTTP/1.0 close-on-finish, so a one-shot TCP responder is
+    /// the matching shape.
+    #[tokio::test]
+    async fn http_probe_distinguishes_2xx_and_5xx() {
+        async fn responder_with_status(status_line: &'static str) -> String {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap().to_string();
+            tokio::spawn(async move {
+                loop {
+                    let Ok((mut s, _)) = listener.accept().await else {
+                        break;
+                    };
+                    let body = format!(
+                        "HTTP/1.0 {}\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                        status_line
+                    );
+                    let _ = s.write_all(body.as_bytes()).await;
+                    let _ = s.shutdown().await;
+                }
+            });
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            addr
+        }
+
+        let timeout_dur = Duration::from_millis(500);
+        let addr_200 = responder_with_status("200 OK").await;
+        let addr_500 = responder_with_status("500 Internal Server Error").await;
+
+        // 200 → healthy regardless of expect_2xx.
+        assert!(probe_http(&addr_200, "/", timeout_dur, true).await);
+        assert!(probe_http(&addr_200, "/", timeout_dur, false).await);
+        // 500 → unhealthy when expect_2xx; healthy when we don't require 2xx.
+        assert!(!probe_http(&addr_500, "/", timeout_dur, true).await);
+        assert!(probe_http(&addr_500, "/", timeout_dur, false).await);
+    }
+
+    /// The probe loop emits `TunnelHealthy` on the first success and
+    /// `TunnelUnhealthy` after `max_failed` consecutive failures.
+    #[tokio::test]
+    async fn probe_loop_emits_on_state_edges() {
+        // Start with a listener that accepts probes — first probe healthy.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        let listener_arc = std::sync::Arc::new(tokio::sync::Mutex::new(Some(listener)));
+        let listener_clone = std::sync::Arc::clone(&listener_arc);
+        tokio::spawn(async move {
+            loop {
+                let g = listener_clone.lock().await;
+                if let Some(l) = g.as_ref() {
+                    let _ = l.accept().await;
+                } else {
+                    break;
+                }
+            }
+        });
+
+        let spec = ProbeSpec {
+            kind: ProbeKind::Tcp,
+            interval: Duration::from_millis(50),
+            timeout: Duration::from_millis(100),
+            max_failed: 2,
+        };
+        let (tx, mut rx) = mpsc::channel::<ControlFrame>(8);
+        let tunnel_id = Uuid::new_v4();
+        let probe_handle = tokio::spawn(run_probe_loop(tunnel_id, addr.clone(), spec, tx));
+
+        // First emitted frame should be TunnelHealthy.
+        let first = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .expect("first frame within 2s")
+            .expect("first frame present");
+        assert!(matches!(first, ControlFrame::TunnelHealthy { tunnel_id: t } if t == tunnel_id));
+
+        // Now break the listener so the probe starts failing.
+        {
+            let mut g = listener_arc.lock().await;
+            *g = None;
+        }
+
+        // After max_failed=2 consecutive failures we should see Unhealthy.
+        let unhealthy = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+            .await
+            .expect("unhealthy frame within 3s")
+            .expect("frame present");
+        assert!(matches!(
+            unhealthy,
+            ControlFrame::TunnelUnhealthy { tunnel_id: t, .. } if t == tunnel_id
+        ));
+
+        probe_handle.abort();
+    }
+}

--- a/crates/rustunnel-client/src/main.rs
+++ b/crates/rustunnel-client/src/main.rs
@@ -10,6 +10,7 @@ mod config;
 mod control;
 mod display;
 mod error;
+mod health;
 mod p2p_direct;
 mod proxy;
 mod reconnect;

--- a/crates/rustunnel-server/src/control/session.rs
+++ b/crates/rustunnel-server/src/control/session.rs
@@ -1141,18 +1141,57 @@ where
             // not used for billing (direct P2P traffic can't be verified).
         }
 
-        // Phase 0 of TUNNEL-7: accept the new health-report frames so newer
-        // clients connecting to this server don't trip a `decode_frame`
-        // warning. Behaviour wires up in Phase 4 (group dispatch + healthy
-        // bit). Until then the only effect is a debug-level log line.
-        ControlFrame::TunnelHealthy { tunnel_id } => {
-            tracing::debug!(%session_id, %tunnel_id, "tunnel reported healthy (no-op pre-Phase-4)");
-        }
+        // TUNNEL-7 Phase 4: health-bit toggle from the client. Each tunnel's
+        // owning session may flip the bit for its own tunnels only; a frame
+        // referencing someone else's tunnel_id is silently dropped (logged
+        // at warn so an attempted abuse leaves a trail).
+        ControlFrame::TunnelHealthy { tunnel_id } => match core.tunnel_session(&tunnel_id) {
+            Some(owner) if owner == session_id => {
+                if core.set_tunnel_healthy(&tunnel_id) {
+                    tracing::debug!(%session_id, %tunnel_id, "tunnel marked healthy");
+                } else {
+                    tracing::debug!(
+                        %session_id, %tunnel_id,
+                        "TunnelHealthy: tunnel found by session but member missing — race"
+                    );
+                }
+            }
+            Some(other_owner) => {
+                tracing::warn!(
+                    %session_id, %tunnel_id, %other_owner,
+                    "TunnelHealthy from non-owning session — ignored"
+                );
+            }
+            None => {
+                tracing::debug!(
+                    %session_id, %tunnel_id,
+                    "TunnelHealthy for unknown tunnel — ignored"
+                );
+            }
+        },
         ControlFrame::TunnelUnhealthy { tunnel_id, reason } => {
-            tracing::debug!(
-                %session_id, %tunnel_id, %reason,
-                "tunnel reported unhealthy (no-op pre-Phase-4)"
-            );
+            match core.tunnel_session(&tunnel_id) {
+                Some(owner) if owner == session_id => {
+                    if core.set_tunnel_unhealthy(&tunnel_id, &reason) {
+                        tracing::debug!(
+                            %session_id, %tunnel_id, %reason,
+                            "tunnel marked unhealthy"
+                        );
+                    }
+                }
+                Some(other_owner) => {
+                    tracing::warn!(
+                        %session_id, %tunnel_id, %other_owner,
+                        "TunnelUnhealthy from non-owning session — ignored"
+                    );
+                }
+                None => {
+                    tracing::debug!(
+                        %session_id, %tunnel_id,
+                        "TunnelUnhealthy for unknown tunnel — ignored"
+                    );
+                }
+            }
         }
 
         other => {

--- a/crates/rustunnel-server/src/core/router.rs
+++ b/crates/rustunnel-server/src/core/router.rs
@@ -726,6 +726,74 @@ impl TunnelCore {
         }
     }
 
+    // ── health-check bit (TUNNEL-7 Phase 4) ───────────────────────────────────
+
+    /// Mark `tunnel_id` healthy and reset its consecutive-failure counter.
+    /// Called from the session frame handler when a `TunnelHealthy` arrives.
+    /// Returns `true` if the tunnel was found and updated, `false` otherwise.
+    /// The caller is expected to gate this on session ownership — see the
+    /// auth check in `control/session.rs`.
+    pub fn set_tunnel_healthy(&self, tunnel_id: &Uuid) -> bool {
+        self.with_member(tunnel_id, |member| {
+            member.healthy.store(true, Ordering::Release);
+            member.consecutive_failures.store(0, Ordering::Release);
+        })
+    }
+
+    /// Mark `tunnel_id` unhealthy and bump its consecutive-failure counter.
+    /// `reason` is a free-form string from the client used for dashboards.
+    /// Returns `true` if the tunnel was found and updated.
+    pub fn set_tunnel_unhealthy(&self, tunnel_id: &Uuid, reason: &str) -> bool {
+        self.with_member(tunnel_id, |member| {
+            member.healthy.store(false, Ordering::Release);
+            member.consecutive_failures.fetch_add(1, Ordering::Release);
+            tracing::debug!(%tunnel_id, %reason, "tunnel marked unhealthy");
+        })
+    }
+
+    /// Resolve `tunnel_id` to its `GroupMember` (across http/tcp/udp routes)
+    /// and run `f` on it. Returns `true` if the tunnel + member were found.
+    fn with_member<F>(&self, tunnel_id: &Uuid, f: F) -> bool
+    where
+        F: FnOnce(&GroupMember),
+    {
+        let key = match self.tunnel_index.get(tunnel_id).as_deref().cloned() {
+            Some(k) => k,
+            None => return false,
+        };
+        let group = match key {
+            TunnelKey::Http(sub) => self.http_routes.get(&sub).map(|g| Arc::clone(&g)),
+            TunnelKey::Tcp(port) => self.tcp_routes.get(&port).map(|g| Arc::clone(&g)),
+            TunnelKey::Udp(port) => self.udp_routes.get(&port).map(|g| Arc::clone(&g)),
+            TunnelKey::P2p(_) => None, // health checks not supported for P2P
+        };
+        let Some(group) = group else { return false };
+        let Some(member) = group.members.get(tunnel_id) else {
+            return false;
+        };
+        f(&member);
+        true
+    }
+
+    /// Look up the session that owns `tunnel_id`. Used by the frame handler
+    /// to authorise health-bit toggles — only the owning session may flip
+    /// the flag for its own tunnels.
+    pub fn tunnel_session(&self, tunnel_id: &Uuid) -> Option<Uuid> {
+        let key = self.tunnel_index.get(tunnel_id).as_deref().cloned()?;
+        let group = match key {
+            TunnelKey::Http(sub) => self.http_routes.get(&sub).map(|g| Arc::clone(&g))?,
+            TunnelKey::Tcp(port) => self.tcp_routes.get(&port).map(|g| Arc::clone(&g))?,
+            TunnelKey::Udp(port) => self.udp_routes.get(&port).map(|g| Arc::clone(&g))?,
+            TunnelKey::P2p(name) => {
+                return self
+                    .p2p_tunnels
+                    .get(&name)
+                    .map(|p| p.tunnel_info.session_id);
+            }
+        };
+        group.members.get(tunnel_id).map(|m| m.info.session_id)
+    }
+
     // ── resolution (hot path) ─────────────────────────────────────────────────
 
     /// Look up the tunnel and its session's control channel by subdomain.
@@ -1760,6 +1828,125 @@ mod tests {
             core.register_tcp_tunnel(&sid_b, Some(solo_group_spec("ssh", "hash-B"))),
             Err(Error::NoPortsAvailable)
         ));
+    }
+
+    // ── set_tunnel_healthy / set_tunnel_unhealthy (Phase 4) ──────────────
+
+    /// `set_tunnel_unhealthy` flips the bit; subsequent dispatch routes
+    /// around the unhealthy member. `set_tunnel_healthy` brings it back.
+    /// `consecutive_failures` resets to 0 on healthy, increments on
+    /// unhealthy.
+    #[test]
+    fn set_tunnel_health_toggles_bit_and_failures() {
+        let core = make_core();
+        let (sid, _rx) = dummy_session(&core);
+        let (tid, _) = core
+            .register_http_tunnel(&sid, Some("hcheck".into()), TunnelProtocol::Http, None)
+            .unwrap();
+
+        // Solo member starts healthy.
+        assert!(core.resolve_http("hcheck").is_some());
+
+        // Mark unhealthy → dispatch excludes it; failure counter bumps.
+        assert!(core.set_tunnel_unhealthy(&tid, "probe-1 failed"));
+        assert!(core.resolve_http("hcheck").is_none());
+        let group = core.http_routes.get("hcheck").unwrap();
+        let member = group.members.get(&tid).unwrap();
+        assert_eq!(member.consecutive_failures.load(Ordering::Acquire), 1);
+        drop(member);
+        drop(group);
+
+        // Another unhealthy → counter to 2.
+        core.set_tunnel_unhealthy(&tid, "probe-2 failed");
+        let group = core.http_routes.get("hcheck").unwrap();
+        let member = group.members.get(&tid).unwrap();
+        assert_eq!(member.consecutive_failures.load(Ordering::Acquire), 2);
+        drop(member);
+        drop(group);
+
+        // Healthy resets counter to 0 + restores dispatch.
+        assert!(core.set_tunnel_healthy(&tid));
+        let group = core.http_routes.get("hcheck").unwrap();
+        let member = group.members.get(&tid).unwrap();
+        assert_eq!(member.consecutive_failures.load(Ordering::Acquire), 0);
+        drop(member);
+        drop(group);
+        assert!(core.resolve_http("hcheck").is_some());
+    }
+
+    /// `set_tunnel_healthy` / `set_tunnel_unhealthy` return `false` for
+    /// unknown tunnel IDs — the frame handler relies on this for the
+    /// "unknown tunnel" path.
+    #[test]
+    fn set_tunnel_health_returns_false_for_unknown() {
+        let core = make_core();
+        let ghost = Uuid::new_v4();
+        assert!(!core.set_tunnel_healthy(&ghost));
+        assert!(!core.set_tunnel_unhealthy(&ghost, "doesn't matter"));
+    }
+
+    /// `tunnel_session` resolves the owning session for HTTP, TCP, and UDP
+    /// tunnels. The frame handler uses this to gate health-bit toggles to
+    /// the owning session only.
+    #[test]
+    fn tunnel_session_resolves_owner_across_protocols() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        let (tid_http, _) = core
+            .register_http_tunnel(&sid_a, Some("owner".into()), TunnelProtocol::Http, None)
+            .unwrap();
+        let (tid_tcp, _) = core.register_tcp_tunnel(&sid_b, None).unwrap();
+
+        assert_eq!(core.tunnel_session(&tid_http), Some(sid_a));
+        assert_eq!(core.tunnel_session(&tid_tcp), Some(sid_b));
+        assert_eq!(core.tunnel_session(&Uuid::new_v4()), None);
+    }
+
+    /// In a multi-member HTTP group, marking one member unhealthy must
+    /// route all subsequent connections to the other. This is the
+    /// load-balancing-with-health invariant — Phase 4's whole point.
+    #[test]
+    fn unhealthy_member_in_group_routes_around() {
+        let core = make_core();
+        let (sid_a, _rx_a) = dummy_session(&core);
+        let (sid_b, _rx_b) = dummy_session(&core);
+
+        let (tid_a, _) = core
+            .register_http_tunnel(
+                &sid_a,
+                Some("pool".into()),
+                TunnelProtocol::Http,
+                Some(solo_group_spec("web", "hash-A")),
+            )
+            .unwrap();
+        let (tid_b, _) = core
+            .register_http_tunnel(
+                &sid_b,
+                Some("pool".into()),
+                TunnelProtocol::Http,
+                Some(solo_group_spec("web", "hash-A")),
+            )
+            .unwrap();
+
+        // Mark A unhealthy. All N dispatches must land on B.
+        core.set_tunnel_unhealthy(&tid_a, "probe failed");
+        for _ in 0..50 {
+            assert!(core.resolve_http("pool").is_some());
+        }
+        assert_eq!(core.get_tunnel_request_count(&tid_a), 0);
+        assert_eq!(core.get_tunnel_request_count(&tid_b), 50);
+
+        // Bring A back. Now dispatch distributes again.
+        core.set_tunnel_healthy(&tid_a);
+        for _ in 0..200 {
+            core.resolve_http("pool");
+        }
+        // Both should have grown — A from 0, B beyond 50. Loose bounds
+        // for flake-resistance; the point is "A serves requests again".
+        assert!(core.get_tunnel_request_count(&tid_a) > 30);
+        assert!(core.get_tunnel_request_count(&tid_b) > 80);
     }
 
     /// A member registered with a `health_check` starts unhealthy and is

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -62,3 +62,7 @@ path = "integration/http_groups.rs"
 [[test]]
 name = "tcp_groups"
 path = "integration/tcp_groups.rs"
+
+[[test]]
+name = "health_checks"
+path = "integration/health_checks.rs"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -564,6 +564,27 @@ impl TestClient {
 
     // ── tunnel registration ───────────────────────────────────────────────────
 
+    /// Send `TunnelHealthy { tunnel_id }` over the control WS.
+    /// Phase 4 server-side handler accepts this only from the owning
+    /// session — that's why this lives on `TestClient` rather than as a
+    /// free function.
+    pub async fn send_tunnel_healthy(&mut self, tunnel_id: Uuid) -> Result<(), String> {
+        self.send(&ControlFrame::TunnelHealthy { tunnel_id }).await
+    }
+
+    /// Send `TunnelUnhealthy { tunnel_id, reason }` over the control WS.
+    pub async fn send_tunnel_unhealthy(
+        &mut self,
+        tunnel_id: Uuid,
+        reason: &str,
+    ) -> Result<(), String> {
+        self.send(&ControlFrame::TunnelUnhealthy {
+            tunnel_id,
+            reason: reason.to_string(),
+        })
+        .await
+    }
+
     /// Register an HTTP tunnel as part of a load-balancing group.
     /// Phase 2 of TUNNEL-7. The server only honours the group fields when
     /// `[load_balancing] enabled = true`. Returns `(tunnel_id, subdomain, public_url)`.

--- a/tests/integration/health_checks.rs
+++ b/tests/integration/health_checks.rs
@@ -1,0 +1,239 @@
+//! Health-check integration tests (TUNNEL-7 Phase 4).
+//!
+//! # What these tests pin down
+//!
+//! 1. **`TunnelUnhealthy` excludes a member from dispatch.** Two clients
+//!    register the same HTTP group; we send `TunnelUnhealthy` for one of
+//!    them and assert that subsequent connections all land on the survivor.
+//!    Then send `TunnelHealthy` and assert traffic resumes to both. This is
+//!    the failover invariant — Phase 4's whole point.
+//!
+//! 2. **`TunnelUnhealthy` from a non-owning session is ignored.** A second
+//!    client tries to mark the *first* client's tunnel unhealthy. The
+//!    server logs a warning and drops the frame; dispatch still hits the
+//!    targeted tunnel. This is the auth boundary — without it any client
+//!    on a shared edge could DoS another's pool members.
+
+#[path = "../common/mod.rs"]
+mod common;
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::{routing::get, Router};
+use common::*;
+use tokio::sync::oneshot;
+
+/// Hello-world server tagged with `who` — same shape as the http_groups suite.
+async fn start_tagged_server(
+    who: &'static str,
+) -> (SocketAddr, Arc<AtomicU64>, oneshot::Sender<()>) {
+    let counter: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
+    let counter_clone = Arc::clone(&counter);
+
+    let app = Router::new().route(
+        "/",
+        get(move || {
+            let counter = Arc::clone(&counter_clone);
+            async move {
+                counter.fetch_add(1, Ordering::Relaxed);
+                axum::http::Response::builder()
+                    .header("X-Backend", who)
+                    .body(format!("hello from {who}"))
+                    .unwrap()
+            }
+        }),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind tagged server");
+    let addr = listener.local_addr().unwrap();
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .ok();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    (addr, counter, shutdown_tx)
+}
+
+// ── 1. Health bit toggles excluded/included from dispatch ──────────────────────
+
+#[tokio::test]
+async fn unhealthy_member_is_excluded_then_restored_on_healthy() {
+    init_tracing();
+
+    let (addr_a, count_a, _hold_a) = start_tagged_server("A").await;
+    let (addr_b, count_b, _hold_b) = start_tagged_server("B").await;
+
+    let server = TestServer::start_with_load_balancing().await;
+
+    let mut client_a = TestClient::connect(&server).await.expect("auth A");
+    let mut client_b = TestClient::connect(&server).await.expect("auth B");
+    let session_a = client_a.session_id.unwrap();
+    let session_b = client_b.session_id.unwrap();
+
+    let group = "web";
+    let key = "deadbeef".repeat(8);
+
+    let (tid_a, _, _) = client_a
+        .register_http_tunnel_grouped(Some("hpool"), group, &key)
+        .await
+        .expect("client A grouped");
+    let (_tid_b, _, _) = client_b
+        .register_http_tunnel_grouped(Some("hpool"), group, &key)
+        .await
+        .expect("client B grouped");
+
+    connect_data_bridge(&server, session_a, addr_a)
+        .await
+        .expect("bridge A");
+    connect_data_bridge(&server, session_b, addr_b)
+        .await
+        .expect("bridge B");
+
+    let https_url = format!("https://127.0.0.1:{}/", server.https_port);
+    let host = format!("hpool.{}", server.domain);
+    let http = insecure_http_client();
+
+    // ── Phase 1: A unhealthy → all traffic lands on B ───────────────────
+    client_a
+        .send_tunnel_unhealthy(tid_a, "synthetic probe failure")
+        .await
+        .expect("send TunnelUnhealthy");
+
+    // Brief delay so the frame is processed before we issue requests.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    const N1: u64 = 50;
+    let baseline_a = count_a.load(Ordering::Relaxed);
+    let baseline_b = count_b.load(Ordering::Relaxed);
+    for _ in 0..N1 {
+        let resp = http
+            .get(&https_url)
+            .header("Host", &host)
+            .send()
+            .await
+            .expect("HTTPS while A unhealthy");
+        assert_eq!(resp.status(), 200);
+    }
+    let delta_a = count_a.load(Ordering::Relaxed) - baseline_a;
+    let delta_b = count_b.load(Ordering::Relaxed) - baseline_b;
+    assert_eq!(
+        delta_a, 0,
+        "A is unhealthy — dispatch must not route to it; got {delta_a} hits"
+    );
+    assert_eq!(delta_b, N1, "B must serve every request while A is out");
+
+    // ── Phase 2: A healthy again → dispatch distributes ────────────────
+    client_a
+        .send_tunnel_healthy(tid_a)
+        .await
+        .expect("send TunnelHealthy");
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    const N2: u64 = 200;
+    let baseline_a = count_a.load(Ordering::Relaxed);
+    let baseline_b = count_b.load(Ordering::Relaxed);
+    for _ in 0..N2 {
+        let resp = http
+            .get(&https_url)
+            .header("Host", &host)
+            .send()
+            .await
+            .expect("HTTPS after A restored");
+        assert_eq!(resp.status(), 200);
+    }
+    let delta_a = count_a.load(Ordering::Relaxed) - baseline_a;
+    let delta_b = count_b.load(Ordering::Relaxed) - baseline_b;
+    assert_eq!(delta_a + delta_b, N2);
+    // Generous bounds: both must serve a non-trivial share.
+    assert!(
+        delta_a >= 30,
+        "A must serve again after TunnelHealthy; got delta_a={delta_a}, delta_b={delta_b}"
+    );
+    assert!(
+        delta_b >= 30,
+        "B must keep serving; got delta_a={delta_a}, delta_b={delta_b}"
+    );
+}
+
+// ── 2. Cross-session health frames are ignored ─────────────────────────────────
+
+#[tokio::test]
+async fn cross_session_tunnel_unhealthy_is_ignored() {
+    init_tracing();
+
+    let (addr_a, count_a, _hold_a) = start_tagged_server("A").await;
+    let (addr_b, count_b, _hold_b) = start_tagged_server("B").await;
+
+    let server = TestServer::start_with_load_balancing().await;
+
+    let mut client_a = TestClient::connect(&server).await.expect("auth A");
+    let mut client_b = TestClient::connect(&server).await.expect("auth B");
+    let session_a = client_a.session_id.unwrap();
+    let session_b = client_b.session_id.unwrap();
+
+    let group = "web";
+    let key = "deadbeef".repeat(8);
+
+    let (tid_a, _, _) = client_a
+        .register_http_tunnel_grouped(Some("xpool"), group, &key)
+        .await
+        .expect("client A grouped");
+    let (_tid_b, _, _) = client_b
+        .register_http_tunnel_grouped(Some("xpool"), group, &key)
+        .await
+        .expect("client B grouped");
+
+    connect_data_bridge(&server, session_a, addr_a)
+        .await
+        .expect("bridge A");
+    connect_data_bridge(&server, session_b, addr_b)
+        .await
+        .expect("bridge B");
+
+    // Client B tries to mark client A's tunnel unhealthy. The server
+    // should log a warning and drop the frame — A stays in the pool.
+    client_b
+        .send_tunnel_unhealthy(tid_a, "i am not the owner")
+        .await
+        .expect("send (server will ignore)");
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let https_url = format!("https://127.0.0.1:{}/", server.https_port);
+    let host = format!("xpool.{}", server.domain);
+    let http = insecure_http_client();
+
+    const N: u64 = 100;
+    for _ in 0..N {
+        let resp = http
+            .get(&https_url)
+            .header("Host", &host)
+            .send()
+            .await
+            .expect("HTTPS request");
+        assert_eq!(resp.status(), 200);
+    }
+
+    let hits_a = count_a.load(Ordering::Relaxed);
+    let hits_b = count_b.load(Ordering::Relaxed);
+    assert_eq!(hits_a + hits_b, N);
+    // Both should serve a non-trivial share — A wasn't actually marked
+    // unhealthy because the frame came from a non-owning session.
+    assert!(
+        hits_a >= 20,
+        "A must keep serving — cross-session unhealthy was ignored; got A={hits_a}, B={hits_b}"
+    );
+    assert!(
+        hits_b >= 20,
+        "B must serve normally; got A={hits_a}, B={hits_b}"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 4 of the FRP-style load balancing plan. Closes the loop between protocol fields wired in Phase 0 and the dispatch path wired in Phases 1–3:

- **Server side**: `TunnelHealthy` / `TunnelUnhealthy` frames now actually flip `member.healthy`. The dispatch path already routes around unhealthy members (Phase 1), so this PR makes that responsiveness real.
- **Client side**: per-tunnel TCP/HTTP probe loops that periodically check the local upstream and emit state-edge frames back to the server.

**Stacked on top of [#62](https://github.com/joaoh82/rustunnel/pull/62) (Phase 3 — TCP groups).** When #62 merges to `main`, I'll re-target this PR's base to `main` (or you can merge #62 first and the PR diff will collapse to just the Phase 4 changes).

## Server side

- `TunnelCore::set_tunnel_healthy(tunnel_id)` and `set_tunnel_unhealthy(tunnel_id, reason)` — flip the bit, manage `consecutive_failures`.
- `TunnelCore::tunnel_session(tunnel_id)` — resolves the owning session. The frame handler uses this to gate health-bit toggles to the owning session only — without it, any client on a shared edge could DoS another tenant's pool members by spamming `TunnelUnhealthy` with the right tunnel_id.
- Frame handler in `session.rs` rewritten from "debug-log no-op" (Phase 0) to do the real work, with the auth check above.

## Client side

- New `rustunnel-client/src/health.rs` module:
  - `probe_tcp(addr, timeout)` — connect-or-timeout TCP probe.
  - `probe_http(addr, path, timeout, expect_2xx)` — minimal hand-rolled HTTP/1.0 GET that pulls the status code from the first 32 bytes. **No reqwest** on the probe path.
  - `run_probe_loop(tunnel_id, local_addr, spec, frame_tx)` — periodic probe loop that emits frames only on state edges.
- `TunnelDef` gains `group` / `group_key` / `health_check` fields. The client now hashes `group_key` with SHA-256 (same convention as `p2p_secret_hash`) and forwards everything on every `RegisterTunnel`. The protocol fields wired in Phase 0 finally have a client-side source — drop `group: web`, `group_key: ...`, `health_check: { type: tcp }` into `~/.rustunnel/config.yml` and the feature works against an edge with `[load_balancing] enabled = true`.
- `main_loop`'s `tokio::select!` gains an outbound-frame arm: probe tasks push frames through an `mpsc::Sender`, the main loop drains them and writes to the control WS. Probe tasks die when the channel closes.

## Tests

- **Server lib: 60 → 64**. 4 new tests cover the bit-toggle, the unknown-tunnel return value, the cross-protocol `tunnel_session` resolution, and the failover invariant.
- **Client lib: 3 new tests** in `health::tests`:
  - `tcp_probe_basics`
  - `http_probe_distinguishes_2xx_and_5xx` (hand-rolled responder, no axum dep)
  - `probe_loop_emits_on_state_edges`
- **New integration suite** `tests/integration/health_checks.rs` (2 tests):
  - `unhealthy_member_is_excluded_then_restored_on_healthy` — full HTTPS edge → yamux → backend chain. Mark A unhealthy, hammer 50 requests, assert all land on B; mark A healthy, hammer 200, both serve ≥30.
  - `cross_session_tunnel_unhealthy_is_ignored` — auth boundary check.
- `TestClient::send_tunnel_healthy` / `send_tunnel_unhealthy` helpers added.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` (with PG): every suite green.

## Out of scope

- **Phase 5** — Prometheus group metrics, dashboard surfaces, marketing/docs updates.
- **Phase 6** — `AuthOk.server_version` gate so newer clients only emit health frames to ≥ v0.6 servers (a client built off this PR will still send health frames to a 0.5.x edge, which logs a `decode_frame` warning per Phase-0 doc).

## Test plan
- [x] cargo fmt + clippy clean
- [x] full workspace test suite green
- [ ] eyeball the auth check in `session.rs`
- [ ] eyeball the probe loop's state-edge logic — particularly the "first probe is a failure, don't emit Healthy, do emit Unhealthy after max_failed" path
- [ ] smoke test: drop `loadBalancer.group`, `loadBalancer.groupKey`, and `health_check.type = tcp` into `~/.rustunnel/config.yml` against a local edge with `[load_balancing] enabled = true` and verify the bit flips on backend kill/revive

🤖 Generated with [Claude Code](https://claude.com/claude-code)