### PR TITLE
feat(client): TUNNEL-8 Phase 6 — version-gate the load-balancing wire

### DIFF
--- a/crates/rustunnel-client/src/control.rs
+++ b/crates/rustunnel-client/src/control.rs
@@ -258,25 +258,39 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
     )
     .await?;
 
-    let session_id = match recv_frame_timeout(&mut ctrl_ws, AUTH_TIMEOUT).await? {
-        ControlFrame::AuthOk {
-            session_id,
-            server_version,
-        } => {
-            info!(%session_id, %server_version, "authenticated");
-            session_id
-        }
-        ControlFrame::AuthError { message } => {
-            sp.finish_and_clear();
-            return Err(Error::Auth(message));
-        }
-        other => {
-            sp.finish_and_clear();
-            return Err(Error::Connection(format!(
-                "unexpected frame during auth: {other:?}"
-            )));
-        }
-    };
+    let (session_id, server_supports_lb) =
+        match recv_frame_timeout(&mut ctrl_ws, AUTH_TIMEOUT).await? {
+            ControlFrame::AuthOk {
+                session_id,
+                server_version,
+            } => {
+                info!(%session_id, %server_version, "authenticated");
+                // TUNNEL-7 Phase 6: gate emission of the new wire fields and
+                // probe-loop spawning on server version. An older edge that
+                // doesn't recognise `TunnelHealthy` / `TunnelUnhealthy` would
+                // log a `decode_frame` warning per frame; we just refrain
+                // from sending them.
+                let supports_lb = crate::version::server_supports_load_balancing(&server_version);
+                if !supports_lb {
+                    debug!(
+                        %server_version,
+                        "server does not advertise TUNNEL-7 load-balancing support; \
+                         group fields and health probes will be suppressed for this session"
+                    );
+                }
+                (session_id, supports_lb)
+            }
+            ControlFrame::AuthError { message } => {
+                sp.finish_and_clear();
+                return Err(Error::Auth(message));
+            }
+            other => {
+                sp.finish_and_clear();
+                return Err(Error::Connection(format!(
+                    "unexpected frame during auth: {other:?}"
+                )));
+            }
+        };
 
     sp.set_message("Registering tunnels…");
 
@@ -294,20 +308,43 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
         let protocol = proto_to_enum(&tunnel.proto)?;
         let local_addr = format!("{}:{}", tunnel.local_host, tunnel.local_port);
 
-        // Hash the user-supplied group_key (never transmit the raw value —
-        // matches the existing p2p_secret_hash convention).
-        let group_key_hash = tunnel.group_key.as_ref().map(|raw| {
-            use sha2::{Digest, Sha256};
-            hex::encode(Sha256::digest(raw.as_bytes()))
-        });
-
-        // Convert the user's HealthCheckConfig into the wire-level
-        // HealthCheckSpec. Done here so a malformed config (HTTP without a
-        // path, unknown kind) fails fast at registration time.
-        let health_check_wire = match &tunnel.health_check {
-            Some(cfg) => Some(health_check_to_wire(cfg)?),
-            None => None,
-        };
+        // ── Version gate (TUNNEL-7 Phase 6) ───────────────────────────────
+        // Only emit the load-balancing fields when the edge advertises
+        // support. An older edge would just ignore them at the wire level
+        // (Option fields with #[serde(default)]) but we suppress them
+        // anyway to (a) keep logs clean and (b) make the user-visible
+        // behaviour symmetric: configured group + old edge → same as
+        // ungrouped + new edge. We warn loudly so the misconfig doesn't
+        // silently degrade.
+        let (effective_group, effective_group_key_hash, effective_health_check) =
+            if server_supports_lb {
+                let group_key_hash = tunnel.group_key.as_ref().map(|raw| {
+                    use sha2::{Digest, Sha256};
+                    hex::encode(Sha256::digest(raw.as_bytes()))
+                });
+                let health_check_wire = match &tunnel.health_check {
+                    Some(cfg) => Some(health_check_to_wire(cfg)?),
+                    None => None,
+                };
+                (tunnel.group.clone(), group_key_hash, health_check_wire)
+            } else {
+                if tunnel.group.is_some() || tunnel.group_key.is_some() {
+                    warn!(
+                        subdomain = ?tunnel.subdomain,
+                        group = ?tunnel.group,
+                        "server does not support load balancing — registering as a solo tunnel; \
+                         bump your edge to 0.7+ to enable group dispatch"
+                    );
+                }
+                if tunnel.health_check.is_some() {
+                    warn!(
+                        subdomain = ?tunnel.subdomain,
+                        "server does not support health probes — disabling client-side probe loop \
+                         for this tunnel; bump your edge to 0.7+ to enable failover routing"
+                    );
+                }
+                (None, None, None)
+            };
 
         send_frame(
             &mut ctrl_ws,
@@ -318,9 +355,9 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
                 local_addr,
                 p2p_secret_hash: tunnel.p2p_secret_hash.clone(),
                 p2p_name: tunnel.p2p_name.clone(),
-                group: tunnel.group.clone(),
-                group_key_hash,
-                health_check: health_check_wire,
+                group: effective_group,
+                group_key_hash: effective_group_key_hash,
+                health_check: effective_health_check,
             },
         )
         .await?;
