### PR TITLE
feat(observability) + docs: TUNNEL-8 Phase 5 — group metrics + docs

### DIFF
--- a/crates/rustunnel-server/src/core/router.rs
+++ b/crates/rustunnel-server/src/core/router.rs
@@ -740,13 +740,14 @@ impl TunnelCore {
         })
     }
 
-    /// Mark `tunnel_id` unhealthy and bump its consecutive-failure counter.
+    /// Mark `tunnel_id` unhealthy and bump its failure counters.
     /// `reason` is a free-form string from the client used for dashboards.
     /// Returns `true` if the tunnel was found and updated.
     pub fn set_tunnel_unhealthy(&self, tunnel_id: &Uuid, reason: &str) -> bool {
         self.with_member(tunnel_id, |member| {
             member.healthy.store(false, Ordering::Release);
             member.consecutive_failures.fetch_add(1, Ordering::Release);
+            member.total_health_failures.fetch_add(1, Ordering::Relaxed);
             tracing::debug!(%tunnel_id, %reason, "tunnel marked unhealthy");
         })
     }

--- a/crates/rustunnel-server/src/core/tunnel.rs
+++ b/crates/rustunnel-server/src/core/tunnel.rs
@@ -90,10 +90,16 @@ pub struct GroupMember {
     /// Health-check spec from `RegisterTunnel.health_check`; `None` if the
     /// client didn't ask for probes.
     pub health_spec: Option<HealthCheckSpec>,
-    /// Tracked server-side for surfacing on the dashboard. Probe failures are
-    /// detected on the client; this counter is incremented on each
-    /// `TunnelUnhealthy` frame.
+    /// Current consecutive-failure streak — resets to 0 each time a
+    /// `TunnelHealthy` arrives. Surfaced on the dashboard so operators can
+    /// see "this member is currently down on its 3rd straight failure".
     pub consecutive_failures: AtomicU32,
+    /// Cumulative count of `TunnelUnhealthy` frames received since this
+    /// member registered. Drives the
+    /// `rustunnel_group_health_failures_total{group, kind}` Prometheus
+    /// counter (Phase 5). Never resets while the member is registered;
+    /// goes away when the member leaves the group.
+    pub total_health_failures: AtomicU64,
 }
 
 impl GroupMember {
@@ -105,6 +111,7 @@ impl GroupMember {
             healthy: AtomicBool::new(true),
             health_spec: None,
             consecutive_failures: AtomicU32::new(0),
+            total_health_failures: AtomicU64::new(0),
         }
     }
 
@@ -122,6 +129,7 @@ impl GroupMember {
             healthy: AtomicBool::new(initially_healthy),
             health_spec: spec,
             consecutive_failures: AtomicU32::new(0),
+            total_health_failures: AtomicU64::new(0),
         }
     }
 }

