### PR TITLE
feat(dashboard): scope /api/tunnels and /api/groups by user (TUNNEL-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,8 @@ make docker-run-monitoring
 
 The dashboard port exposes a REST API for programmatic access to tunnels, tokens, captured requests, and tunnel history. All endpoints (except the health check) require an `Authorization: Bearer <token>` header.
 
+`/api/tunnels`, `/api/groups`, and their per-tunnel sub-resources are scoped by caller: the admin token sees everything; a user-scoped API token sees only its own tunnels and groups; tunnels the caller can't see return `404`, never `403`. See [docs/api-reference.md § Visibility scope](docs/api-reference.md#visibility-scope) for the full rules.
+
 **Quick reference**
 
 | Method | Path | Description |

--- a/crates/rustunnel-server/src/control/session.rs
+++ b/crates/rustunnel-server/src/control/session.rs
@@ -253,7 +253,8 @@ where
 
     let token_id = token.clone();
     let db_token_id = db_token.as_ref().map(|t| t.id.clone());
-    let session_id = core.register_session(peer_addr, token, db_token_id, ctrl_tx);
+    let user_id = db_token.as_ref().and_then(|t| t.user_id);
+    let session_id = core.register_session(peer_addr, token, db_token_id, user_id, ctrl_tx);
 
     let _ = audit_tx.try_send(AuditEvent::AuthAttempt {
         peer: peer_addr.to_string(),

--- a/crates/rustunnel-server/src/core/router.rs
+++ b/crates/rustunnel-server/src/core/router.rs
@@ -247,12 +247,13 @@ impl TunnelCore {
         addr: SocketAddr,
         token_id: String,
         db_token_id: Option<String>,
+        user_id: Option<Uuid>,
         control_tx: mpsc::Sender<ControlMessage>,
     ) -> Uuid {
         let session_id = Uuid::new_v4();
         self.sessions.insert(
             session_id,
-            SessionInfo::new(addr, token_id, db_token_id, control_tx),
+            SessionInfo::new(addr, token_id, db_token_id, user_id, control_tx),
         );
         session_id
     }
@@ -1094,7 +1095,7 @@ mod tests {
     fn dummy_session(core: &TunnelCore) -> (Uuid, mpsc::Receiver<ControlMessage>) {
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
         let (tx, rx) = mpsc::channel(16);
-        let session_id = core.register_session(addr, "token-1".to_string(), None, tx);
+        let session_id = core.register_session(addr, "token-1".to_string(), None, None, tx);
         (session_id, rx)
     }
 

--- a/crates/rustunnel-server/src/core/tunnel.rs
+++ b/crates/rustunnel-server/src/core/tunnel.rs
@@ -345,6 +345,12 @@ pub struct SessionInfo {
     /// The `tokens.id` (UUID) of the authenticated token, if it came from the DB.
     /// `None` for the admin token or when auth is disabled.
     pub db_token_id: Option<String>,
+    /// `tokens.user_id` of the authenticated token. `None` for the admin
+    /// token, for legacy / admin-issued DB tokens with no owning user, and
+    /// when auth is disabled. Cached at session creation so the dashboard
+    /// API can scope `/api/tunnels` and `/api/groups` to a single tenant
+    /// without a per-request DB lookup.
+    pub user_id: Option<Uuid>,
     /// Channel for sending control messages to the session handler task.
     pub control_tx: mpsc::Sender<ControlMessage>,
     /// Tunnel IDs owned by this session.
@@ -362,6 +368,7 @@ impl SessionInfo {
         client_addr: SocketAddr,
         auth_token_id: String,
         db_token_id: Option<String>,
+        user_id: Option<Uuid>,
         control_tx: mpsc::Sender<ControlMessage>,
     ) -> Self {
         let now = Instant::now();
@@ -369,6 +376,7 @@ impl SessionInfo {
             client_addr,
             auth_token_id,
             db_token_id,
+            user_id,
             control_tx,
             tunnels: Vec::new(),
             connected_at: now,

--- a/crates/rustunnel-server/src/dashboard/api.rs
+++ b/crates/rustunnel-server/src/dashboard/api.rs
@@ -101,12 +101,55 @@ pub fn router(state: ApiState) -> Router {
 
 // ── auth helper ───────────────────────────────────────────────────────────────
 
+/// Tenant scope resolved from the `Authorization` header. Determines which
+/// tunnels/groups a dashboard caller is allowed to see (TUNNEL-1).
+///
+/// - `Admin` — operator-level access (the `auth.admin_token`). Sees every
+///   tunnel and group across every tenant. This is the historical
+///   behaviour and must stay unchanged.
+/// - `User(user_id)` — a DB token whose `tokens.user_id` is set. The
+///   caller can only see tunnels owned by sessions whose token belongs to
+///   that same `user_id` (so a user can list all of *their* tunnels even
+///   across multiple tokens / multiple clients).
+/// - `Token(token_id)` — a legacy / admin-issued DB token with no
+///   `user_id` (e.g. the bootstrap "agent" tokens that predate the
+///   platform-api). Visibility is narrowed to that specific token: you
+///   only see tunnels opened by sessions authenticated with the same DB
+///   token row. Picked over admin-equivalent so adding the user dashboard
+///   surface can't widen visibility for these legacy tokens by accident.
+#[derive(Clone, Debug)]
+enum AuthScope {
+    Admin,
+    User(uuid::Uuid),
+    Token(String),
+}
+
+impl AuthScope {
+    /// Whether this caller can see a tunnel/group member owned by the
+    /// session described by `(session_user_id, session_db_token_id)`.
+    /// Sessions with neither value (auth disabled, admin-token control
+    /// plane, …) are visible only to `Admin` callers.
+    fn can_see(
+        &self,
+        session_user_id: Option<uuid::Uuid>,
+        session_db_token_id: Option<&str>,
+    ) -> bool {
+        match self {
+            AuthScope::Admin => true,
+            AuthScope::User(uid) => session_user_id == Some(*uid),
+            AuthScope::Token(tid) => session_db_token_id == Some(tid.as_str()),
+        }
+    }
+}
+
 /// Validate `Authorization: Bearer <token>` against the DB token table.
-/// Also accepts the admin token directly.
+/// Also accepts the admin token directly. Returns the resolved
+/// [`AuthScope`] so handlers can scope their results to the caller's
+/// tenant.
 async fn require_auth(
     headers: &HeaderMap,
     state: &ApiState,
-) -> Result<(), (StatusCode, Json<ErrBody>)> {
+) -> Result<AuthScope, (StatusCode, Json<ErrBody>)> {
     let auth = headers
         .get("authorization")
         .and_then(|v| v.to_str().ok())
@@ -119,17 +162,74 @@ async fn require_auth(
 
     // Check admin token first (avoids DB hit for the most common case).
     if auth == state.admin_token {
-        return Ok(());
+        return Ok(AuthScope::Admin);
     }
 
     match db::verify_token(&state.db.pg, auth).await {
-        Ok(Some(_)) => Ok(()),
+        Ok(Some(t)) => match t.user_id {
+            Some(uid) => Ok(AuthScope::User(uid)),
+            None => Ok(AuthScope::Token(t.id)),
+        },
         Ok(None) => Err(unauthorized("invalid token")),
         Err(e) => {
             warn!("token verification DB error: {e}");
             Err(unauthorized("invalid token"))
         }
     }
+}
+
+/// Look up the owning session of a `TunnelInfo` (or P2P publisher) and
+/// answer whether `scope` is allowed to see the member.
+///
+/// Sessions can disappear under us (the session map is mutated lock-free
+/// from other tasks) — when that happens we deny access except for the
+/// admin scope. That matches the issue's "404 for tunnels the caller
+/// can't see" rule and avoids leaking a stale tunnel after its session
+/// closed.
+fn scope_sees_session(
+    core: &crate::core::TunnelCore,
+    scope: &AuthScope,
+    session_id: &uuid::Uuid,
+) -> bool {
+    if matches!(scope, AuthScope::Admin) {
+        return true;
+    }
+    match core.sessions.get(session_id) {
+        Some(s) => scope.can_see(s.user_id, s.db_token_id.as_deref()),
+        None => false,
+    }
+}
+
+/// Walk the routing tables to find which session owns `tunnel_id`.
+/// Returns `None` if the tunnel doesn't exist. Used by handlers that
+/// resolve a tunnel by ID and need to enforce scope before returning
+/// data or mutating state.
+fn find_tunnel_owning_session(
+    core: &crate::core::TunnelCore,
+    tunnel_id: &uuid::Uuid,
+) -> Option<uuid::Uuid> {
+    for entry in core.http_routes.iter() {
+        if let Some(member) = entry.value().members.get(tunnel_id) {
+            return Some(member.info.session_id);
+        }
+    }
+    for entry in core.tcp_routes.iter() {
+        if let Some(member) = entry.value().members.get(tunnel_id) {
+            return Some(member.info.session_id);
+        }
+    }
+    for entry in core.udp_routes.iter() {
+        if let Some(member) = entry.value().members.get(tunnel_id) {
+            return Some(member.info.session_id);
+        }
+    }
+    for entry in core.p2p_tunnels.iter() {
+        let publisher = entry.value();
+        if publisher.tunnel_info.tunnel_id == *tunnel_id {
+            return Some(publisher.tunnel_info.session_id);
+        }
+    }
+    None
 }
 
 // ── response helpers ──────────────────────────────────────────────────────────
@@ -295,15 +395,20 @@ fn instant_to_iso(created: std::time::Instant) -> String {
 }
 
 async fn list_tunnels(headers: HeaderMap, State(state): State<ApiState>) -> impl IntoResponse {
-    if let Err(e) = require_auth(&headers, &state).await {
-        return e.into_response();
-    }
+    let scope = match require_auth(&headers, &state).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
 
     let mut tunnels: Vec<TunnelSummary> = Vec::new();
 
-    // One row per member. Solo tunnels (Phase 1 case) render exactly as
-    // before — `group` is `None`, `healthy` is `true`, the failure counters
-    // are 0. Group members get the full `GroupRef`, the actual health bit,
+    // One row per member, filtered to the caller's tenant scope. Admin
+    // sees everything; user-scoped tokens see only members owned by
+    // sessions belonging to that user; legacy / no-user-id tokens see
+    // only members opened by sessions authenticated with that exact
+    // token. Solo tunnels (Phase 1 case) render exactly as before —
+    // `group` is `None`, `healthy` is `true`, the failure counters are
+    // 0. Group members get the full `GroupRef`, the actual health bit,
     // and per-member failure counters so the dashboard can show "this
     // backend is currently down on its 3rd straight probe failure".
     for entry in state.core.http_routes.iter() {
@@ -311,6 +416,9 @@ async fn list_tunnels(headers: HeaderMap, State(state): State<ApiState>) -> impl
         let group_arc = entry.value();
         let group_ref = group_summary_ref(group_arc);
         for member in group_arc.members.iter() {
+            if !scope_sees_session(&state.core, &scope, &member.info.session_id) {
+                continue;
+            }
             tunnels.push(member_to_summary(
                 &member,
                 "http",
@@ -327,6 +435,9 @@ async fn list_tunnels(headers: HeaderMap, State(state): State<ApiState>) -> impl
         let group_arc = entry.value();
         let group_ref = group_summary_ref(group_arc);
         for member in group_arc.members.iter() {
+            if !scope_sees_session(&state.core, &scope, &member.info.session_id) {
+                continue;
+            }
             tunnels.push(member_to_summary(
                 &member,
                 "tcp",
@@ -343,6 +454,9 @@ async fn list_tunnels(headers: HeaderMap, State(state): State<ApiState>) -> impl
         let group_arc = entry.value();
         let group_ref = group_summary_ref(group_arc);
         for member in group_arc.members.iter() {
+            if !scope_sees_session(&state.core, &scope, &member.info.session_id) {
+                continue;
+            }
             tunnels.push(member_to_summary(
                 &member,
                 "udp",
@@ -357,6 +471,9 @@ async fn list_tunnels(headers: HeaderMap, State(state): State<ApiState>) -> impl
     for entry in state.core.p2p_tunnels.iter() {
         let publisher = entry.value();
         let info = &publisher.tunnel_info;
+        if !scope_sees_session(&state.core, &scope, &info.session_id) {
+            continue;
+        }
         let client_addr = state
             .core
             .sessions
@@ -451,14 +568,37 @@ async fn force_close_tunnel(
     State(state): State<ApiState>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    if let Err(e) = require_auth(&headers, &state).await {
-        return e.into_response();
-    }
+    let scope = match require_auth(&headers, &state).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
 
     let tunnel_id = match id.parse::<uuid::Uuid>() {
         Ok(u) => u,
         Err(_) => return not_found("invalid tunnel id").into_response(),
     };
+
+    // Admin short-circuit: preserves the historical idempotent
+    // semantics (204 even when the tunnel doesn't exist) and avoids
+    // walking every route to find an owner that doesn't matter.
+    if matches!(scope, AuthScope::Admin) {
+        state.core.remove_tunnel(&tunnel_id);
+        return StatusCode::NO_CONTENT.into_response();
+    }
+
+    // Non-admin: resolve the tunnel's owning session before mutating
+    // state so a user-scoped caller can't close another tenant's
+    // tunnel. Return 404 (not 403) when the caller can't see the
+    // tunnel — same shape as "tunnel doesn't exist" so we don't leak
+    // existence.
+    let owning_session = find_tunnel_owning_session(&state.core, &tunnel_id);
+    let visible = match owning_session {
+        Some(sid) => scope_sees_session(&state.core, &scope, &sid),
+        None => false,
+    };
+    if !visible {
+        return not_found("tunnel not found").into_response();
+    }
 
     state.core.remove_tunnel(&tunnel_id);
     StatusCode::NO_CONTENT.into_response()
@@ -469,9 +609,10 @@ async fn get_tunnel(
     State(state): State<ApiState>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    if let Err(e) = require_auth(&headers, &state).await {
-        return e.into_response();
-    }
+    let scope = match require_auth(&headers, &state).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
 
     // Search HTTP routes first.
     for entry in state.core.http_routes.iter() {
@@ -480,6 +621,9 @@ async fn get_tunnel(
         let group_ref = group_summary_ref(group_arc);
         for member in group_arc.members.iter() {
             if member.info.tunnel_id.to_string() == id {
+                if !scope_sees_session(&state.core, &scope, &member.info.session_id) {
+                    return not_found("tunnel not found").into_response();
+                }
                 return Json(member_to_summary(
                     &member,
                     "http",
@@ -500,6 +644,9 @@ async fn get_tunnel(
         let group_ref = group_summary_ref(group_arc);
         for member in group_arc.members.iter() {
             if member.info.tunnel_id.to_string() == id {
+                if !scope_sees_session(&state.core, &scope, &member.info.session_id) {
+                    return not_found("tunnel not found").into_response();
+                }
                 return Json(member_to_summary(
                     &member,
                     "tcp",
@@ -520,6 +667,9 @@ async fn get_tunnel(
         let group_ref = group_summary_ref(group_arc);
         for member in group_arc.members.iter() {
             if member.info.tunnel_id.to_string() == id {
+                if !scope_sees_session(&state.core, &scope, &member.info.session_id) {
+                    return not_found("tunnel not found").into_response();
+                }
                 return Json(member_to_summary(
                     &member,
                     "udp",
@@ -538,6 +688,9 @@ async fn get_tunnel(
         let publisher = entry.value();
         if publisher.tunnel_info.tunnel_id.to_string() == id {
             let info = &publisher.tunnel_info;
+            if !scope_sees_session(&state.core, &scope, &info.session_id) {
+                return not_found("tunnel not found").into_response();
+            }
             let client_addr = state
                 .core
                 .sessions
@@ -592,14 +745,25 @@ async fn tunnel_health_events(
     State(state): State<ApiState>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    if let Err(e) = require_auth(&headers, &state).await {
-        return e.into_response();
-    }
+    let scope = match require_auth(&headers, &state).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
 
     let tunnel_id = match id.parse::<uuid::Uuid>() {
         Ok(u) => u,
         Err(_) => return not_found("invalid tunnel id").into_response(),
     };
+
+    // 404 (not 403) when the caller can't see this tunnel — same shape
+    // as "tunnel doesn't exist" so existence isn't leaked.
+    let owning_session = find_tunnel_owning_session(&state.core, &tunnel_id);
+    if !owning_session
+        .map(|sid| scope_sees_session(&state.core, &scope, &sid))
+        .unwrap_or(false)
+    {
+        return not_found("tunnel not found").into_response();
+    }
 
     // Walk the routing tables to find this tunnel's GroupMember and
     // snapshot its ring. Same shape as `get_tunnel`.
@@ -703,25 +867,39 @@ struct GroupSummary {
 }
 
 async fn list_groups(headers: HeaderMap, State(state): State<ApiState>) -> impl IntoResponse {
-    if let Err(e) = require_auth(&headers, &state).await {
-        return e.into_response();
-    }
+    let scope = match require_auth(&headers, &state).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
 
     let mut groups: Vec<GroupSummary> = Vec::new();
     let region = state.region.id.clone();
 
+    // Per-group filtering rules:
+    // - Admin sees every group with full aggregates.
+    // - Other scopes only see groups where at least one member's owning
+    //   session is visible to them, and every counter
+    //   (`member_count`, `healthy_count`, `unhealthy_count`,
+    //   `total_dispatches`, `total_health_failures`) reflects only the
+    //   visible subset. Today's group-key model is single-tenant in
+    //   practice, but filtering aggregates as well keeps the response
+    //   safe under any future multi-tenant pool — no cross-tenant
+    //   counts ever leak through.
     for entry in state.core.http_routes.iter() {
         let group = entry.value();
         if group.key_hash.is_none() {
             continue; // solo registration — covered by /api/tunnels
         }
-        groups.push(group_to_summary(
+        if let Some(summary) = group_to_summary(
             "http",
             entry.key().clone(),
             group,
             &state.core,
             &region,
-        ));
+            &scope,
+        ) {
+            groups.push(summary);
+        }
     }
 
     for entry in state.core.tcp_routes.iter() {
@@ -729,34 +907,44 @@ async fn list_groups(headers: HeaderMap, State(state): State<ApiState>) -> impl 
         if group.key_hash.is_none() {
             continue;
         }
-        groups.push(group_to_summary(
+        if let Some(summary) = group_to_summary(
             "tcp",
             entry.key().to_string(),
             group,
             &state.core,
             &region,
-        ));
+            &scope,
+        ) {
+            groups.push(summary);
+        }
     }
 
     Json(groups).into_response()
 }
 
-/// Build a `GroupSummary` for a single routing entry.
+/// Build a `GroupSummary` for a single routing entry, filtered to the
+/// caller's `scope`. Returns `None` when the caller can't see any
+/// member of this group — the row is dropped from the response.
 fn group_to_summary(
     protocol: &str,
     label: String,
     group: &Arc<crate::core::TunnelGroup>,
     core: &Arc<crate::core::TunnelCore>,
     region_id: &str,
-) -> GroupSummary {
+    scope: &AuthScope,
+) -> Option<GroupSummary> {
     let key_hash = group.key_hash.as_deref().unwrap_or("");
     let mut healthy_count = 0;
     let mut unhealthy_count = 0;
     let mut total_dispatches: u64 = 0;
     let mut total_health_failures: u64 = 0;
+    let mut visible_member_count = 0usize;
     let mut members = Vec::with_capacity(group.members.len());
     for m in group.members.iter() {
         let info = &m.info;
+        if !scope_sees_session(core, scope, &info.session_id) {
+            continue;
+        }
         let healthy = m.healthy.load(Ordering::Acquire);
         if healthy {
             healthy_count += 1;
@@ -767,6 +955,7 @@ fn group_to_summary(
         let failures = m.total_health_failures.load(Ordering::Relaxed);
         total_dispatches += req_count;
         total_health_failures += failures;
+        visible_member_count += 1;
         let client_addr = core
             .sessions
             .get(&info.session_id)
@@ -795,19 +984,26 @@ fn group_to_summary(
             has_alert_webhook,
         });
     }
-    GroupSummary {
+    if members.is_empty() {
+        return None;
+    }
+    // Aggregates reflect only visible members. For admin callers this
+    // matches the historical full-pool numbers because every member is
+    // visible. For tenant callers it never includes members from
+    // sessions they aren't allowed to see.
+    Some(GroupSummary {
         protocol: protocol.to_string(),
         label,
         name: group.name.clone(),
         key_hash_short: key_hash.chars().take(8).collect(),
         region_id: region_id.to_string(),
-        member_count: group.members.len(),
+        member_count: visible_member_count,
         healthy_count,
         unhealthy_count,
         total_dispatches,
         total_health_failures,
         members,
-    }
+    })
 }
 
 // ── /api/groups/:protocol/:label/events — SSE (TUNNEL-8 Phase 5) ────────────
@@ -830,21 +1026,73 @@ async fn group_events_sse(
     State(state): State<ApiState>,
     Path((protocol, label)): Path<(String, String)>,
 ) -> impl IntoResponse {
-    if let Err(e) = require_auth(&headers, &state).await {
-        return e.into_response();
+    let scope = match require_auth(&headers, &state).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+
+    // Resolve the group up-front and verify the caller can see it. We
+    // look it up by `(protocol, label)` in the routing tables and check
+    // that at least one member is visible to the caller. 404 otherwise
+    // — same shape as a non-existent group, no existence leak. After
+    // the initial check the per-event filter only emits events for
+    // members the caller is allowed to see, so member churn (a new
+    // foreign-tenant member joins a previously visible group) can't
+    // exfil events from outside the caller's scope.
+    let group_visible = match protocol.as_str() {
+        "http" => state
+            .core
+            .http_routes
+            .get(&label)
+            .map(|g| {
+                g.members
+                    .iter()
+                    .any(|m| scope_sees_session(&state.core, &scope, &m.info.session_id))
+            })
+            .unwrap_or(false),
+        "tcp" => label
+            .parse::<u16>()
+            .ok()
+            .and_then(|p| state.core.tcp_routes.get(&p))
+            .map(|g| {
+                g.members
+                    .iter()
+                    .any(|m| scope_sees_session(&state.core, &scope, &m.info.session_id))
+            })
+            .unwrap_or(false),
+        _ => false,
+    };
+    if !matches!(scope, AuthScope::Admin) && !group_visible {
+        return not_found("group not found").into_response();
     }
 
     let receiver = state.core.subscribe_group_events();
     let stream = tokio_stream::wrappers::BroadcastStream::new(receiver);
     let proto = protocol;
     let lbl = label;
+    let core = Arc::clone(&state.core);
+    let stream_scope = scope.clone();
     let filtered = futures_util::StreamExt::filter_map(stream, move |result| {
         let proto = proto.clone();
         let lbl = lbl.clone();
+        let core = Arc::clone(&core);
+        let stream_scope = stream_scope.clone();
         async move {
             match result {
                 Ok(event) => {
                     if event.protocol == proto && event.label == lbl {
+                        // Drop events for members the caller can't see
+                        // — protects against a foreign tenant joining
+                        // the same group later in the stream.
+                        if !matches!(stream_scope, AuthScope::Admin) {
+                            let owning = find_tunnel_owning_session(&core, &event.tunnel_id);
+                            let visible = owning
+                                .map(|sid| scope_sees_session(&core, &stream_scope, &sid))
+                                .unwrap_or(false);
+                            if !visible {
+                                return None;
+                            }
+                        }
                         let payload = serde_json::to_string(&event).ok()?;
                         Some(Ok::<_, std::convert::Infallible>(
                             axum::response::sse::Event::default()
@@ -891,8 +1139,26 @@ async fn tunnel_requests(
     Path(tunnel_id): Path<String>,
     axum::extract::Query(q): axum::extract::Query<RequestsQuery>,
 ) -> impl IntoResponse {
-    if let Err(e) = require_auth(&headers, &state).await {
-        return e.into_response();
+    let scope = match require_auth(&headers, &state).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+
+    // Captured requests are tied to a tunnel — same scope check as the
+    // `/api/tunnels/:id` endpoint. 404 (not 403) when the caller can't
+    // see the tunnel so we don't leak existence. We require the tunnel
+    // to be live in-memory (the dashboard typically captures only for
+    // live tunnels); a tunnel that has gone away can't be looked up by
+    // owner so we deny non-admin callers in that case.
+    let parsed = tunnel_id.parse::<uuid::Uuid>().ok();
+    let visible = match parsed {
+        Some(tid) => find_tunnel_owning_session(&state.core, &tid)
+            .map(|sid| scope_sees_session(&state.core, &scope, &sid))
+            .unwrap_or(matches!(scope, AuthScope::Admin)),
+        None => matches!(scope, AuthScope::Admin),
+    };
+    if !visible {
+        return not_found("tunnel not found").into_response();
     }
 
     // Try in-memory ring buffer first for low-latency reads.
@@ -925,8 +1191,23 @@ async fn replay_request(
     State(state): State<ApiState>,
     Path((tunnel_id, request_id)): Path<(String, String)>,
 ) -> impl IntoResponse {
-    if let Err(e) = require_auth(&headers, &state).await {
-        return e.into_response();
+    let scope = match require_auth(&headers, &state).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+
+    // Same scope check as `/api/tunnels/:id/requests`: 404 if the caller
+    // can't see the parent tunnel. Stops a non-admin tenant from
+    // replaying captured requests they didn't generate.
+    let parsed = tunnel_id.parse::<uuid::Uuid>().ok();
+    let visible = match parsed {
+        Some(tid) => find_tunnel_owning_session(&state.core, &tid)
+            .map(|sid| scope_sees_session(&state.core, &scope, &sid))
+            .unwrap_or(matches!(scope, AuthScope::Admin)),
+        None => matches!(scope, AuthScope::Admin),
+    };
+    if !visible {
+        return not_found("tunnel not found").into_response();
     }
 
     match crate::dashboard::capture::get_request(&state.db.local, &request_id).await {
@@ -1645,9 +1926,10 @@ async fn tunnel_udp_sessions(
     State(state): State<ApiState>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    if let Err(e) = require_auth(&headers, &state).await {
-        return e.into_response();
-    }
+    let scope = match require_auth(&headers, &state).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
 
     // Find the UDP tunnel by ID.
     for entry in state.core.udp_routes.iter() {
@@ -1655,6 +1937,9 @@ async fn tunnel_udp_sessions(
         for member in entry.value().members.iter() {
             let info = &member.info;
             if info.tunnel_id.to_string() == id {
+                if !scope_sees_session(&state.core, &scope, &info.session_id) {
+                    return not_found("UDP tunnel not found").into_response();
+                }
                 return Json(UdpSessionInfo {
                     tunnel_id: info.tunnel_id.to_string(),
                     port,
@@ -1690,15 +1975,19 @@ async fn tunnel_p2p_peers(
     State(state): State<ApiState>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    if let Err(e) = require_auth(&headers, &state).await {
-        return e.into_response();
-    }
+    let scope = match require_auth(&headers, &state).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
 
     // Find the P2P tunnel by ID.
     for entry in state.core.p2p_tunnels.iter() {
         let publisher = entry.value();
         let info = &publisher.tunnel_info;
         if info.tunnel_id.to_string() == id {
+            if !scope_sees_session(&state.core, &scope, &info.session_id) {
+                return not_found("P2P tunnel not found").into_response();
+            }
             return Json(P2pPeerInfo {
                 tunnel_id: info.tunnel_id.to_string(),
                 tunnel_name: publisher.name.clone(),

--- a/crates/rustunnel-server/src/edge/tcp.rs
+++ b/crates/rustunnel-server/src/edge/tcp.rs
@@ -261,7 +261,7 @@ mod tests {
     fn add_session(core: &Arc<TunnelCore>) -> (Uuid, mpsc::Receiver<ControlMessage>) {
         let addr: SocketAddr = "127.0.0.1:9000".parse().unwrap();
         let (tx, rx) = mpsc::channel(16);
-        let sid = core.register_session(addr, "tok".into(), None, tx);
+        let sid = core.register_session(addr, "tok".into(), None, None, tx);
         (sid, rx)
     }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,8 +16,20 @@ Two token types are accepted:
 
 | Type | Value | Notes |
 |------|-------|-------|
-| Admin token | Value of `auth.admin_token` in `server.toml` | Full access |
-| API token | Raw UUID returned at token creation time | Same access as admin token today; scope enforcement planned |
+| Admin token | Value of `auth.admin_token` in `server.toml` | Full access — sees every tunnel and group across every tenant |
+| API token | Raw UUID returned at token creation time | Tenant-scoped (TUNNEL-1) — see "Visibility scope" below |
+
+### Visibility scope
+
+`/api/tunnels`, `/api/tunnels/:id`, `/api/tunnels/:id/*`, `/api/groups`, and `/api/groups/:protocol/:label/events` are filtered by the caller's identity:
+
+- **Admin token** — every tunnel and group in the region.
+- **API token with an owning user** (`tokens.user_id IS NOT NULL`, the platform-issued tokens) — only tunnels whose owning sessions are authenticated against tokens belonging to the same `user_id`. A user listing `/api/tunnels` sees all of *their* tunnels even when they're spread across multiple tokens or multiple clients.
+- **API token without an owning user** (legacy / admin-issued tokens, e.g. the bootstrap "agent" tokens that predate the platform-api) — only tunnels opened by sessions authenticated with that exact token.
+
+`DELETE /api/tunnels/:id` honours the same scope: a tenant cannot force-close another tenant's tunnel. `/api/groups` aggregate counters (`member_count`, `healthy_count`, `total_dispatches`, …) reflect only the members the caller is allowed to see.
+
+Tunnels and groups the caller can't see return **404 Not Found** rather than `403`, so existence isn't leaked.
 
 **Error responses**
 

--- a/docs/load-balancing.md
+++ b/docs/load-balancing.md
@@ -327,7 +327,12 @@ without polling all of `/api/tunnels`:
   consumer fell behind — resync via `/api/groups`.
 
 Both endpoints are gated by the same auth as `/api/tunnels` (admin
-token or DB token).
+token or DB token), and they apply the same per-tenant scope: a
+user-scoped DB token sees only groups containing at least one of its
+own members; aggregate counters reflect just the visible members.
+Groups the caller can't see return `404` rather than `403` so existence
+isn't leaked. See `docs/api-reference.md` § "Visibility scope" for the
+full rules.
 
 ---
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -78,3 +78,7 @@ path = "integration/alert_webhook.rs"
 [[test]]
 name = "group_events_sse"
 path = "integration/group_events_sse.rs"
+
+[[test]]
+name = "dashboard_scope"
+path = "integration/dashboard_scope.rs"

--- a/tests/integration/dashboard_scope.rs
+++ b/tests/integration/dashboard_scope.rs
@@ -1,0 +1,605 @@
+//! TUNNEL-1: Per-tenant scoping of `/api/tunnels` and `/api/groups`.
+//!
+//! Before this change every authenticated caller of the dashboard API
+//! saw every tunnel and group across every tenant. These tests pin the
+//! intended behaviour:
+//!
+//! - **Admin token** → sees everything (unchanged historical behaviour).
+//! - **User-scoped DB token** (`tokens.user_id IS NOT NULL`) → sees only
+//!   tunnels/groups whose owning sessions are authenticated against
+//!   tokens belonging to the same `user_id`.
+//! - **No-user-id DB token** (legacy) → sees only tunnels opened by
+//!   sessions authenticated with that exact token row.
+//! - **Hidden tunnels** return `404` (not `403`) so existence isn't leaked.
+//! - **Aggregate group counters** never include cross-tenant data —
+//!   `member_count`, `healthy_count`, etc. always reflect just the
+//!   members the caller is allowed to see.
+
+#[path = "../common/mod.rs"]
+mod common;
+
+use common::*;
+use uuid::Uuid;
+
+/// Insert a user row and return its ID.
+async fn create_user(db: &rustunnel_server::db::Db, email: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO users (id, email, password_hash, status, email_verified, auth_method) \
+         VALUES ($1, $2, $3, 'active', true, 'password')",
+    )
+    .bind(id)
+    .bind(email)
+    .bind("not-a-real-hash")
+    .execute(&db.pg)
+    .await
+    .expect("insert user");
+    id
+}
+
+/// Insert a token tied to (optional) `user_id` and return `(token_id, raw_token)`.
+async fn create_token_for_user(
+    db: &rustunnel_server::db::Db,
+    label: &str,
+    user_id: Option<Uuid>,
+) -> (String, String) {
+    let raw = format!("rt_test_{}", Uuid::new_v4());
+    let hash = rustunnel_server::db::hash_token(&raw);
+    let id = Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO tokens (id, token_hash, label, created_at, user_id, status, unlimited) \
+         VALUES ($1, $2, $3, now(), $4, 'active', false)",
+    )
+    .bind(&id)
+    .bind(&hash)
+    .bind(label)
+    .bind(user_id)
+    .execute(&db.pg)
+    .await
+    .expect("insert token");
+    (id, raw)
+}
+
+/// Strip a token row by ID. Used to reset state between tests so a flaky
+/// run on a shared DB doesn't pollute the next run.
+async fn delete_token(db: &rustunnel_server::db::Db, token_id: &str) {
+    let _ = sqlx::query("DELETE FROM tokens WHERE id = $1")
+        .bind(token_id)
+        .execute(&db.pg)
+        .await;
+}
+
+async fn delete_user(db: &rustunnel_server::db::Db, user_id: Uuid) {
+    let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&db.pg)
+        .await;
+}
+
+fn count_tunnels_with_id(body: &serde_json::Value, tunnel_id: Uuid) -> usize {
+    body.as_array()
+        .map(|a| {
+            a.iter()
+                .filter(|t| t["tunnel_id"].as_str() == Some(tunnel_id.to_string().as_str()))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+// Tag a freshly-registered tunnel's owning session with `db_token_id` /
+// `user_id` so the dashboard scope filter can route it to the right
+// tenant. Production wires these up automatically from the auth handshake;
+// tests bypass that path because `TestClient` connects with the admin
+// token, so we patch SessionInfo directly.
+fn assign_session_owner(
+    server: &TestServer,
+    session_id: Uuid,
+    db_token_id: Option<String>,
+    user_id: Option<Uuid>,
+) {
+    let mut entry = server
+        .core
+        .sessions
+        .get_mut(&session_id)
+        .expect("session not found");
+    entry.db_token_id = db_token_id;
+    entry.user_id = user_id;
+}
+
+// ── 1. Two users — each only sees their own tunnels ─────────────────────────
+
+#[tokio::test]
+async fn list_tunnels_filters_to_caller_user() {
+    init_tracing();
+    let server = TestServer::start().await;
+    let http = insecure_http_client();
+    let base = format!("http://127.0.0.1:{}", server.dashboard_port);
+
+    // Two distinct users, each with their own DB token.
+    let user_a = create_user(&server.db, &format!("a-{}@example.com", Uuid::new_v4())).await;
+    let user_b = create_user(&server.db, &format!("b-{}@example.com", Uuid::new_v4())).await;
+    let (token_a_id, token_a_raw) = create_token_for_user(&server.db, "a", Some(user_a)).await;
+    let (token_b_id, token_b_raw) = create_token_for_user(&server.db, "b", Some(user_b)).await;
+
+    // Two clients connect (using the admin token because TestClient's
+    // control-plane auth path doesn't share verify_token with the
+    // dashboard). We then re-tag each session with a DB token so the
+    // dashboard scope filter recognises ownership.
+    let mut client_a = TestClient::connect(&server).await.expect("auth a");
+    let mut client_b = TestClient::connect(&server).await.expect("auth b");
+    let sess_a = client_a.session_id.unwrap();
+    let sess_b = client_b.session_id.unwrap();
+    assign_session_owner(&server, sess_a, Some(token_a_id.clone()), Some(user_a));
+    assign_session_owner(&server, sess_b, Some(token_b_id.clone()), Some(user_b));
+
+    let (tun_a, _, _) = client_a
+        .register_http_tunnel(Some(&format!("a-{}", Uuid::new_v4())))
+        .await
+        .expect("register a");
+    let (tun_b, _, _) = client_b
+        .register_http_tunnel(Some(&format!("b-{}", Uuid::new_v4())))
+        .await
+        .expect("register b");
+
+    // Admin sees both.
+    let resp = http
+        .get(format!("{base}/api/tunnels"))
+        .header("Authorization", format!("Bearer {}", server.admin_token))
+        .send()
+        .await
+        .expect("admin list");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(count_tunnels_with_id(&body, tun_a), 1);
+    assert_eq!(count_tunnels_with_id(&body, tun_b), 1);
+
+    // User A's token sees only A's tunnel.
+    let resp = http
+        .get(format!("{base}/api/tunnels"))
+        .header("Authorization", format!("Bearer {token_a_raw}"))
+        .send()
+        .await
+        .expect("a list");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(count_tunnels_with_id(&body, tun_a), 1);
+    assert_eq!(
+        count_tunnels_with_id(&body, tun_b),
+        0,
+        "user A must not see user B's tunnel"
+    );
+
+    // User B's token sees only B's tunnel.
+    let resp = http
+        .get(format!("{base}/api/tunnels"))
+        .header("Authorization", format!("Bearer {token_b_raw}"))
+        .send()
+        .await
+        .expect("b list");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(count_tunnels_with_id(&body, tun_b), 1);
+    assert_eq!(count_tunnels_with_id(&body, tun_a), 0);
+
+    // Cleanup so other tests on the same shared DB don't see these rows.
+    delete_token(&server.db, &token_a_id).await;
+    delete_token(&server.db, &token_b_id).await;
+    delete_user(&server.db, user_a).await;
+    delete_user(&server.db, user_b).await;
+}
+
+// ── 2. Get-by-ID returns 404 for cross-tenant tunnels ───────────────────────
+
+#[tokio::test]
+async fn get_tunnel_returns_404_for_other_tenant() {
+    init_tracing();
+    let server = TestServer::start().await;
+    let http = insecure_http_client();
+    let base = format!("http://127.0.0.1:{}", server.dashboard_port);
+
+    let user_a = create_user(&server.db, &format!("a-{}@example.com", Uuid::new_v4())).await;
+    let user_b = create_user(&server.db, &format!("b-{}@example.com", Uuid::new_v4())).await;
+    let (token_a_id, token_a_raw) = create_token_for_user(&server.db, "a", Some(user_a)).await;
+    let (token_b_id, token_b_raw) = create_token_for_user(&server.db, "b", Some(user_b)).await;
+
+    let mut client_a = TestClient::connect(&server).await.expect("auth a");
+    let client_b = TestClient::connect(&server).await.expect("auth b");
+    assign_session_owner(
+        &server,
+        client_a.session_id.unwrap(),
+        Some(token_a_id.clone()),
+        Some(user_a),
+    );
+    assign_session_owner(
+        &server,
+        client_b.session_id.unwrap(),
+        Some(token_b_id.clone()),
+        Some(user_b),
+    );
+
+    let (tun_a, _, _) = client_a
+        .register_http_tunnel(Some(&format!("a-{}", Uuid::new_v4())))
+        .await
+        .expect("register a");
+
+    // B asking for A's tunnel must get 404 (not 403 — 404 hides existence).
+    let resp = http
+        .get(format!("{base}/api/tunnels/{tun_a}"))
+        .header("Authorization", format!("Bearer {token_b_raw}"))
+        .send()
+        .await
+        .expect("b get a");
+    assert_eq!(resp.status(), 404, "cross-tenant must 404");
+
+    // A still sees their own.
+    let resp = http
+        .get(format!("{base}/api/tunnels/{tun_a}"))
+        .header("Authorization", format!("Bearer {token_a_raw}"))
+        .send()
+        .await
+        .expect("a get a");
+    assert_eq!(resp.status(), 200);
+
+    // Same rule for `/health-events` and `/udp-sessions`.
+    let resp = http
+        .get(format!("{base}/api/tunnels/{tun_a}/health-events"))
+        .header("Authorization", format!("Bearer {token_b_raw}"))
+        .send()
+        .await
+        .expect("b get health-events");
+    assert_eq!(resp.status(), 404);
+    let resp = http
+        .get(format!("{base}/api/tunnels/{tun_a}/udp-sessions"))
+        .header("Authorization", format!("Bearer {token_b_raw}"))
+        .send()
+        .await
+        .expect("b get udp-sessions");
+    assert_eq!(resp.status(), 404);
+
+    // And requests/replay sub-resources.
+    let resp = http
+        .get(format!("{base}/api/tunnels/{tun_a}/requests"))
+        .header("Authorization", format!("Bearer {token_b_raw}"))
+        .send()
+        .await
+        .expect("b get requests");
+    assert_eq!(resp.status(), 404);
+
+    delete_token(&server.db, &token_a_id).await;
+    delete_token(&server.db, &token_b_id).await;
+    delete_user(&server.db, user_a).await;
+    delete_user(&server.db, user_b).await;
+}
+
+// ── 3. force_close cannot reach other tenants' tunnels ──────────────────────
+
+#[tokio::test]
+async fn force_close_blocked_for_other_tenant() {
+    init_tracing();
+    let server = TestServer::start().await;
+    let http = insecure_http_client();
+    let base = format!("http://127.0.0.1:{}", server.dashboard_port);
+
+    let user_a = create_user(&server.db, &format!("a-{}@example.com", Uuid::new_v4())).await;
+    let user_b = create_user(&server.db, &format!("b-{}@example.com", Uuid::new_v4())).await;
+    let (token_a_id, _token_a_raw) = create_token_for_user(&server.db, "a", Some(user_a)).await;
+    let (token_b_id, token_b_raw) = create_token_for_user(&server.db, "b", Some(user_b)).await;
+
+    let mut client_a = TestClient::connect(&server).await.expect("auth a");
+    let client_b = TestClient::connect(&server).await.expect("auth b");
+    assign_session_owner(
+        &server,
+        client_a.session_id.unwrap(),
+        Some(token_a_id.clone()),
+        Some(user_a),
+    );
+    assign_session_owner(
+        &server,
+        client_b.session_id.unwrap(),
+        Some(token_b_id.clone()),
+        Some(user_b),
+    );
+
+    let (tun_a, _, _) = client_a
+        .register_http_tunnel(Some(&format!("a-{}", Uuid::new_v4())))
+        .await
+        .expect("register a");
+
+    // B's DELETE attempt must 404 and the tunnel must remain.
+    let resp = http
+        .delete(format!("{base}/api/tunnels/{tun_a}"))
+        .header("Authorization", format!("Bearer {token_b_raw}"))
+        .send()
+        .await
+        .expect("b delete a");
+    assert_eq!(resp.status(), 404);
+    assert!(
+        server
+            .core
+            .http_routes
+            .iter()
+            .any(|e| e.value().members.contains_key(&tun_a)),
+        "tunnel must still be live after foreign-tenant DELETE"
+    );
+
+    delete_token(&server.db, &token_a_id).await;
+    delete_token(&server.db, &token_b_id).await;
+    delete_user(&server.db, user_a).await;
+    delete_user(&server.db, user_b).await;
+}
+
+// ── 4. /api/groups: aggregate counters reflect only visible members ─────────
+
+#[tokio::test]
+async fn list_groups_filters_to_caller_user() {
+    init_tracing();
+    let server = TestServer::start_with_load_balancing().await;
+    let http = insecure_http_client();
+    let base = format!("http://127.0.0.1:{}", server.dashboard_port);
+
+    let user_a = create_user(&server.db, &format!("a-{}@example.com", Uuid::new_v4())).await;
+    let user_b = create_user(&server.db, &format!("b-{}@example.com", Uuid::new_v4())).await;
+    let (token_a_id, token_a_raw) = create_token_for_user(&server.db, "a", Some(user_a)).await;
+    let (token_b_id, _token_b_raw) = create_token_for_user(&server.db, "b", Some(user_b)).await;
+
+    let mut client_a = TestClient::connect(&server).await.expect("auth a");
+    let mut client_b = TestClient::connect(&server).await.expect("auth b");
+    assign_session_owner(
+        &server,
+        client_a.session_id.unwrap(),
+        Some(token_a_id.clone()),
+        Some(user_a),
+    );
+    assign_session_owner(
+        &server,
+        client_b.session_id.unwrap(),
+        Some(token_b_id.clone()),
+        Some(user_b),
+    );
+
+    // User A registers a load-balanced group.
+    let group_a = format!("group-a-{}", Uuid::new_v4());
+    let key_a = format!("hash-a-{}", Uuid::new_v4());
+    let (_tun_a, sub_a, _) = client_a
+        .register_http_tunnel_grouped(Some(&format!("sub-a-{}", Uuid::new_v4())), &group_a, &key_a)
+        .await
+        .expect("register a grouped");
+
+    // User B registers a different load-balanced group.
+    let group_b = format!("group-b-{}", Uuid::new_v4());
+    let key_b = format!("hash-b-{}", Uuid::new_v4());
+    let (_tun_b, sub_b, _) = client_b
+        .register_http_tunnel_grouped(Some(&format!("sub-b-{}", Uuid::new_v4())), &group_b, &key_b)
+        .await
+        .expect("register b grouped");
+
+    // Admin sees both groups.
+    let resp = http
+        .get(format!("{base}/api/groups"))
+        .header("Authorization", format!("Bearer {}", server.admin_token))
+        .send()
+        .await
+        .expect("admin list groups");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let labels: Vec<&str> = body
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|g| g["label"].as_str())
+        .collect();
+    assert!(labels.contains(&sub_a.as_str()));
+    assert!(labels.contains(&sub_b.as_str()));
+
+    // User A's token sees only group A.
+    let resp = http
+        .get(format!("{base}/api/groups"))
+        .header("Authorization", format!("Bearer {token_a_raw}"))
+        .send()
+        .await
+        .expect("a list groups");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let arr = body.as_array().unwrap();
+    let a_groups: Vec<&serde_json::Value> = arr
+        .iter()
+        .filter(|g| g["label"].as_str() == Some(sub_a.as_str()))
+        .collect();
+    let b_groups: Vec<&serde_json::Value> = arr
+        .iter()
+        .filter(|g| g["label"].as_str() == Some(sub_b.as_str()))
+        .collect();
+    assert_eq!(a_groups.len(), 1);
+    assert_eq!(
+        b_groups.len(),
+        0,
+        "user A must not see user B's group at all"
+    );
+    // Aggregate counters reflect only A's member.
+    assert_eq!(a_groups[0]["member_count"].as_u64(), Some(1));
+    assert_eq!(a_groups[0]["members"].as_array().unwrap().len(), 1);
+
+    delete_token(&server.db, &token_a_id).await;
+    delete_token(&server.db, &token_b_id).await;
+    delete_user(&server.db, user_a).await;
+    delete_user(&server.db, user_b).await;
+}
+
+// ── 5. No token → 401, even though endpoint is now scope-aware ──────────────
+
+#[tokio::test]
+async fn missing_or_invalid_token_returns_401() {
+    init_tracing();
+    let server = TestServer::start().await;
+    let http = insecure_http_client();
+    let base = format!("http://127.0.0.1:{}", server.dashboard_port);
+
+    // No header.
+    let resp = http
+        .get(format!("{base}/api/tunnels"))
+        .send()
+        .await
+        .expect("no auth");
+    assert_eq!(resp.status(), 401);
+
+    // Bad token.
+    let resp = http
+        .get(format!("{base}/api/tunnels"))
+        .header("Authorization", "Bearer not-a-token")
+        .send()
+        .await
+        .expect("bad auth");
+    assert_eq!(resp.status(), 401);
+}
+
+// ── 6. Legacy DB token (no user_id) is scoped to its own session ────────────
+
+#[tokio::test]
+async fn legacy_token_sees_only_its_own_tunnels() {
+    init_tracing();
+    let server = TestServer::start().await;
+    let http = insecure_http_client();
+    let base = format!("http://127.0.0.1:{}", server.dashboard_port);
+
+    // Two legacy DB tokens (no user_id) and a real user-scoped token.
+    let (legacy_id, legacy_raw) = create_token_for_user(&server.db, "legacy", None).await;
+    let (other_legacy_id, _) = create_token_for_user(&server.db, "other-legacy", None).await;
+
+    let mut client_legacy = TestClient::connect(&server).await.expect("auth legacy");
+    let mut client_other = TestClient::connect(&server).await.expect("auth other");
+    assign_session_owner(
+        &server,
+        client_legacy.session_id.unwrap(),
+        Some(legacy_id.clone()),
+        None,
+    );
+    assign_session_owner(
+        &server,
+        client_other.session_id.unwrap(),
+        Some(other_legacy_id.clone()),
+        None,
+    );
+
+    let (tun_legacy, _, _) = client_legacy
+        .register_http_tunnel(Some(&format!("l-{}", Uuid::new_v4())))
+        .await
+        .expect("register legacy");
+    let (tun_other, _, _) = client_other
+        .register_http_tunnel(Some(&format!("o-{}", Uuid::new_v4())))
+        .await
+        .expect("register other");
+
+    // Legacy caller sees only their own session's tunnel.
+    let resp = http
+        .get(format!("{base}/api/tunnels"))
+        .header("Authorization", format!("Bearer {legacy_raw}"))
+        .send()
+        .await
+        .expect("legacy list");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(count_tunnels_with_id(&body, tun_legacy), 1);
+    assert_eq!(
+        count_tunnels_with_id(&body, tun_other),
+        0,
+        "legacy token must not see other legacy token's tunnels"
+    );
+
+    delete_token(&server.db, &legacy_id).await;
+    delete_token(&server.db, &other_legacy_id).await;
+}
+
+// ── 7. SessionInfo.user_id is populated by the auth handshake ──────────────
+
+#[tokio::test]
+async fn session_info_carries_user_id_after_handshake() {
+    init_tracing();
+    let server = TestServer::start().await;
+
+    let user = create_user(&server.db, &format!("u-{}@example.com", Uuid::new_v4())).await;
+    let (token_id, raw) = create_token_for_user(&server.db, "u", Some(user)).await;
+
+    // Connect with the user-scoped DB token directly so the production
+    // auth path runs end-to-end. require_auth = true is the default.
+    let client = TestClient::connect_with_token(&server, &raw)
+        .await
+        .expect("auth user");
+    let session_id = client.session_id.unwrap();
+
+    let entry = server
+        .core
+        .sessions
+        .get(&session_id)
+        .expect("session present");
+    assert_eq!(
+        entry.user_id,
+        Some(user),
+        "control-plane handshake must populate SessionInfo.user_id from tokens.user_id"
+    );
+    assert_eq!(
+        entry.db_token_id.as_deref(),
+        Some(token_id.as_str()),
+        "control-plane handshake must populate SessionInfo.db_token_id"
+    );
+
+    drop(entry);
+    delete_token(&server.db, &token_id).await;
+    delete_user(&server.db, user).await;
+}
+
+// ── 8. End-to-end: user-scoped DB token, no SessionInfo shim ───────────────
+
+/// Same scenario as test #1 but the user's tunnel is registered through
+/// the production auth handshake (no `assign_session_owner` shim). Proves
+/// the whole pipeline — handshake populates `SessionInfo.user_id`, the
+/// scope filter reads it back, and the dashboard returns the right
+/// rows when the same raw user-scoped token is presented over HTTP.
+#[tokio::test]
+async fn end_to_end_user_token_pipeline() {
+    init_tracing();
+    let server = TestServer::start().await;
+    let http = insecure_http_client();
+    let base = format!("http://127.0.0.1:{}", server.dashboard_port);
+
+    let user = create_user(&server.db, &format!("e2e-{}@example.com", Uuid::new_v4())).await;
+    let (token_id, raw) = create_token_for_user(&server.db, "e2e", Some(user)).await;
+
+    // Admin client registers a foreign tunnel — should NOT appear in
+    // the user's listing.
+    let mut admin = TestClient::connect(&server).await.expect("admin auth");
+    let (foreign_tun, _, _) = admin
+        .register_http_tunnel(Some(&format!("foreign-{}", Uuid::new_v4())))
+        .await
+        .expect("register foreign");
+
+    // User client connects with the user-scoped DB token directly.
+    let mut user_client = TestClient::connect_with_token(&server, &raw)
+        .await
+        .expect("user auth");
+    let (user_tun, _, _) = user_client
+        .register_http_tunnel(Some(&format!("user-{}", Uuid::new_v4())))
+        .await
+        .expect("register user");
+
+    let resp = http
+        .get(format!("{base}/api/tunnels"))
+        .header("Authorization", format!("Bearer {raw}"))
+        .send()
+        .await
+        .expect("user list tunnels");
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        count_tunnels_with_id(&body, user_tun),
+        1,
+        "user must see their own tunnel via the production pipeline"
+    );
+    assert_eq!(
+        count_tunnels_with_id(&body, foreign_tun),
+        0,
+        "user must not see admin-owned tunnels"
+    );
+
+    delete_token(&server.db, &token_id).await;
+    delete_user(&server.db, user).await;
+}


### PR DESCRIPTION
## Summary

- Resolves the bearer token to an `AuthScope { Admin, User(uuid), Token(string) }` and filters every tunnel- and group-facing endpoint accordingly. Admin sees everything (unchanged); a user-scoped DB token (`tokens.user_id IS NOT NULL`) sees only its own tunnels across all of its tokens; legacy tokens with no `user_id` are narrowed to their own session.
- `tokens.user_id` is cached on `SessionInfo` at the control-plane handshake, so the dashboard filter is a pointer comparison — no per-request DB hit.
- Filtering is applied to: `list_tunnels`, `get_tunnel`, `force_close_tunnel`, `tunnel_health_events`, `tunnel_udp_sessions`, `tunnel_p2p_peers`, `tunnel_requests`, `replay_request`, `list_groups`, `group_events_sse` (initial check + per-event filter so a foreign tenant joining the same group later in the stream can't leak events). Tunnels the caller can't see return **404** (not 403) so existence isn't leaked; group aggregate counters reflect only visible members.
- Hard prerequisite for the upcoming tenant-facing LB visibility surface in the user dashboard — the platform side can now safely query `/api/tunnels` and `/api/groups` with a user-scoped token.

## Wire compatibility

Response shapes are unchanged; only the contents are filtered. Admin behaviour is preserved end-to-end, including `force_close_tunnel`'s historical idempotent 204-on-unknown-id (the new ownership lookup short-circuits for admin).

## Test plan

- [x] `make check` (fmt + clippy `-D warnings`) clean
- [x] `cargo test --workspace` (64 unit + ~120 integration tests) green
- [x] New `tests/integration/dashboard_scope.rs` — 8 tests covering:
  - admin sees both users' tunnels; each user sees only their own
  - cross-tenant `GET /api/tunnels/:id` / health-events / udp-sessions / requests all return 404
  - cross-tenant `DELETE /api/tunnels/:id` returns 404 and the target tunnel survives
  - `/api/groups` filters per-user and aggregate counters reflect only visible members
  - missing/invalid tokens still return 401
  - legacy DB token (no `user_id`) is narrowed to its own session
  - control-plane handshake populates `SessionInfo.user_id` from `tokens.user_id`
  - end-to-end pipeline with a real user-scoped token, no test shims
- [ ] Manual smoke: hit `/api/tunnels` on a dev edge with admin token → see all; with a DB token tied to a user → see only that user's tunnels

## Follow-ups (out of scope here)

A code-review pass surfaced **pre-existing** security holes that share the same threat model but weren't introduced by TUNNEL-1:

- **`/api/history`** (the SQL-backed tunnel registration log) is still unfiltered.
- **`/api/tokens`** (`GET` leaks the whole table; `DELETE /api/tokens/:id` is an active cross-tenant privilege escalation; `POST` mints unscoped legacy tokens).

These get strictly worse the moment platform-api starts handing out user-scoped DB tokens — i.e. the very thing this PR unblocks. Recommend gating `/api/tokens` mutations on `require_admin` (platform-api owns user-token CRUD) and adding the same scope filter to `/api/history` and the `GET /api/tokens` list. Tracked as separate tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)