### PR TITLE
fix(tests): wait for every public listener; clean up tunnel_log on user delete

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -501,21 +501,33 @@ impl TestServer {
         });
         task_handles.push(h.abort_handle());
 
-        // Wait until the control plane is actually accepting TCP connections.
+        // Wait until every public listener is actually accepting TCP
+        // connections — control plane, HTTP edge, HTTPS edge, dashboard.
         // A fixed sleep is unreliable on CI; polling eliminates the race.
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            if tokio::net::TcpStream::connect(format!("127.0.0.1:{control_port}"))
-                .await
-                .is_ok()
-            {
-                break;
+        // We poll all four ports because the four background tasks bind
+        // their listeners independently. On a slow runner the test
+        // client can outrun the HTTPS bind and get ECONNREFUSED if we
+        // only wait for the control port.
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        for (label, port) in [
+            ("control plane", control_port),
+            ("http edge", http_port),
+            ("https edge", https_port),
+            ("dashboard", dashboard_port),
+        ] {
+            loop {
+                if tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+                    .await
+                    .is_ok()
+                {
+                    break;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "{label} did not start within 10 seconds"
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
             }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "server control plane did not start within 5 seconds"
-            );
-            tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
         Self {

--- a/tests/integration/dashboard_scope.rs
+++ b/tests/integration/dashboard_scope.rs
@@ -70,6 +70,15 @@ async fn delete_token(db: &rustunnel_server::db::Db, token_id: &str) {
 }
 
 async fn delete_user(db: &rustunnel_server::db::Db, user_id: Uuid) {
+    // `tunnel_log.user_id` is a FK to `users.id` (RESTRICT on default).
+    // Tests register tunnels through the production handshake, which
+    // writes a tunnel_log row referencing the user — so we have to
+    // strip those refs before we can remove the user. Otherwise the
+    // DELETE silently fails and the row leaks into the shared CI DB.
+    let _ = sqlx::query("DELETE FROM tunnel_log WHERE user_id = $1")
+        .bind(user_id)
+        .execute(&db.pg)
+        .await;
     let _ = sqlx::query("DELETE FROM users WHERE id = $1")
         .bind(user_id)
         .execute(&db.pg)


### PR DESCRIPTION
## Summary

Two test-only fixes that surfaced after TUNNEL-1 ([#72](https://github.com/joaoh82/rustunnel/pull/72)) landed.

### 1. CI flake in `http_tunnel_proxies_hello_world`

[Run 25443471690](https://github.com/joaoh82/rustunnel/actions/runs/25443471690) failed with `ECONNREFUSED` connecting to the HTTPS port. Root cause is in `tests/common/mod.rs::start_with_opts` — the readiness loop only polls the control port, but the HTTP / HTTPS / dashboard listeners are spawned in parallel and may not be bound when the test client connects. The same code passed twice in a row before failing on the next commit; classic timing race.

Fix: poll **all four** public ports (control, http, https, dashboard) before returning, with a 10s deadline.

This race pre-dates TUNNEL-1, but the 8 new dashboard_scope tests added enough parallel-server-startup pressure to expose it.

### 2. FK violation leaking `users` rows on cleanup

The Postgres service log on the same failed run shows:

```
ERROR:  update or delete on table "users" violates foreign key constraint "tunnel_log_user_id_fkey"
DETAIL: Key (id)=(...) is still referenced from table "tunnel_log".
STATEMENT:  DELETE FROM users WHERE id = $1
```

That's `dashboard_scope::delete_user`. The new e2e test (and #7's handshake test) register tunnels through the production handshake, which writes a `tunnel_log` row with a `user_id` FK reference. The cleanup helper used `let _ = ...await;` so the FK violation was swallowed but `users` rows leaked into the shared CI database run after run.

Fix: strip the dependent `tunnel_log` rows before deleting the user.

## Test plan

- [x] `make check` clean
- [x] Full `cargo test --workspace` green locally (64 unit + ~120 integration)
- [x] No production code touched — these are purely changes to `tests/`
- [ ] Confirm the next CI run on `main` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)