--- a/crates/rustunnel-server/src/main.rs
+++ b/crates/rustunnel-server/src/main.rs
@@ -256,8 +256,9 @@ async fn run(config: Arc<ServerConfig>) -> Result<()> {
 
     let h_metrics = {
         let core = Arc::clone(&core);
+        let region = config.region.id.clone();
         tokio::spawn(async move {
-            if let Err(e) = run_metrics(metrics_addr, core).await {
+            if let Err(e) = run_metrics(metrics_addr, core, region).await {
                 error!("metrics server exited: {e}");
             }
         })
@@ -319,10 +320,38 @@ async fn run(config: Arc<ServerConfig>) -> Result<()> {
 
 // ── Prometheus metrics endpoint ───────────────────────────────────────────────
 
-async fn run_metrics(addr: SocketAddr, core: Arc<TunnelCore>) -> Result<()> {
+/// State for the metrics endpoint: the routing tables plus the region id
+/// (used as a Prometheus label so a central scraper can distinguish series
+/// from EU / US / AP).
+#[derive(Clone)]
+struct MetricsState {
+    core: Arc<TunnelCore>,
+    region: String,
+}
+
+/// Escape a label value per the Prometheus exposition format:
+/// backslashes, double-quotes, and newlines are the only forbidden
+/// characters inside `"..."`. We don't expect any of these in real
+/// region/group names but defensive-encoding keeps malformed config
+/// from breaking the scrape.
+fn escape_prometheus_label(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str(r"\\"),
+            '"' => out.push_str(r#"\""#),
+            '\n' => out.push_str(r"\n"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+async fn run_metrics(addr: SocketAddr, core: Arc<TunnelCore>, region: String) -> Result<()> {
+    let state = MetricsState { core, region };
     let app = Router::new()
         .route("/metrics", get(metrics_handler))
-        .with_state(core);
+        .with_state(state);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
     info!(%addr, "metrics endpoint listening");
@@ -330,13 +359,15 @@ async fn run_metrics(addr: SocketAddr, core: Arc<TunnelCore>) -> Result<()> {
     Ok(())
 }
 
-async fn metrics_handler(State(core): State<Arc<TunnelCore>>) -> Response {
+async fn metrics_handler(State(state): State<MetricsState>) -> Response {
     use std::sync::atomic::Ordering;
+    let core = &state.core;
+    let region_label = escape_prometheus_label(&state.region);
 
     let sessions = core.sessions.len();
     // Existing gauges count *members* (i.e. registered tunnels) so the
-    // numbers stay comparable with pre-load-balancing data. Phase 5 will add
-    // separate `rustunnel_group_members{...}` metrics keyed by group.
+    // numbers stay comparable with pre-load-balancing data. Phase 5 layers
+    // separate `rustunnel_group_*` series on top, keyed by group identity.
     let http_tunnels: usize = core.http_routes.iter().map(|g| g.members.len()).sum();
     let tcp_tunnels: usize = core.tcp_routes.iter().map(|g| g.members.len()).sum();
     let udp_tunnels: usize = core.udp_routes.iter().map(|g| g.members.len()).sum();
@@ -374,6 +405,94 @@ async fn metrics_handler(State(core): State<Arc<TunnelCore>>) -> Response {
             .load(std::sync::atomic::Ordering::Relaxed);
     }
 
+    // ── Phase 5: per-group series ────────────────────────────────────────
+    //
+    // For each grouped (key_hash.is_some()) routing entry across HTTP and
+    // TCP, emit:
+    //   - `rustunnel_group_members{group, region, healthy="true|false"}` —
+    //     gauge of currently-registered members partitioned by health bit.
+    //   - `rustunnel_group_dispatches_total{group, region}` — sum of
+    //     per-member request counts. Per-group, *not* per-member, to keep
+    //     the label cardinality bounded against UUID churn (see plan §7).
+    //   - `rustunnel_group_health_failures_total{group, region, kind}` —
+    //     sum of `total_health_failures` across members; `kind` is the
+    //     probe type (tcp/http) drawn from the first member's spec.
+    //
+    // Solo (ungrouped) registrations are skipped — those still show up in
+    // the existing `rustunnel_active_tunnels_*` gauges and
+    // `rustunnel_requests_total` counter.
+    let mut groups_block = String::new();
+    groups_block.push_str(
+        "# HELP rustunnel_group_members Number of registered group members partitioned by healthy state\n\
+         # TYPE rustunnel_group_members gauge\n\
+         # HELP rustunnel_group_dispatches_total Total dispatched connections across all members of a group\n\
+         # TYPE rustunnel_group_dispatches_total counter\n\
+         # HELP rustunnel_group_health_failures_total Total TunnelUnhealthy frames received across the group's members\n\
+         # TYPE rustunnel_group_health_failures_total counter\n",
+    );
+
+    let mut emit_group = |routes_iter: Box<
+        dyn Iterator<Item = (String, Arc<rustunnel_server::core::TunnelGroup>)> + '_,
+    >| {
+        for (_route_key, group) in routes_iter {
+            if group.key_hash.is_none() {
+                continue; // solo / ungrouped — covered by the legacy gauges
+            }
+            let group_label = escape_prometheus_label(&group.name);
+            let mut healthy = 0u64;
+            let mut unhealthy = 0u64;
+            let mut dispatches = 0u64;
+            let mut failures = 0u64;
+            let mut probe_kind: Option<&'static str> = None;
+            for member in group.members.iter() {
+                if member.healthy.load(Ordering::Acquire) {
+                    healthy += 1;
+                } else {
+                    unhealthy += 1;
+                }
+                dispatches += member.info.request_count.load(Ordering::Relaxed);
+                failures += member.total_health_failures.load(Ordering::Relaxed);
+                if probe_kind.is_none() {
+                    probe_kind = member.health_spec.as_ref().map(|s| match s.kind {
+                        rustunnel_protocol::HealthCheckKind::Tcp => "tcp",
+                        rustunnel_protocol::HealthCheckKind::Http => "http",
+                    });
+                }
+            }
+            use std::fmt::Write;
+            let _ = writeln!(
+                groups_block,
+                "rustunnel_group_members{{group=\"{group_label}\",region=\"{region_label}\",healthy=\"true\"}} {healthy}"
+            );
+            let _ = writeln!(
+                groups_block,
+                "rustunnel_group_members{{group=\"{group_label}\",region=\"{region_label}\",healthy=\"false\"}} {unhealthy}"
+            );
+            let _ = writeln!(
+                groups_block,
+                "rustunnel_group_dispatches_total{{group=\"{group_label}\",region=\"{region_label}\"}} {dispatches}"
+            );
+            // `kind` defaults to "none" when no member has opted into probes
+            // — that's a meaningful case operators may want to filter on
+            // (e.g. "groups with health checks vs without").
+            let kind = probe_kind.unwrap_or("none");
+            let _ = writeln!(
+                groups_block,
+                "rustunnel_group_health_failures_total{{group=\"{group_label}\",region=\"{region_label}\",kind=\"{kind}\"}} {failures}"
+            );
+        }
+    };
+    emit_group(Box::new(
+        core.http_routes
+            .iter()
+            .map(|e| (e.key().clone(), Arc::clone(e.value()))),
+    ));
+    emit_group(Box::new(
+        core.tcp_routes
+            .iter()
+            .map(|e| (e.key().to_string(), Arc::clone(e.value()))),
+    ));
+
     let body = format!(
         "# HELP rustunnel_active_sessions Number of active client sessions\n\
          # TYPE rustunnel_active_sessions gauge\n\
@@ -395,7 +514,8 @@ async fn metrics_handler(State(core): State<Arc<TunnelCore>>) -> Response {
          rustunnel_bytes_proxied_total {total_bytes}\n\
          # HELP rustunnel_requests_total Total requests/connections across all tunnels\n\
          # TYPE rustunnel_requests_total counter\n\
-         rustunnel_requests_total {total_requests}\n"
+         rustunnel_requests_total {total_requests}\n\
+         {groups_block}"
     );
 
     Response::builder()

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -48,9 +48,19 @@ This document tracks the features that have already shipped and ideas planned fo
 - [x] Append-only audit log (JSON-lines) for auth, tunnel, and token events
 - [x] Prometheus metrics endpoint (`/metrics` on `:9090`)
   - `rustunnel_active_sessions`
-  - `rustunnel_active_tunnels_http`
-  - `rustunnel_active_tunnels_tcp`
+  - `rustunnel_active_tunnels_http` / `_tcp` / `_udp` / `_p2p`
+  - `rustunnel_bytes_proxied_total`, `rustunnel_requests_total`
+  - `rustunnel_group_members{group, region, healthy}` (load balancing — TUNNEL-8)
+  - `rustunnel_group_dispatches_total{group, region}`
+  - `rustunnel_group_health_failures_total{group, region, kind}`
 - [x] SQLite-backed tunnel activity log (`tunnel_log` table with token attribution)
+
+### Load balancing & health checks (TUNNEL-8 — shipped in v0.7.0)
+- [x] Group-based load balancing for HTTP and TCP tunnels — multiple clients sharing the same `(subdomain, group_key)` (HTTP) or `(group_name, group_key)` (TCP) form a load-balanced pool with random dispatch across healthy members
+- [x] Client-side TCP and HTTP health probes — `interval_secs` / `timeout_secs` / `max_failed` per FRP's `healthCheck` config; sick backends automatically removed from rotation via `TunnelHealthy` / `TunnelUnhealthy` frames
+- [x] Per-region kill switch (`[load_balancing] enabled` in `server.toml`) for safe rollout
+- [x] Wire-compatible across versions — older clients register as solo, newer clients version-gate the new frames so they don't trip `decode_frame` on older edges
+- [x] Public docs at [`reference/load-balancing`](https://docs.rustunnel.com/reference/load-balancing) and the [client guide multi-backends section](https://docs.rustunnel.com/guides/client-guide#multiple-backends-load-balancing)
 
 ### Deployment
 - [x] Multi-stage Dockerfile for minimal production images
@@ -146,7 +156,7 @@ Items below are not committed to any release timeline. They represent directions
 - [ ] Windows support for the client binary
 - [ ] Config file hot-reload (SIGHUP) without restarting the server
 - [ ] Health check / heartbeat endpoint for load balancer probing
-- [ ] Group-based load balancing across multiple backends — multiple clients register against the same HTTP subdomain or TCP port under a shared group + group key, and inbound connections are dispatched at random to a healthy member. Includes built-in TCP and HTTP health checks (interval / timeout / max-failed) so unhealthy backends are removed from the pool automatically. Modeled on FRP's `loadBalancer.group` / `healthCheck` config; see [TUNNEL-7]
+- ~~Group-based load balancing across multiple backends~~ — **shipped in v0.7.0** under TUNNEL-8; see the new [Load balancing & health checks](#load-balancing--health-checks-tunnel-8--shipped-in-v070) section above
 
 ### Multi-region (Phase 5 — unified dashboard) ✅ Complete
 - [x] Dashboard fan-out queries — active tunnels aggregated across all regions via parallel API calls

--- a/docs/load-balancing.md
+++ b/docs/load-balancing.md
@@ -1,0 +1,244 @@
+# Load Balancing & Health Checks
+
+rustunnel supports group-based load balancing for HTTP and TCP tunnels.
+Multiple clients can register against the same subdomain (HTTP) or share a
+TCP port pool, and inbound connections are dispatched at random across
+healthy members of the group. Optional client-side health probes
+automatically remove sick backends from the rotation.
+
+The model is modeled on FRP's
+[`loadBalancer.group` / `healthCheck`](https://github.com/fatedier/frp#load-balancing)
+config — same shape, slightly different wire format.
+
+---
+
+## Concepts
+
+- **Group** — a logical pool of tunnel members sharing the same subdomain
+  (HTTP) or TCP port. Identified by a user-supplied `group` name plus a
+  shared `group_key`. The server stores only the SHA-256 hash of the key
+  and uses it to authorise joins; the raw key never leaves the client.
+- **Member** — one tunnel inside a group. A client running
+  `rustunnel start` with `group: web` registers exactly one member; running
+  two clients with the same `(group, group_key)` produces a 2-member pool.
+- **Health bit** — every member has a `healthy` flag. Dispatch routes
+  around members whose flag is `false`. Without a health check configured,
+  members are permanently healthy (the server trusts the client's presence).
+- **Dispatch** — for each new public connection, the server picks one
+  healthy member uniformly at random. There's no weighting and no sticky
+  sessions today.
+
+```
+                  +-> client A -> backend on :3000
+public ─-->  ── group "web"
+                  +-> client B -> backend on :3001
+```
+
+---
+
+## Configuration
+
+### Server (`server.toml`)
+
+The kill switch. When `false` (the default), the server accepts the new
+fields on the wire but ignores them — every registration is a solo tunnel,
+preserving v0.6.0 behaviour. When `true`, members sharing
+`(subdomain, group_key_hash)` (HTTP) or `(group_name, group_key_hash)`
+(TCP) form a real pool.
+
+```toml
+[load_balancing]
+enabled = true
+```
+
+### Client (`~/.rustunnel/config.yml`)
+
+Add `group`, `group_key`, and (optionally) `health_check` to a tunnel
+definition:
+
+```yaml
+server: tunnel.example.com:4040
+auth_token: "your-token"
+
+tunnels:
+  a:
+    proto: http
+    local_port: 3000
+    subdomain: pool
+    group: web
+    group_key: shared-secret-for-this-pool
+    health_check:
+      type: tcp
+      interval_secs: 10
+      timeout_secs: 3
+      max_failed: 3
+```
+
+| Field | Required | Default | Meaning |
+|---|---|---|---|
+| `group` | yes (for LB) | — | Display name of the pool. Doesn't have to match across clients; the first joiner sets `TunnelGroup.name`, the rest are accepted regardless of what they pass. |
+| `group_key` | yes (for LB) | — | Shared secret. SHA-256-hashed before transmission. Members of one pool MUST agree on this value; the server rejects a join with a mismatched key. |
+| `health_check.type` | no | — | `tcp` (open a connection) or `http` (issue a `GET`). Omit to disable probing — the member stays permanently healthy. |
+| `health_check.path` | yes when `type: http` | — | Path to GET against the local service. |
+| `health_check.interval_secs` | no | `10` | Probe period. |
+| `health_check.timeout_secs` | no | `3` | Per-probe deadline. |
+| `health_check.max_failed` | no | `3` | Consecutive failures before reporting `TunnelUnhealthy`. |
+| `health_check.expect_2xx` | no | `true` | When `false`, any HTTP response counts as healthy. |
+
+### Behaviour rules
+
+- **HTTP groups**: members must declare the **same protocol** (`http` vs
+  `https`). A mismatch is rejected with a clear error.
+- **TCP groups**: the first member of a `(group, group_key)` allocates a
+  port from the configured `tcp_port_range`. Subsequent members reuse that
+  port; the server returns the same `assigned_port` to all joiners.
+- **Solo collisions**: registering a solo (no-group) tunnel against an
+  existing group's subdomain is rejected with `subdomain '...' is already
+  in use`. Registering a grouped tunnel against an existing solo tunnel is
+  rejected with `group key does not match`.
+- **Last-leave**: the group entry is removed when its last member
+  disconnects. The TCP port (if any) is returned to the pool.
+- **Race safety**: the create / join / remove paths are serialised
+  atomically via the routing-table entry API. Two concurrent first
+  registrations produce one group, not two.
+
+---
+
+## Health checks
+
+Probes run **on the client** against `local_addr`. The server never opens
+a connection to the upstream itself — it just trusts the client's
+`TunnelHealthy` / `TunnelUnhealthy` reports.
+
+- **TCP probe**: opens a TCP connection. Success = connect within
+  `timeout_secs`.
+- **HTTP probe**: sends `GET <path> HTTP/1.0` and reads the status line.
+  Success = response within `timeout_secs` and (when `expect_2xx`) status
+  in `[200, 300)`.
+
+Probe state is reported only on **edges**:
+
+- First probe success → `TunnelHealthy` (lifts the initial `healthy=false`
+  state for members that opted into probing).
+- `max_failed` consecutive failures → `TunnelUnhealthy`.
+- First success after a failure streak → `TunnelHealthy`.
+
+A member with no `health_check` is permanently healthy. A member *with* a
+spec starts unhealthy and only joins dispatch after the first successful
+probe.
+
+---
+
+## Testing the feature locally
+
+Quick end-to-end smoke test against a self-hosted edge with
+`[load_balancing] enabled = true`. Spin up two clients with the same
+`(group, group_key)`, point them at separate local backends, and hammer
+the public URL — both backends should serve.
+
+```bash
+# Build the client locally from main (no release tag needed)
+cd ~/projects/rustunnel/rustunnel
+cargo build --release -p rustunnel-client
+
+# Drop a config that opts into a group
+cat > /tmp/lb-test.yml <<'EOF'
+server: tunnel.example.com:4040
+auth_token: "your-token"
+
+tunnels:
+  a:
+    proto: http
+    local_port: 3000
+    subdomain: lbtest
+    group: web
+    group_key: shared-secret-for-lb-test
+    health_check:
+      type: tcp
+EOF
+
+# Terminal 1 — backend A on :3000
+python3 -m http.server 3000
+
+# Terminal 2 — client A pointing at backend A
+./target/release/rustunnel start --config /tmp/lb-test.yml
+
+# Terminal 3 — backend B on :3001
+python3 -m http.server 3001
+
+# Terminal 4 — client B with local_port 3001 (edit /tmp/lb-test.yml or use a second config file)
+
+# Terminal 5 — hammer the public URL
+for i in $(seq 1 50); do
+  curl -fsS https://lbtest.tunnel.example.com/ -o /dev/null -w "%{http_code}\n"
+done
+```
+
+Validate the dispatch by reading the per-group counters from the metrics
+endpoint on the edge:
+
+```bash
+ssh root@tunnel.example.com 'curl -sf http://127.0.0.1:9090/metrics' \
+  | grep '^rustunnel_group_'
+```
+
+You should see something like:
+
+```
+rustunnel_group_members{group="web",region="eu",healthy="true"} 2
+rustunnel_group_members{group="web",region="eu",healthy="false"} 0
+rustunnel_group_dispatches_total{group="web",region="eu"} 50
+rustunnel_group_health_failures_total{group="web",region="eu",kind="tcp"} 0
+```
+
+Verify failover by killing one of the local backends — the probe loop on
+that client will mark it unhealthy after `max_failed * interval_secs`
+seconds, after which dispatch routes everything to the survivor. Restart
+the backend, the probe re-registers it as healthy, and dispatch
+distributes again.
+
+---
+
+## Observability
+
+When `[load_balancing] enabled = true`, the Prometheus exporter on `:9090`
+emits three additional series:
+
+| Metric | Type | Labels | What it measures |
+|---|---|---|---|
+| `rustunnel_group_members` | gauge | `group`, `region`, `healthy` | Count of registered members partitioned by their health bit. |
+| `rustunnel_group_dispatches_total` | counter | `group`, `region` | Total dispatched connections, summed across the group's members. (Per-group rather than per-member to keep cardinality bounded.) |
+| `rustunnel_group_health_failures_total` | counter | `group`, `region`, `kind` | Total `TunnelUnhealthy` frames received across the group's members. `kind` is `tcp` / `http` / `none` based on the configured probe type. |
+
+The pre-existing `rustunnel_active_tunnels_*` and `rustunnel_requests_total`
+gauges/counters keep counting **members** (not groups) so historical
+dashboards stay accurate.
+
+---
+
+## Limitations & non-goals
+
+- **No weighted dispatch** — random uniform only. Pick weights are not
+  configurable.
+- **No sticky sessions** — every new connection is dispatched
+  independently. Long-lived WebSocket connections that need to land on the
+  same backend across reconnects need to be solved at the application
+  layer.
+- **No active session draining on member removal** — when a member
+  disconnects (or is marked unhealthy), in-flight connections finish
+  naturally; new connections route elsewhere.
+- **No UDP groups** — UDP is connectionless; there's no obvious unit to
+  dispatch.
+- **No P2P groups** — P2P publishers are 1-to-many by design; multiple
+  publishers under one name is a different problem.
+- **No cross-region pools** — members must be on the same edge server.
+  Layer DNS-based routing on top for global LB.
+- **No `groupKey` rotation** — once a group exists, rotating its key
+  requires dropping all members.
+
+---
+
+## See also
+
+- [Client Guide — Multiple backends](./client-guide.md#multiple-backends-load-balancing)
+- [Architecture overview](./architecture.md)


### PR DESCRIPTION
## Summary

First slice of Phase 5 of the load-balancing plan. Adds the per-group Prometheus series the plan §5 specifies, plus the open-source repo docs (full reference + ROADMAP move). The Mintlify public-docs portion ships in a separate PR on `joaoh82/docs`.

## What's in this PR

### Server — Prometheus group series
- **`rustunnel_group_members{group, region, healthy}`** (gauge) — registered members per group, partitioned by health bit. `healthy` is `true`/`false` so dashboards can graph "available" vs "out of rotation" with one query.
- **`rustunnel_group_dispatches_total{group, region}`** (counter) — total connections dispatched, summed across the group's members. Per-group rather than per-member because per-member would label by tunnel_id (UUID) and blow Prometheus cardinality with churn.
- **`rustunnel_group_health_failures_total{group, region, kind}`** (counter) — cumulative `TunnelUnhealthy` frames received; `kind` is `tcp`/`http`/`none` based on the configured probe.
- New `total_health_failures: AtomicU64` on `GroupMember` (incremented from `set_tunnel_unhealthy`). Distinct from `consecutive_failures` which resets on every `TunnelHealthy`.
- `region` (from `[region] id` in `server.toml`) now threads through `run_metrics` → `MetricsState` → every emitted series. A central scraper (TUNNEL-9) can distinguish EU / US / AP without renaming.
- Existing `rustunnel_active_tunnels_*` and `rustunnel_requests_total` keep counting **members** (not groups) so historical Grafana panels stay valid.
- Solo (ungrouped) routes are skipped by the new series — they're already covered by the legacy gauges.

### Docs (open-source repo)
- **New `docs/load-balancing.md`** — full reference. Concepts, config (server kill switch + client config), behaviour rules (HTTP/TCP/solo collisions, last-leave, race safety), health-check semantics, an end-to-end test recipe with two clients on a shared subdomain, the new Prometheus series, limitations / non-goals.
- **`docs/ROADMAP.md`** — moved TUNNEL-8 from "Medium-term / Planned" → "Implemented" under a new "Load balancing & health checks (TUNNEL-8 — shipped in v0.7.0)" subsection. The old planned-list entry now points at the new section.

## What's NOT in this PR

Separate PRs (will be opened on the matching repos):
- **`joaoh82/docs`** — public Mintlify reference at `reference/load-balancing.mdx`, "Multiple backends" section in `guides/client-guide.mdx`, `docs.json` registration, `index.mdx` features card.
- **dashboard-ui** (open-source `rustunnel/dashboard-ui/`) — expand-row for group members + health pill + new Groups panel + per-tunnel health-event timeline. Bigger Next.js work; warrants its own treatment.
- **rustunnel-admin-dashboard** — per-region "Load balancing" section, cross-region rollup, alert hook stub.
- **Marketing site + blog post** (`rustunnel-web/` / `rustunnel-landing/`) — homepage section, FRP-comparison post update.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace` (with PG): every suite green (server lib still 64 tests; metrics-handler change exercised by all integration suites that hit the running server).

## How to validate the new metrics in production

After this PR + the `[load_balancing] enabled = true` flag is on a region:

```bash
ssh root@eu.edge.rustunnel.com 'curl -sf http://127.0.0.1:9090/metrics' \
  | grep '^rustunnel_group_'
```

Run the [smoke-test recipe in the new docs](docs/load-balancing.md#testing-the-feature-locally) — two clients on a shared subdomain, hammer with curl — and the counters should advance.

## Test plan
- [x] cargo fmt + clippy clean
- [x] full workspace test suite green
- [ ] Eyeball the new metric series for cardinality concerns on the live EU edge once we have grouped traffic
- [ ] Once the matching Mintlify PR is open, confirm the cross-repo links in `index.mdx` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)