@@ -466,31 +503,39 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
     //    Each probe task writes `TunnelHealthy` / `TunnelUnhealthy` frames
     //    into `outbound_frame_tx`; main_loop drains that channel and writes
     //    to the control WS. Probe tasks die when the channel closes.
+    //
+    //    Skipped entirely when the server doesn't advertise load-balancing
+    //    support (TUNNEL-7 Phase 6) — the probe's only output channel is
+    //    those frames, which an older edge would log as `decode_frame`
+    //    errors. We already warned at registration time above; the spawn
+    //    branch just no-ops.
     let (outbound_frame_tx, outbound_frame_rx) =
         mpsc::channel::<rustunnel_protocol::ControlFrame>(32);
-    for (tunnel, _url) in &registered {
-        let Some(cfg) = &tunnel.health_check else {
-            continue;
-        };
-        let Some(tunnel_id) = tunnel.registered_tunnel_id else {
-            continue;
-        };
-        let spec = match crate::health::ProbeSpec::from_config(cfg) {
-            Ok(s) => s,
-            Err(e) => {
-                warn!(%tunnel_id, "invalid health_check config: {e}; skipping probe");
+    if server_supports_lb {
+        for (tunnel, _url) in &registered {
+            let Some(cfg) = &tunnel.health_check else {
                 continue;
-            }
-        };
-        let local_addr = format!("{}:{}", tunnel.local_host, tunnel.local_port);
-        let tx = outbound_frame_tx.clone();
-        info!(
-            %tunnel_id, ?spec.kind, interval_ms = spec.interval.as_millis() as u64,
-            "starting client-side health probe"
-        );
-        tokio::spawn(crate::health::run_probe_loop(
-            tunnel_id, local_addr, spec, tx,
-        ));
+            };
+            let Some(tunnel_id) = tunnel.registered_tunnel_id else {
+                continue;
+            };
+            let spec = match crate::health::ProbeSpec::from_config(cfg) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(%tunnel_id, "invalid health_check config: {e}; skipping probe");
+                    continue;
+                }
+            };
+            let local_addr = format!("{}:{}", tunnel.local_host, tunnel.local_port);
+            let tx = outbound_frame_tx.clone();
+            info!(
+                %tunnel_id, ?spec.kind, interval_ms = spec.interval.as_millis() as u64,
+                "starting client-side health probe"
+            );
+            tokio::spawn(crate::health::run_probe_loop(
+                tunnel_id, local_addr, spec, tx,
+            ));
+        }
     }
     drop(outbound_frame_tx); // probe tasks own clones; main holder dropped so the channel closes when they exit
 

--- a/crates/rustunnel-client/src/main.rs
+++ b/crates/rustunnel-client/src/main.rs
@@ -16,6 +16,7 @@ mod proxy;
 mod reconnect;
 mod regions;
 mod stun;
+mod version;
 
 use std::path::PathBuf;
 

