### PR TITLE
TUNNEL-14: add publish metadata to crates (unblocks first crates.io publish)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ socket2 = { version = "0.5", features = ["all"] }
 quinn = "0.11"
 sentry = { version = "0.47", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls", "tracing", "logs"] }
 sentry-tracing = "0.47"
-rustunnel-protocol = { path = "crates/rustunnel-protocol" }
+rustunnel-protocol = { path = "crates/rustunnel-protocol", version = "0.7.8" }

--- a/crates/rustunnel-client/Cargo.toml
+++ b/crates/rustunnel-client/Cargo.toml
@@ -2,6 +2,13 @@
 name = "rustunnel-client"
 version = "0.7.8"
 edition = "2021"
+description = "CLI client for rustunnel — open-source secure tunnel server. Expose local HTTP/HTTPS/TCP/UDP services from your machine to a public URL."
+keywords = ["tunnel", "ngrok", "cli", "webhook", "reverse-proxy"]
+categories = ["command-line-utilities", "network-programming", "development-tools"]
+license = "AGPL-3.0"
+repository = "https://github.com/joaoh82/rustunnel"
+homepage = "https://rustunnel.com"
+readme = "../../README.md"
 
 [[bin]]
 name = "rustunnel"

--- a/crates/rustunnel-mcp/Cargo.toml
+++ b/crates/rustunnel-mcp/Cargo.toml
@@ -2,6 +2,13 @@
 name = "rustunnel-mcp"
 version = "0.7.8"
 edition = "2021"
+description = "MCP (Model Context Protocol) server for rustunnel. Lets AI agents (Claude Code, Cursor, Windsurf) create and manage public tunnels to local services from inside an agent session."
+keywords = ["mcp", "tunnel", "claude", "ai-agent", "webhook"]
+categories = ["network-programming", "command-line-utilities", "development-tools"]
+license = "AGPL-3.0"
+repository = "https://github.com/joaoh82/rustunnel"
+homepage = "https://rustunnel.com"
+readme = "../../README.md"
 
 [[bin]]
 name = "rustunnel-mcp"

--- a/crates/rustunnel-protocol/Cargo.toml
+++ b/crates/rustunnel-protocol/Cargo.toml
@@ -2,6 +2,13 @@
 name = "rustunnel-protocol"
 version = "0.7.8"
 edition = "2021"
+description = "Shared protocol types for rustunnel — the open-source secure tunnel server. Used by rustunnel-server, rustunnel-client, and rustunnel-mcp."
+keywords = ["tunnel", "ngrok", "protocol", "rustunnel"]
+categories = ["network-programming", "data-structures"]
+license = "AGPL-3.0"
+repository = "https://github.com/joaoh82/rustunnel"
+homepage = "https://rustunnel.com"
+readme = "../../README.md"
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/rustunnel-server/Cargo.toml
+++ b/crates/rustunnel-server/Cargo.toml
@@ -2,6 +2,13 @@
 name = "rustunnel-server"
 version = "0.7.8"
 edition = "2021"
+description = "Self-hosted, secure tunnel server in Rust. Exposes local HTTP/HTTPS/TCP/UDP services via TLS-encrypted WebSocket. Open-source ngrok alternative with multi-region and Prometheus metrics."
+keywords = ["tunnel", "ngrok", "self-hosted", "reverse-proxy", "webhook"]
+categories = ["network-programming", "web-programming::http-server", "command-line-utilities"]
+license = "AGPL-3.0"
+repository = "https://github.com/joaoh82/rustunnel"
+homepage = "https://rustunnel.com"
+readme = "../../README.md"
 
 [lib]
 name = "rustunnel_server"


### PR DESCRIPTION
## Summary

Unblocks the first crates.io publish of `rustunnel-protocol`, `rustunnel-server`, `rustunnel-client`, and `rustunnel-mcp` — needed for the **TUNNEL-14** off-page SEO work (crates.io + lib.rs listings are a high-value backlink surface, especially for AI-driven discovery).

The action plan in `rustunnel-web/web/seo/off-page-action-plan.md` § 0.2 had the per-crate metadata diff, but two things were missing for a first publish:
1. The workspace `rustunnel-protocol` path dep needed `version = "..."` — cargo enforces this on every dep at publish time.
2. `rustunnel-protocol` itself needed full publish metadata (description, license, repository, etc.) — it'll be published too, since the other three crates depend on it.

## Changes

- **`Cargo.toml`** — workspace dep `rustunnel-protocol = { path = "...", version = "0.7.8" }`. `path` stays for local builds; `version` is what crates.io sees.
- **`crates/rustunnel-protocol/Cargo.toml`** — full publish metadata (description, keywords, categories, license, repository, homepage, readme).
- **`crates/rustunnel-server/Cargo.toml`** — same metadata block (per off-page-action-plan § 0.2).
- **`crates/rustunnel-client/Cargo.toml`** — same.
- **`crates/rustunnel-mcp/Cargo.toml`** — same.

All 4 crates use `readme = "../../README.md"` to reuse the workspace root README.

## Verification

- [x] `cargo check --workspace` — all 4 crates compile cleanly
- [x] `cargo publish --dry-run -p rustunnel-protocol` — passes (packages, builds, aborts at upload as expected)
- [x] `cargo publish --dry-run -p rustunnel-mcp` — passes (no internal deps)
- [ ] `cargo publish --dry-run -p rustunnel-server` / `rustunnel-client` — manifests are valid (packaging starts cleanly), but full dry-run requires `rustunnel-protocol` to be on crates.io first
- [x] `make check` (fmt + clippy) — pre-push hook passed

## Publish order (after merge)

```bash
cargo publish -p rustunnel-protocol     # first — no internal deps
# wait ~30-60s for crates.io to index
cargo publish -p rustunnel-server
cargo publish -p rustunnel-client
cargo publish -p rustunnel-mcp          # can go anytime (no internal deps)
```

## Refs

- TUNNEL-14 (marvinapp)
- Companion PR: joaoh82/rustunnel-web#27 (off-page SEO scaffolding)
- Follow-up: update `rustunnel-web/web/seo/off-page-action-plan.md` § 0.2 to add the workspace-dep edit + the `rustunnel-protocol` metadata block (the plan's original diff was incomplete for a first publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)