--- a/crates/rustunnel-client/src/version.rs
+++ b/crates/rustunnel-client/src/version.rs
@@ -1,0 +1,102 @@
+//! Server-version compatibility checks (TUNNEL-7 Phase 6).
+//!
+//! The server stamps its `Cargo.toml` version into every `AuthOk` frame.
+//! When the client connects to an *older* edge that doesn't understand the
+//! load-balancing additions (group fields on `RegisterTunnel`, the
+//! `TunnelHealthy` / `TunnelUnhealthy` frames), it must:
+//!
+//!   1. Skip emitting the new wire fields (avoids old server logging
+//!      `decode_frame` warnings every time we send a probe report).
+//!   2. Skip spawning client-side probe loops (their only output channel
+//!      is the new frames; spawning them would just consume FDs and CPU).
+//!   3. Warn the user once per affected tunnel so a misconfigured edge
+//!      doesn't silently degrade the feature without explanation.
+//!
+//! We avoid pulling `semver` into the client crate for one threshold —
+//! a hand-rolled `(u32, u32, u32)` parse is enough.
+
+/// Minimum server version required for full TUNNEL-7 / TUNNEL-8 support.
+///
+/// Phase 0 + 1 shipped in 0.6.0 (just the wire format additions). Phase 4
+/// in 0.7.0 brought server-side handling of `TunnelHealthy` /
+/// `TunnelUnhealthy`, so 0.7.0 is the floor where emitting those frames
+/// is safe (= no `decode_frame` warning on the edge).
+pub const MIN_SERVER_VERSION_FOR_LOAD_BALANCING: (u32, u32, u32) = (0, 7, 0);
+
+/// Parse a `"X.Y.Z"` string into `(major, minor, patch)`. Returns `None`
+/// for anything that doesn't fit that exact shape — a malformed
+/// `server_version` is treated as "unknown / assume old" by callers.
+///
+/// Pre-release (`-rc1`) and build (`+build.5`) suffixes are stripped from
+/// the patch component. We don't honour pre-release ordering — `0.7.0-rc1`
+/// parses as `(0, 7, 0)` for our coarse-grained "is this server new
+/// enough?" check.
+pub fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
+    // Strip everything after a `-` or `+` once (keeps the major.minor.patch
+    // numeric core only).
+    let core = s.split(['-', '+']).next()?;
+    let mut parts = core.split('.');
+    let major: u32 = parts.next()?.parse().ok()?;
+    let minor: u32 = parts.next()?.parse().ok()?;
+    let patch: u32 = parts.next()?.parse().ok()?;
+    // Reject extra dot-components in the numeric core (e.g. "0.7.0.0").
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+/// Returns `true` if the server's reported version is `>= MIN_SERVER_VERSION_FOR_LOAD_BALANCING`.
+/// Returns `false` for unparseable versions — safer to assume the worst.
+pub fn server_supports_load_balancing(server_version: &str) -> bool {
+    match parse_semver(server_version) {
+        Some(v) => v >= MIN_SERVER_VERSION_FOR_LOAD_BALANCING,
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_normal_semver() {
+        assert_eq!(parse_semver("0.7.0"), Some((0, 7, 0)));
+        assert_eq!(parse_semver("1.0.0"), Some((1, 0, 0)));
+        assert_eq!(parse_semver("12.34.56"), Some((12, 34, 56)));
+    }
+
+    #[test]
+    fn parses_pre_release_as_patch_number() {
+        // We don't honour pre-release ordering, but we shouldn't fail to
+        // parse either — pre-release builds should still report a version.
+        assert_eq!(parse_semver("0.7.0-rc1"), Some((0, 7, 0)));
+        assert_eq!(parse_semver("0.7.0+build.5"), Some((0, 7, 0)));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert_eq!(parse_semver(""), None);
+        assert_eq!(parse_semver("0.7"), None);
+        assert_eq!(parse_semver("0.7.0.0"), None);
+        assert_eq!(parse_semver("not.a.version"), None);
+        assert_eq!(parse_semver("v0.7.0"), None);
+    }
+
+    #[test]
+    fn supports_lb_flag_for_each_threshold() {
+        // Below 0.7.0 — too old.
+        assert!(!server_supports_load_balancing("0.5.0"));
+        assert!(!server_supports_load_balancing("0.5.1"));
+        assert!(!server_supports_load_balancing("0.6.0"));
+        assert!(!server_supports_load_balancing("0.6.99"));
+        // Exactly the threshold and above.
+        assert!(server_supports_load_balancing("0.7.0"));
+        assert!(server_supports_load_balancing("0.7.5"));
+        assert!(server_supports_load_balancing("0.8.0"));
+        assert!(server_supports_load_balancing("1.0.0"));
+        // Unparseable → assume too old.
+        assert!(!server_supports_load_balancing(""));
+        assert!(!server_supports_load_balancing("garbage"));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 6 of the FRP-style load balancing plan. Closes the foot-gun called out in Phase 4's PR description: a v0.7.0 client connecting to an older edge during a rollout window would emit `TunnelHealthy` / `TunnelUnhealthy` frames the older edge can't decode, spamming `decode_frame` warning lines.

This PR makes the client read `AuthOk.server_version`, parse it, and suppress the new wire emissions when the server is < 0.7.0. Old-server scenarios downgrade cleanly to solo registration with a single client-side warning per misconfigured tunnel.

## What changed

- **New crate-internal module** [`crates/rustunnel-client/src/version.rs`](https://github.com/joaoh82/rustunnel/blob/tunnel-8-phase-6-version-gate/crates/rustunnel-client/src/version.rs):
  - `parse_semver(&str) -> Option<(u32, u32, u32)>` — accepts pre-release (`-rc1`) and build (`+build.5`) suffixes by stripping them. Coarse-grained for our "is this server new enough" check; we don't honour pre-release ordering.
  - `MIN_SERVER_VERSION_FOR_LOAD_BALANCING = (0, 7, 0)` — Phase 4 brought server-side handling, so 0.7.0 is the floor where emitting the new frames is safe.
  - `server_supports_load_balancing(&str) -> bool` — unparseable versions count as too-old (defensive).
- **`control.rs`** computes a `server_supports_lb` flag right after the `AuthOk` handshake and threads it through:
  - **Registration loop**: if the server doesn't support LB, `group` / `group_key_hash` / `health_check` are forced to `None` on the wire. Warns once per affected tunnel with a clear remediation ("bump your edge to 0.7+").
  - **Probe-spawn loop**: skipped entirely when the server doesn't support LB. The probe's only output channel is the new frames; running it would consume FDs + CPU for no observable effect.

## Tests

- 4 new unit tests in `version::tests`: normal semver, pre-release suffix handling, garbage rejection, and the LB-support threshold matrix.
- All existing integration tests (`health_checks`, `http_groups`, `tcp_groups`, plus all pre-existing suites) still green — they run against a current server that advertises 0.7.0, so the gate evaluates to `true` and the happy path is unchanged. If I'd inverted the gate logic, those suites would have failed (grouped registration wouldn't work, health-frame failover would never trigger).
- Server lib: 64 tests green. Workspace fmt/clippy clean.

## Why no integration test for the "old-server" path?

The integration harness's `TestServer` always advertises the current `CARGO_PKG_VERSION` (0.7.0). Faking an older version would require either a server-side test override (invasive) or a fake `AuthOk` responder (also invasive). The unit tests cover the parse + comparison; the gate's effect (skip emit, skip spawn) is a single conditional in `control.rs` that's verifiable by code review.

If we ever want a true mixed-version end-to-end test, the cleanest path is to add a `[testing] override_server_version` config field on the server and exercise both branches via a parameterised test. Worth doing if Phase 5 lands more wire additions; not blocking here.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` (with PG): every suite green.

## What this unblocks

Tagging a **v0.7.0 client release**. Without this PR:
- v0.7.0 client + v0.7.0 edge: works fine.
- v0.7.0 client + v0.6.x edge: floods edge logs with `decode_frame` warnings every probe interval if the user has `health_check` configured.
- v0.7.0 client + v0.5.x edge: same as above.

With this PR:
- v0.7.0 client + v0.7.0 edge: works fine, full feature.
- v0.7.0 client + older edge: cleanly downgrades to solo registration. One warning per affected tunnel telling the user how to fix it. No noise on the edge.

## Test plan
- [x] cargo fmt + clippy clean
- [x] full workspace test suite green
- [ ] eyeball the gate logic in `control.rs` (the if/else at registration + the if-guard around the probe spawn)
- [ ] confirm `MIN_SERVER_VERSION_FOR_LOAD_BALANCING = (0, 7, 0)` is right — bumping the threshold later requires a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)