### PR TITLE
Full MCP feature parity + multi-harness agent integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+Guidance for AI agents working in or with this repository.
+
+> Building/working **on** this codebase? See [`CLAUDE.md`](./CLAUDE.md) for build,
+> test, and lint commands and the architecture overview.
+
+## Using rustunnel as a tool (expose local services)
+
+rustunnel ships an **MCP server** (`rustunnel-mcp`) that lets you open public
+tunnels to local services — HTTP, TCP, UDP, peer-to-peer, and load-balanced
+pools — directly from an agent session.
+
+**To make rustunnel available in your harness** (Claude Code, Claude Desktop,
+Codex, Cursor, Windsurf, Cline, or a custom MCP client), follow
+[`docs/agent-integration.md`](./docs/agent-integration.md), or run:
+
+```bash
+./integrations/install.sh        # prompts for your API token, writes the config
+```
+
+### One-time setup the user must do
+
+rustunnel needs an **API token**. If one isn't already configured (via the
+`RUSTUNNEL_TOKEN` env var in the MCP config, or `~/.rustunnel/config.yml`), ask
+the user for it once:
+
+> "Get a free rustunnel token at https://rustunnel.com → Dashboard → API Keys,
+> then add it as `RUSTUNNEL_TOKEN` in your MCP config."
+
+Once `RUSTUNNEL_TOKEN` is set you don't need to pass `token` on tool calls, and
+you should not ask for it again.
+
+### What you can do (MCP tools)
+
+- `create_tunnel` — open a tunnel, get a public URL. Supports:
+  - `protocol`: `http`, `tcp`, `udp`, `p2p`
+  - `subdomain`, `region`, `local_host`
+  - **P2P**: `secret` + `peer_name` (publish) or `peer_target` (connect)
+  - **Load balancing**: `group` + `group_key` (http/tcp), optional `health_check`
+- `close_tunnel`, `list_tunnels`, `get_tunnel_history`, `list_regions`
+- `get_connection_info` — the CLI command/config for environments where the
+  agent can't spawn subprocesses (cloud sandboxes)
+
+Prefer the MCP tools over the raw `rustunnel` CLI — they manage the tunnel
+lifecycle and clean up automatically.
+
+See [`docs/mcp-server.md`](./docs/mcp-server.md) for the full tool reference and
+the [`skills/rustunnel/SKILL.md`](./skills/rustunnel/SKILL.md) skill for workflow
+examples.

--- a/README.md
+++ b/README.md
@@ -961,6 +961,14 @@ rustunnel ships a `rustunnel-mcp` binary that implements the
 letting AI agents (Claude, GPT-4o, custom agents) open and manage tunnels
 without any manual intervention.
 
+**Works with any MCP harness.** For copy-paste config for Claude Code, Claude
+Desktop, Codex, Cursor, Windsurf, Cline, and custom agents — plus a one-command
+installer — see the **[Agent Integration Guide](docs/agent-integration.md)**:
+
+```bash
+./integrations/install.sh        # prompts for your token, writes the config
+```
+
 ### Quick setup (Claude Desktop — hosted server)
 
 ```json
@@ -971,17 +979,20 @@ without any manual intervention.
       "args": [
         "--server", "edge.rustunnel.com:4040",
         "--api",    "https://edge.rustunnel.com:8443"
-      ]
+      ],
+      "env": { "RUSTUNNEL_TOKEN": "<your-token>" }
     }
   }
 }
 ```
 
+Set `RUSTUNNEL_TOKEN` once and the agent never has to pass a token on a tool call.
+
 ### Available tools
 
 | Tool | Description |
 |------|-------------|
-| `create_tunnel` | Spawn a tunnel and return the public URL |
+| `create_tunnel` | Open a tunnel and return the public URL — HTTP/TCP/UDP, P2P, and load-balanced pools with health checks |
 | `list_tunnels` | List all active tunnels |
 | `close_tunnel` | Force-close a tunnel by ID |
 | `list_regions` | List available server regions |

--- a/crates/rustunnel-mcp/src/main.rs
+++ b/crates/rustunnel-mcp/src/main.rs
@@ -19,11 +19,16 @@
 //!     "rustunnel": {
 //!       "command": "rustunnel-mcp",
 //!       "args": ["--server", "tunnel.example.com:4040",
-//!                "--api",    "https://tunnel.example.com:8443"]
+//!                "--api",    "https://tunnel.example.com:8443"],
+//!       "env": { "RUSTUNNEL_TOKEN": "<your-token>" }
 //!     }
 //!   }
 //! }
 //! ```
+//!
+//! The `RUSTUNNEL_TOKEN` environment variable, when set, is used as the
+//! default API token for every tool call — agents only need it configured
+//! once here rather than passing `token` on each request.
 
 mod api_client;
 mod mcp;
@@ -76,6 +81,10 @@ pub struct State {
     pub tunnel_manager: TunnelManager,
     /// Whether to pass --insecure to the CLI.
     pub insecure: bool,
+    /// Default API token, read from the `RUSTUNNEL_TOKEN` environment variable
+    /// at startup. Used as a fallback when a tool call omits the `token`
+    /// argument, so agents don't have to pass the token on every call.
+    pub token: Option<String>,
 }
 
 // ── entry point ───────────────────────────────────────────────────────────────
@@ -93,11 +102,19 @@ async fn main() {
 
     let cli = Cli::parse();
 
+    // A token supplied via RUSTUNNEL_TOKEN becomes the default for every tool
+    // call, so the agent only needs the token configured once (in the MCP
+    // client config) rather than passing it on each request.
+    let env_token = std::env::var("RUSTUNNEL_TOKEN")
+        .ok()
+        .filter(|t| !t.trim().is_empty());
+
     let state = Arc::new(State {
         server_addr: cli.server,
         api: ApiClient::new(&cli.api, cli.insecure),
         tunnel_manager: TunnelManager::new(),
         insecure: cli.insecure,
+        token: env_token,
     });
 
     run(state).await;

--- a/crates/rustunnel-mcp/src/tools.rs
+++ b/crates/rustunnel-mcp/src/tools.rs
@@ -1,14 +1,24 @@
 //! Tool definitions, input schemas, and execution logic for all MCP tools.
 //!
 //! Tools implemented here:
-//!   - `create_tunnel`       — spawns `rustunnel` CLI and polls API for the URL
-//!   - `list_tunnels`        — GET /api/tunnels wrapper
-//!   - `close_tunnel`        — DELETE /api/tunnels/:id + kills spawned process
-//!   - `get_connection_info` — returns CLI command string (no API call)
-//!   - `list_regions`        — GET /api/regions wrapper
-//!   - `get_tunnel_history`  — GET /api/history wrapper
+//!   - `create_tunnel` — spawns the `rustunnel` CLI and polls the API for the
+//!     URL. Supports HTTP/TCP/UDP, P2P (peer-to-peer with a shared secret), and
+//!     load-balanced groups with optional health checks.
+//!   - `list_tunnels` — GET /api/tunnels wrapper
+//!   - `close_tunnel` — DELETE /api/tunnels/:id + kills spawned process
+//!   - `get_connection_info` — returns CLI command / config (no API call)
+//!   - `list_regions` — GET /api/regions wrapper
+//!   - `get_tunnel_history` — GET /api/history wrapper
+//!
+//! ## Authentication
+//!
+//! Every authenticated tool accepts an optional `token` argument. When omitted,
+//! the token configured via the `RUSTUNNEL_TOKEN` environment variable (read at
+//! startup into [`State::token`]) is used. This lets an agent configure the
+//! token once in its MCP client config instead of passing it on every call.
 
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -29,46 +39,84 @@ macro_rules! req_str {
     };
 }
 
+/// Guidance returned when no token can be resolved from the argument or env.
+const NO_TOKEN_HELP: &str = "No API token available. Set the RUSTUNNEL_TOKEN \
+    environment variable in your MCP client config, or pass a `token` argument. \
+    Get a free token at https://rustunnel.com (Dashboard → API Keys), or for a \
+    self-hosted server create one with `rustunnel token create`.";
+
+/// Choose a token: an explicit argument wins, otherwise fall back to the
+/// environment-configured default. Pure so it can be unit-tested.
+fn pick_token(arg: Option<&str>, env: Option<&str>) -> Option<String> {
+    arg.filter(|t| !t.trim().is_empty())
+        .or(env.filter(|t| !t.trim().is_empty()))
+        .map(str::to_string)
+}
+
+/// Resolve the API token for a tool call from the `token` argument or the
+/// `RUSTUNNEL_TOKEN`-derived default.
+fn resolve_token(args: &Value, state: &State) -> Option<String> {
+    pick_token(
+        args.get("token").and_then(Value::as_str),
+        state.token.as_deref(),
+    )
+}
+
 // ── tool definitions (returned by tools/list) ─────────────────────────────────
 
 pub fn tool_definitions() -> Vec<Value> {
+    let health_check_schema = serde_json::json!({
+        "type": "object",
+        "description": "Optional client-side health probe. The client probes the \
+            local service and reports health so the server routes around a sick \
+            backend. Only meaningful for load-balanced tunnels (group set).",
+        "properties": {
+            "type":          { "type": "string", "enum": ["tcp", "http"], "description": "Probe kind: 'tcp' opens a connection, 'http' issues a GET" },
+            "path":          { "type": "string", "description": "Path to GET (required when type='http'), e.g. /health" },
+            "interval_secs": { "type": "integer", "description": "Probe period in seconds (default 10)" },
+            "timeout_secs":  { "type": "integer", "description": "Per-probe timeout in seconds (default 3)" },
+            "max_failed":    { "type": "integer", "description": "Consecutive failures before marking unhealthy (default 3)" },
+            "expect_2xx":    { "type": "boolean", "description": "When false, any HTTP response counts as healthy (default true)" },
+            "alert_webhook": { "type": "string", "description": "URL the server POSTs to when this tunnel's group drops to 0 healthy members" }
+        },
+        "required": ["type"]
+    });
+
     vec![
         serde_json::json!({
             "name": "create_tunnel",
             "description": "Open a tunnel to a locally running service and get a public URL. \
-                Requires a valid API token. Spawns the rustunnel CLI as a subprocess — the \
-                tunnel stays open until close_tunnel is called or the MCP server exits. \
-                Use protocol='http' for web services (returns an https:// URL), \
-                protocol='tcp' for databases, SSH, or raw TCP (returns a host:port).",
+                Spawns the rustunnel CLI as a subprocess — the tunnel stays open until \
+                close_tunnel is called or the MCP server exits.\n\
+                \n\
+                Modes:\n\
+                - protocol='http'  → public https:// URL (web/API services)\n\
+                - protocol='tcp'   → public host:port (databases, SSH, raw TCP)\n\
+                - protocol='udp'   → public host:port (game servers, DNS)\n\
+                - protocol='p2p'   → peer-to-peer; requires `secret` plus `peer_name` \
+                                     (to publish) or `peer_target` (to connect)\n\
+                - load balancing   → set `group` + `group_key` (http/tcp only) to join \
+                                     this tunnel into a load-balanced pool; add \
+                                     `health_check` to auto-remove sick backends.\n\
+                \n\
+                The token may be omitted if RUSTUNNEL_TOKEN is configured.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "token": {
-                        "type": "string",
-                        "description": "API token for authentication"
-                    },
-                    "local_port": {
-                        "type": "integer",
-                        "description": "Local port the service is listening on, e.g. 3000"
-                    },
-                    "protocol": {
-                        "type": "string",
-                        "enum": ["http", "tcp", "udp", "p2p"],
-                        "description": "Use 'http' for web/API services, 'tcp' for databases or SSH, 'udp' for game servers or DNS, 'p2p' for peer-to-peer connections"
-                    },
-                    "subdomain": {
-                        "type": "string",
-                        "description": "Optional custom subdomain for HTTP tunnels. \
-                            Server assigns a random one if omitted."
-                    },
-                    "region": {
-                        "type": "string",
-                        "description": "Optional region ID (e.g. 'eu', 'us', 'ap'). \
-                            Omit to let the client auto-select the nearest region by latency. \
-                            Use list_regions to see available regions."
-                    }
+                    "token":      { "type": "string", "description": "API token. Optional if RUSTUNNEL_TOKEN is set in the MCP client config." },
+                    "local_port": { "type": "integer", "description": "Local port the service is listening on, e.g. 3000" },
+                    "protocol":   { "type": "string", "enum": ["http", "tcp", "udp", "p2p"], "description": "Tunnel type" },
+                    "subdomain":  { "type": "string", "description": "Custom subdomain (HTTP tunnels only). Server assigns a random one if omitted." },
+                    "region":     { "type": "string", "description": "Region ID (e.g. 'eu', 'us', 'ap'). Omit to auto-select the nearest by latency. Use list_regions to see options." },
+                    "local_host": { "type": "string", "description": "Local hostname to forward to (default 'localhost'). Use to expose a service on another host in your network." },
+                    "secret":     { "type": "string", "description": "Shared secret for P2P (protocol='p2p'). Publisher and subscriber must use the same value." },
+                    "peer_name":  { "type": "string", "description": "P2P publisher mode: publish the local service under this name." },
+                    "peer_target":{ "type": "string", "description": "P2P subscriber mode: connect to a published P2P tunnel with this name." },
+                    "group":      { "type": "string", "description": "Load-balancing pool name. Tunnels sharing the same (group, group_key) form one pool (http/tcp only)." },
+                    "group_key":  { "type": "string", "description": "Shared secret for the load-balancing group. Members of one pool must agree on this value." },
+                    "health_check": health_check_schema
                 },
-                "required": ["token", "local_port", "protocol"]
+                "required": ["local_port", "protocol"]
             }
         }),
         serde_json::json!({
@@ -79,12 +127,8 @@ pub fn tool_definitions() -> Vec<Value> {
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "token": {
-                        "type": "string",
-                        "description": "API token for authentication"
-                    }
-                },
-                "required": ["token"]
+                    "token": { "type": "string", "description": "API token. Optional if RUSTUNNEL_TOKEN is set." }
+                }
             }
         }),
         serde_json::json!({
@@ -94,56 +138,43 @@ pub fn tool_definitions() -> Vec<Value> {
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "token": {
-                        "type": "string",
-                        "description": "API token for authentication"
-                    },
-                    "tunnel_id": {
-                        "type": "string",
-                        "description": "UUID of the tunnel to close"
-                    }
+                    "token":     { "type": "string", "description": "API token. Optional if RUSTUNNEL_TOKEN is set." },
+                    "tunnel_id": { "type": "string", "description": "UUID of the tunnel to close" }
                 },
-                "required": ["token", "tunnel_id"]
+                "required": ["tunnel_id"]
             }
         }),
         serde_json::json!({
             "name": "get_connection_info",
-            "description": "Get the CLI command needed to create a tunnel manually. Use this \
-                when the MCP server cannot spawn subprocesses (e.g. cloud sandbox) or when \
-                you prefer to run the client yourself.",
+            "description": "Get the CLI command (and, for load-balanced tunnels, a config file) \
+                needed to create a tunnel manually — without spawning anything. Use this when the \
+                MCP server cannot spawn subprocesses (e.g. cloud sandbox) or when you prefer to \
+                run the client yourself. Accepts the same arguments as create_tunnel.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "token": {
-                        "type": "string",
-                        "description": "API token for authentication"
-                    },
-                    "local_port": {
-                        "type": "integer",
-                        "description": "Local port the service is listening on"
-                    },
-                    "protocol": {
-                        "type": "string",
-                        "enum": ["http", "tcp", "udp", "p2p"],
-                        "description": "Tunnel protocol"
-                    },
-                    "region": {
-                        "type": "string",
-                        "description": "Optional region ID (e.g. 'eu', 'us', 'ap'). \
-                            Omit to let the client auto-select."
-                    }
+                    "token":      { "type": "string", "description": "API token. Optional if RUSTUNNEL_TOKEN is set." },
+                    "local_port": { "type": "integer", "description": "Local port the service is listening on" },
+                    "protocol":   { "type": "string", "enum": ["http", "tcp", "udp", "p2p"], "description": "Tunnel type" },
+                    "subdomain":  { "type": "string", "description": "Custom subdomain (HTTP only)" },
+                    "region":     { "type": "string", "description": "Region ID (e.g. 'eu', 'us', 'ap'). Omit to auto-select." },
+                    "local_host": { "type": "string", "description": "Local hostname to forward to (default 'localhost')" },
+                    "secret":     { "type": "string", "description": "Shared secret for P2P (protocol='p2p')" },
+                    "peer_name":  { "type": "string", "description": "P2P publisher mode: publish under this name" },
+                    "peer_target":{ "type": "string", "description": "P2P subscriber mode: connect to this name" },
+                    "group":      { "type": "string", "description": "Load-balancing pool name (http/tcp only)" },
+                    "group_key":  { "type": "string", "description": "Shared secret for the load-balancing group" },
+                    "health_check": health_check_schema
                 },
-                "required": ["token", "local_port", "protocol"]
+                "required": ["local_port", "protocol"]
             }
         }),
         serde_json::json!({
             "name": "list_regions",
             "description": "List available tunnel server regions with their IDs, names, \
-                and locations. Use this to pick a specific region for create_tunnel.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {}
-            }
+                and locations. Use this to pick a specific region for create_tunnel. \
+                No authentication required.",
+            "inputSchema": { "type": "object", "properties": {} }
         }),
         serde_json::json!({
             "name": "get_tunnel_history",
@@ -152,22 +183,10 @@ pub fn tool_definitions() -> Vec<Value> {
             "inputSchema": {
                 "type": "object",
                 "properties": {
-                    "token": {
-                        "type": "string",
-                        "description": "API token for authentication"
-                    },
-                    "protocol": {
-                        "type": "string",
-                        "enum": ["http", "tcp", "udp", "p2p"],
-                        "description": "Optional: filter by protocol. Omit for all."
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "default": 25,
-                        "description": "Maximum number of entries to return"
-                    }
-                },
-                "required": ["token"]
+                    "token":    { "type": "string", "description": "API token. Optional if RUSTUNNEL_TOKEN is set." },
+                    "protocol": { "type": "string", "enum": ["http", "tcp", "udp", "p2p"], "description": "Optional: filter by protocol. Omit for all." },
+                    "limit":    { "type": "integer", "default": 25, "description": "Maximum number of entries to return" }
+                }
             }
         }),
     ]
@@ -187,57 +206,341 @@ pub async fn dispatch(name: &str, args: &Value, state: &Arc<State>) -> Value {
     }
 }
 
-// ── tool implementations ──────────────────────────────────────────────────────
+// ── command / config builders (pure, unit-tested) ─────────────────────────────
 
-async fn create_tunnel(args: &Value, state: &Arc<State>) -> Value {
-    let token = req_str!(args, "token");
-    let protocol = req_str!(args, "protocol");
+/// Build the `rustunnel <proto> <port> ...` argument vector for an inline
+/// HTTP/TCP/UDP tunnel (everything after the binary name).
+#[allow(clippy::too_many_arguments)]
+fn build_inline_args(
+    protocol: &str,
+    local_port: u64,
+    server: &str,
+    token: &str,
+    insecure: bool,
+    subdomain: Option<&str>,
+    region: Option<&str>,
+    local_host: Option<&str>,
+) -> Vec<String> {
+    let mut a = vec![
+        protocol.to_string(),
+        local_port.to_string(),
+        "--server".into(),
+        server.into(),
+        "--token".into(),
+        token.into(),
+    ];
+    if insecure {
+        a.push("--insecure".into());
+    }
+    if let Some(s) = subdomain {
+        a.push("--subdomain".into());
+        a.push(s.into());
+    }
+    if let Some(r) = region {
+        a.push("--region".into());
+        a.push(r.into());
+    }
+    if let Some(h) = local_host {
+        a.push("--local_host".into());
+        a.push(h.into());
+    }
+    a
+}
 
-    let local_port = match args.get("local_port").and_then(Value::as_u64) {
-        Some(p) => p,
-        None => return tool_err("missing required argument: local_port"),
+/// Build the `rustunnel p2p <port> ...` argument vector. Returns an error
+/// string when the required P2P arguments are missing or contradictory.
+#[allow(clippy::too_many_arguments)]
+fn build_p2p_args(
+    local_port: u64,
+    server: &str,
+    token: &str,
+    insecure: bool,
+    secret: Option<&str>,
+    peer_name: Option<&str>,
+    peer_target: Option<&str>,
+    region: Option<&str>,
+    local_host: Option<&str>,
+) -> Result<Vec<String>, String> {
+    let secret = secret.filter(|s| !s.is_empty()).ok_or_else(|| {
+        "P2P tunnels require a `secret` (publisher and subscriber must match).".to_string()
+    })?;
+
+    let mut a = vec![
+        "p2p".to_string(),
+        local_port.to_string(),
+        "--secret".into(),
+        secret.into(),
+        "--server".into(),
+        server.into(),
+        "--token".into(),
+        token.into(),
+    ];
+
+    match (peer_name, peer_target) {
+        (Some(n), None) => {
+            a.push("--name".into());
+            a.push(n.into());
+        }
+        (None, Some(t)) => {
+            a.push("--target".into());
+            a.push(t.into());
+        }
+        (Some(_), Some(_)) => {
+            return Err("P2P: set either `peer_name` (publish) or `peer_target` \
+                (connect), not both."
+                .into())
+        }
+        (None, None) => {
+            return Err(
+                "P2P: set `peer_name` to publish a service, or `peer_target` \
+                to connect to one."
+                    .into(),
+            )
+        }
+    }
+
+    if insecure {
+        a.push("--insecure".into());
+    }
+    if let Some(r) = region {
+        a.push("--region".into());
+        a.push(r.into());
+    }
+    if let Some(h) = local_host {
+        a.push("--local_host".into());
+        a.push(h.into());
+    }
+    Ok(a)
+}
+
+/// Double-quote and escape a string for safe embedding as a YAML scalar.
+fn yaml_str(s: &str) -> String {
+    let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+/// Render the indented `health_check:` field lines (6-space indent) from the
+/// `health_check` argument object. Returns an empty string when `hc` is not an
+/// object. Pure so it can be unit-tested.
+fn health_check_yaml(hc: &Value) -> String {
+    let Some(map) = hc.as_object() else {
+        return String::new();
     };
+    let mut out = String::from("    health_check:\n");
+    if let Some(t) = map.get("type").and_then(Value::as_str) {
+        out.push_str(&format!("      type: {}\n", yaml_str(t)));
+    }
+    if let Some(p) = map.get("path").and_then(Value::as_str) {
+        out.push_str(&format!("      path: {}\n", yaml_str(p)));
+    }
+    for (key, json_key) in [
+        ("interval_secs", "interval_secs"),
+        ("timeout_secs", "timeout_secs"),
+        ("max_failed", "max_failed"),
+    ] {
+        if let Some(n) = map.get(json_key).and_then(Value::as_u64) {
+            out.push_str(&format!("      {key}: {n}\n"));
+        }
+    }
+    if let Some(b) = map.get("expect_2xx").and_then(Value::as_bool) {
+        out.push_str(&format!("      expect_2xx: {b}\n"));
+    }
+    if let Some(w) = map.get("alert_webhook").and_then(Value::as_str) {
+        out.push_str(&format!("      alert_webhook: {}\n", yaml_str(w)));
+    }
+    out
+}
+
+/// Build a `rustunnel start` config file for one load-balanced tunnel member.
+/// Pure so it can be unit-tested.
+#[allow(clippy::too_many_arguments)]
+fn build_lb_config_yaml(
+    server: &str,
+    token: &str,
+    insecure: bool,
+    protocol: &str,
+    local_port: u64,
+    local_host: Option<&str>,
+    subdomain: Option<&str>,
+    region: Option<&str>,
+    group: &str,
+    group_key: &str,
+    health_check: Option<&Value>,
+) -> String {
+    let mut out = String::from("# Generated by rustunnel-mcp for a load-balanced tunnel.\n");
+    out.push_str(&format!("server: {}\n", yaml_str(server)));
+    out.push_str(&format!("auth_token: {}\n", yaml_str(token)));
+    if insecure {
+        out.push_str("insecure: true\n");
+    }
+    if let Some(r) = region {
+        out.push_str(&format!("region: {}\n", yaml_str(r)));
+    }
+    out.push_str("\ntunnels:\n  lb:\n");
+    out.push_str(&format!("    proto: {protocol}\n"));
+    out.push_str(&format!("    local_port: {local_port}\n"));
+    out.push_str(&format!(
+        "    local_host: {}\n",
+        yaml_str(local_host.unwrap_or("localhost"))
+    ));
+    if let Some(s) = subdomain {
+        out.push_str(&format!("    subdomain: {}\n", yaml_str(s)));
+    }
+    out.push_str(&format!("    group: {}\n", yaml_str(group)));
+    out.push_str(&format!("    group_key: {}\n", yaml_str(group_key)));
+    if let Some(hc) = health_check {
+        out.push_str(&health_check_yaml(hc));
+    }
+    out
+}
+
+/// Generate a unique temp path for a load-balanced tunnel's config file.
+fn temp_config_path() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "rustunnel-mcp-{}-{nanos}-{n}.yml",
+        std::process::id()
+    ))
+}
+
+/// Plan: the CLI args to run and an optional temp config file backing them.
+struct SpawnPlan {
+    args: Vec<String>,
+    temp_config: Option<PathBuf>,
+}
+
+/// Decide how to launch `rustunnel` for a create_tunnel / get_connection_info
+/// request. Writes a temp config file for load-balanced tunnels.
+fn plan_spawn(args: &Value, token: &str, state: &State) -> Result<SpawnPlan, String> {
+    let protocol = args
+        .get("protocol")
+        .and_then(Value::as_str)
+        .ok_or("missing required argument: protocol")?;
+    let local_port = args
+        .get("local_port")
+        .and_then(Value::as_u64)
+        .ok_or("missing required argument: local_port")?;
 
     let subdomain = args.get("subdomain").and_then(Value::as_str);
     let region = args.get("region").and_then(Value::as_str);
+    let local_host = args.get("local_host").and_then(Value::as_str);
+    let group = args.get("group").and_then(Value::as_str);
+    let group_key = args.get("group_key").and_then(Value::as_str);
+    let health_check = args.get("health_check").filter(|v| v.is_object());
 
-    // Snapshot existing tunnel IDs before spawning so we can identify the new one.
-    let before_ids: HashSet<String> = match state.api.list_tunnels(token).await {
-        Ok(ts) => ts.iter().map(|t| t.tunnel_id.clone()).collect(),
-        Err(e) => return tool_err(format!("failed to query current tunnels: {e}")),
+    // Load-balanced tunnel: requires group + group_key, only http/tcp.
+    if group.is_some() || group_key.is_some() {
+        let group = group.ok_or("load balancing requires `group`")?;
+        let group_key = group_key.ok_or("load balancing requires `group_key`")?;
+        if protocol != "http" && protocol != "tcp" {
+            return Err("load balancing is only supported for http and tcp tunnels".into());
+        }
+        let yaml = build_lb_config_yaml(
+            &state.server_addr,
+            token,
+            state.insecure,
+            protocol,
+            local_port,
+            local_host,
+            subdomain,
+            region,
+            group,
+            group_key,
+            health_check,
+        );
+        let path = temp_config_path();
+        std::fs::write(&path, yaml)
+            .map_err(|e| format!("failed to write temp config {}: {e}", path.display()))?;
+        let args = vec![
+            "start".to_string(),
+            "--config".into(),
+            path.to_string_lossy().into_owned(),
+        ];
+        return Ok(SpawnPlan {
+            args,
+            temp_config: Some(path),
+        });
+    }
+
+    // P2P tunnel.
+    if protocol == "p2p" {
+        let cli = build_p2p_args(
+            local_port,
+            &state.server_addr,
+            token,
+            state.insecure,
+            args.get("secret").and_then(Value::as_str),
+            args.get("peer_name").and_then(Value::as_str),
+            args.get("peer_target").and_then(Value::as_str),
+            region,
+            local_host,
+        )?;
+        return Ok(SpawnPlan {
+            args: cli,
+            temp_config: None,
+        });
+    }
+
+    // Plain HTTP/TCP/UDP tunnel.
+    let cli = build_inline_args(
+        protocol,
+        local_port,
+        &state.server_addr,
+        token,
+        state.insecure,
+        subdomain,
+        region,
+        local_host,
+    );
+    Ok(SpawnPlan {
+        args: cli,
+        temp_config: None,
+    })
+}
+
+// ── tool implementations ──────────────────────────────────────────────────────
+
+async fn create_tunnel(args: &Value, state: &Arc<State>) -> Value {
+    let token = match resolve_token(args, state) {
+        Some(t) => t,
+        None => return tool_err(NO_TOKEN_HELP),
     };
 
-    // Build the CLI command.
+    let plan = match plan_spawn(args, &token, state) {
+        Ok(p) => p,
+        Err(e) => return tool_err(e),
+    };
+
+    // Snapshot existing tunnel IDs before spawning so we can identify the new one.
+    let before_ids: HashSet<String> = match state.api.list_tunnels(&token).await {
+        Ok(ts) => ts.iter().map(|t| t.tunnel_id.clone()).collect(),
+        Err(e) => {
+            cleanup_temp(&plan.temp_config);
+            return tool_err(format!("failed to query current tunnels: {e}"));
+        }
+    };
+
+    // Build and spawn the CLI command.
     let mut cmd = tokio::process::Command::new("rustunnel");
-    cmd.arg(protocol)
-        .arg(local_port.to_string())
-        .arg("--server")
-        .arg(&state.server_addr)
-        .arg("--token")
-        .arg(token)
+    cmd.args(&plan.args)
         // Suppress CLI output so it doesn't interfere with MCP stdio.
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null());
 
-    if state.insecure {
-        cmd.arg("--insecure");
-    }
-
-    if let Some(sub) = subdomain {
-        cmd.arg("--subdomain").arg(sub);
-    }
-
-    if let Some(r) = region {
-        cmd.arg("--region").arg(r);
-    }
-
     let mut child_opt = match cmd.spawn() {
         Ok(c) => Some(c),
         Err(e) => {
+            cleanup_temp(&plan.temp_config);
             return tool_err(format!(
                 "failed to spawn rustunnel: {e}. \
                 Is the 'rustunnel' binary installed and in PATH?"
-            ))
+            ));
         }
     };
 
@@ -245,7 +548,7 @@ async fn create_tunnel(args: &Value, state: &Arc<State>) -> Value {
     for _ in 0..30 {
         tokio::time::sleep(Duration::from_millis(500)).await;
 
-        match state.api.list_tunnels(token).await {
+        match state.api.list_tunnels(&token).await {
             Ok(tunnels) => {
                 let new = tunnels
                     .into_iter()
@@ -255,7 +558,11 @@ async fn create_tunnel(args: &Value, state: &Arc<State>) -> Value {
                     let tunnel_id = tunnel.tunnel_id.clone();
                     state
                         .tunnel_manager
-                        .insert(tunnel_id.clone(), child_opt.take().unwrap())
+                        .insert(
+                            tunnel_id.clone(),
+                            child_opt.take().unwrap(),
+                            plan.temp_config.clone(),
+                        )
                         .await;
 
                     return tool_ok(
@@ -274,10 +581,11 @@ async fn create_tunnel(args: &Value, state: &Arc<State>) -> Value {
         }
     }
 
-    // Timeout — kill the subprocess to avoid a leaked process.
+    // Timeout — kill the subprocess and remove the temp config to avoid leaks.
     if let Some(mut child) = child_opt {
         let _ = child.start_kill();
     }
+    cleanup_temp(&plan.temp_config);
 
     tool_err(
         "timeout: tunnel did not appear within 15 seconds. \
@@ -285,24 +593,36 @@ async fn create_tunnel(args: &Value, state: &Arc<State>) -> Value {
     )
 }
 
-async fn list_tunnels(args: &Value, state: &Arc<State>) -> Value {
-    let token = req_str!(args, "token");
+fn cleanup_temp(path: &Option<PathBuf>) {
+    if let Some(p) = path {
+        let _ = std::fs::remove_file(p);
+    }
+}
 
-    match state.api.list_tunnels(token).await {
+async fn list_tunnels(args: &Value, state: &Arc<State>) -> Value {
+    let token = match resolve_token(args, state) {
+        Some(t) => t,
+        None => return tool_err(NO_TOKEN_HELP),
+    };
+
+    match state.api.list_tunnels(&token).await {
         Ok(tunnels) => tool_ok(serde_json::to_string_pretty(&tunnels).unwrap()),
         Err(e) => tool_err(format!("API error: {e}")),
     }
 }
 
 async fn close_tunnel(args: &Value, state: &Arc<State>) -> Value {
-    let token = req_str!(args, "token");
+    let token = match resolve_token(args, state) {
+        Some(t) => t,
+        None => return tool_err(NO_TOKEN_HELP),
+    };
     let tunnel_id = req_str!(args, "tunnel_id");
 
     // Kill the spawned process if we were the ones that opened this tunnel.
     state.tunnel_manager.kill(tunnel_id).await;
 
     // Close via the REST API (authoritative close — removes it from routing).
-    match state.api.close_tunnel(token, tunnel_id).await {
+    match state.api.close_tunnel(&token, tunnel_id).await {
         Ok(204) | Ok(200) => tool_ok("Tunnel closed successfully."),
         Ok(404) => tool_err("Tunnel not found. It may have already been closed."),
         Ok(401) => tool_err("Authentication failed — check your token."),
@@ -312,33 +632,40 @@ async fn close_tunnel(args: &Value, state: &Arc<State>) -> Value {
 }
 
 fn get_connection_info(args: &Value, state: &Arc<State>) -> Value {
-    let token = req_str!(args, "token");
-    let protocol = req_str!(args, "protocol");
-    let region = args.get("region").and_then(Value::as_str);
-
-    let local_port = match args.get("local_port").and_then(Value::as_u64) {
-        Some(p) => p,
-        None => return tool_err("missing required argument: local_port"),
+    let token = match resolve_token(args, state) {
+        Some(t) => t,
+        None => return tool_err(NO_TOKEN_HELP),
     };
 
-    let mut cmd = format!(
-        "rustunnel {protocol} {local_port} --server {} --token {token}",
-        state.server_addr
-    );
-    if let Some(r) = region {
-        cmd.push_str(&format!(" --region {r}"));
-    }
-    if state.insecure {
-        cmd.push_str(" --insecure");
-    }
+    let plan = match plan_spawn(args, &token, state) {
+        Ok(p) => p,
+        Err(e) => return tool_err(e),
+    };
+
+    let cli_command = format!("rustunnel {}", plan.args.join(" "));
 
     let mut info = serde_json::json!({
-        "cli_command":  cmd,
-        "server":       state.server_addr,
-        "install_url":  "https://github.com/joaoh82/rustunnel/releases/latest"
+        "cli_command": cli_command,
+        "server":      state.server_addr,
+        "install_url": "https://github.com/joaoh82/rustunnel/releases/latest",
     });
-    if let Some(r) = region {
-        info["region"] = serde_json::Value::String(r.to_string());
+
+    // For a load-balanced tunnel the args reference a temp file; surface the
+    // config contents and a stable path the user can save it to instead.
+    if let Some(path) = &plan.temp_config {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            info["config_yaml"] = Value::String(contents);
+            info["cli_command"] = Value::String(
+                "rustunnel start --config ~/.rustunnel/lb.yml  # save config_yaml there first"
+                    .to_string(),
+            );
+        }
+        // This was only generated to render the command; remove it now.
+        let _ = std::fs::remove_file(path);
+    }
+
+    if let Some(r) = args.get("region").and_then(Value::as_str) {
+        info["region"] = Value::String(r.to_string());
     }
 
     tool_ok(serde_json::to_string_pretty(&info).unwrap())
@@ -352,12 +679,209 @@ async fn list_regions(state: &Arc<State>) -> Value {
 }
 
 async fn get_tunnel_history(args: &Value, state: &Arc<State>) -> Value {
-    let token = req_str!(args, "token");
+    let token = match resolve_token(args, state) {
+        Some(t) => t,
+        None => return tool_err(NO_TOKEN_HELP),
+    };
     let limit = args.get("limit").and_then(Value::as_u64).unwrap_or(25);
     let protocol = args.get("protocol").and_then(Value::as_str);
 
-    match state.api.get_history(token, limit, protocol).await {
+    match state.api.get_history(&token, limit, protocol).await {
         Ok(history) => tool_ok(serde_json::to_string_pretty(&history).unwrap()),
         Err(e) => tool_err(format!("API error: {e}")),
+    }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn pick_token_prefers_argument() {
+        assert_eq!(
+            pick_token(Some("arg"), Some("env")),
+            Some("arg".to_string())
+        );
+    }
+
+    #[test]
+    fn pick_token_falls_back_to_env() {
+        assert_eq!(pick_token(None, Some("env")), Some("env".to_string()));
+        assert_eq!(pick_token(Some(""), Some("env")), Some("env".to_string()));
+        assert_eq!(pick_token(Some("  "), Some("env")), Some("env".to_string()));
+    }
+
+    #[test]
+    fn pick_token_none_when_unset() {
+        assert_eq!(pick_token(None, None), None);
+        assert_eq!(pick_token(Some(""), Some("  ")), None);
+    }
+
+    #[test]
+    fn inline_args_minimal() {
+        let a = build_inline_args("http", 3000, "srv:4040", "tok", false, None, None, None);
+        assert_eq!(
+            a,
+            vec!["http", "3000", "--server", "srv:4040", "--token", "tok"]
+        );
+    }
+
+    #[test]
+    fn inline_args_full() {
+        let a = build_inline_args(
+            "http",
+            5173,
+            "srv:4040",
+            "tok",
+            true,
+            Some("myapp"),
+            Some("eu"),
+            Some("0.0.0.0"),
+        );
+        assert!(a.contains(&"--insecure".to_string()));
+        assert!(a.windows(2).any(|w| w == ["--subdomain", "myapp"]));
+        assert!(a.windows(2).any(|w| w == ["--region", "eu"]));
+        assert!(a.windows(2).any(|w| w == ["--local_host", "0.0.0.0"]));
+    }
+
+    #[test]
+    fn p2p_publisher_args() {
+        let a = build_p2p_args(
+            3000,
+            "srv:4040",
+            "tok",
+            false,
+            Some("s3cret"),
+            Some("my-svc"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(a[0], "p2p");
+        assert!(a.windows(2).any(|w| w == ["--secret", "s3cret"]));
+        assert!(a.windows(2).any(|w| w == ["--name", "my-svc"]));
+        assert!(!a.iter().any(|x| x == "--target"));
+    }
+
+    #[test]
+    fn p2p_subscriber_args() {
+        let a = build_p2p_args(
+            8000,
+            "srv:4040",
+            "tok",
+            false,
+            Some("s3cret"),
+            None,
+            Some("my-svc"),
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(a.windows(2).any(|w| w == ["--target", "my-svc"]));
+        assert!(!a.iter().any(|x| x == "--name"));
+    }
+
+    #[test]
+    fn p2p_requires_secret() {
+        let err = build_p2p_args(
+            3000,
+            "srv",
+            "tok",
+            false,
+            None,
+            Some("svc"),
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("secret"));
+    }
+
+    #[test]
+    fn p2p_requires_peer_role() {
+        let err = build_p2p_args(3000, "srv", "tok", false, Some("s"), None, None, None, None)
+            .unwrap_err();
+        assert!(err.contains("peer_name") || err.contains("peer_target"));
+
+        let err = build_p2p_args(
+            3000,
+            "srv",
+            "tok",
+            false,
+            Some("s"),
+            Some("a"),
+            Some("b"),
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("not both"));
+    }
+
+    #[test]
+    fn lb_config_yaml_contains_group_and_health() {
+        let hc = json!({
+            "type": "http",
+            "path": "/health",
+            "interval_secs": 5,
+            "expect_2xx": false
+        });
+        let yaml = build_lb_config_yaml(
+            "srv:4040",
+            "tok",
+            false,
+            "http",
+            3000,
+            None,
+            Some("pool"),
+            None,
+            "web",
+            "shared-key",
+            Some(&hc),
+        );
+        assert!(yaml.contains("auth_token: \"tok\""));
+        assert!(yaml.contains("server: \"srv:4040\""));
+        assert!(yaml.contains("proto: http"));
+        assert!(yaml.contains("group: \"web\""));
+        assert!(yaml.contains("group_key: \"shared-key\""));
+        assert!(yaml.contains("subdomain: \"pool\""));
+        assert!(yaml.contains("health_check:"));
+        assert!(yaml.contains("type: \"http\""));
+        assert!(yaml.contains("path: \"/health\""));
+        assert!(yaml.contains("interval_secs: 5"));
+        assert!(yaml.contains("expect_2xx: false"));
+        // No region line when none requested.
+        assert!(!yaml.contains("region:"));
+    }
+
+    #[test]
+    fn lb_config_yaml_insecure_and_region() {
+        let yaml = build_lb_config_yaml(
+            "localhost:4040",
+            "tok",
+            true,
+            "tcp",
+            5432,
+            Some("db.internal"),
+            None,
+            Some("eu"),
+            "dbpool",
+            "k",
+            None,
+        );
+        assert!(yaml.contains("insecure: true"));
+        assert!(yaml.contains("region: \"eu\""));
+        assert!(yaml.contains("local_host: \"db.internal\""));
+        assert!(!yaml.contains("health_check:"));
+    }
+
+    #[test]
+    fn yaml_str_escapes() {
+        assert_eq!(yaml_str("a\"b\\c"), "\"a\\\"b\\\\c\"");
     }
 }

--- a/crates/rustunnel-mcp/src/tunnel_manager.rs
+++ b/crates/rustunnel-mcp/src/tunnel_manager.rs
@@ -1,12 +1,26 @@
 //! Tracks spawned `rustunnel` CLI subprocesses so they can be killed when a
 //! tunnel is closed or when the MCP server exits.
+//!
+//! Load-balanced tunnels are started via `rustunnel start --config <tmp>`,
+//! so each tracked process may also own a temporary config file that must be
+//! removed when the process is killed.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
+
 use tokio::process::Child;
 use tokio::sync::Mutex;
 
+/// A spawned CLI process plus any temporary file it owns.
+struct Tracked {
+    child: Child,
+    /// Temp config file written for load-balanced tunnels (`rustunnel start`).
+    /// Removed when the process is killed.
+    temp_config: Option<PathBuf>,
+}
+
 pub struct TunnelManager {
-    processes: Mutex<HashMap<String, Child>>,
+    processes: Mutex<HashMap<String, Tracked>>,
 }
 
 impl Default for TunnelManager {
@@ -22,17 +36,24 @@ impl TunnelManager {
         }
     }
 
-    /// Register a child process for the given tunnel ID.
-    pub async fn insert(&self, tunnel_id: String, child: Child) {
-        self.processes.lock().await.insert(tunnel_id, child);
+    /// Register a child process for the given tunnel ID, optionally tracking a
+    /// temporary config file to delete when the process is killed.
+    pub async fn insert(&self, tunnel_id: String, child: Child, temp_config: Option<PathBuf>) {
+        self.processes
+            .lock()
+            .await
+            .insert(tunnel_id, Tracked { child, temp_config });
     }
 
     /// Kill the process associated with `tunnel_id`, if one exists.
     /// Returns `true` if a process was found and signalled.
     pub async fn kill(&self, tunnel_id: &str) -> bool {
         let mut guard = self.processes.lock().await;
-        if let Some(mut child) = guard.remove(tunnel_id) {
-            let _ = child.start_kill();
+        if let Some(mut tracked) = guard.remove(tunnel_id) {
+            let _ = tracked.child.start_kill();
+            if let Some(path) = tracked.temp_config.take() {
+                let _ = std::fs::remove_file(path);
+            }
             true
         } else {
             false
@@ -42,8 +63,11 @@ impl TunnelManager {
     /// Kill all tracked processes. Called on server shutdown.
     pub async fn kill_all(&self) {
         let mut guard = self.processes.lock().await;
-        for (_, mut child) in guard.drain() {
-            let _ = child.start_kill();
+        for (_, mut tracked) in guard.drain() {
+            let _ = tracked.child.start_kill();
+            if let Some(path) = tracked.temp_config.take() {
+                let _ = std::fs::remove_file(path);
+            }
         }
     }
 }

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,0 +1,210 @@
+# Using rustunnel from an AI agent / LLM harness
+
+rustunnel ships an **MCP server** (`rustunnel-mcp`) that exposes tunnel
+management as tools any [Model Context Protocol](https://modelcontextprotocol.io)
+client can call. Once it's wired into your harness, you can just say:
+
+> "Create an HTTP tunnel to my service on port 3000."
+> "Expose port 5432 over TCP so I can reach my database."
+> "Spin up a load-balanced pool across ports 3000 and 3001 with a health check."
+
+This guide is the one-stop reference for adding rustunnel to **Claude Code,
+Claude Desktop, Codex, Cursor, Windsurf, Cline, or any custom/MCP agent**.
+
+---
+
+## 1. Prerequisites
+
+You need two binaries on your `PATH`:
+
+- `rustunnel` — the client (the MCP server spawns it to open tunnels)
+- `rustunnel-mcp` — the MCP server itself
+
+```bash
+# Homebrew (macOS / Linux)
+brew tap joaoh82/rustunnel && brew install rustunnel
+
+# Or build from source
+git clone https://github.com/joaoh82/rustunnel.git && cd rustunnel
+make release          # builds rustunnel, rustunnel-server, rustunnel-mcp
+sudo install -m755 target/release/rustunnel     /usr/local/bin/rustunnel
+sudo install -m755 target/release/rustunnel-mcp /usr/local/bin/rustunnel-mcp
+```
+
+## 2. Get an API token (one-time)
+
+rustunnel requires an API token. **You only need to do this once.**
+
+- **Hosted (rustunnel.com):** sign up free at <https://rustunnel.com> →
+  **Dashboard → API Keys** → create a key. No waiting list.
+- **Self-hosted:** `rustunnel token create --name agent --server <host>:4040 --admin_token <admin>`,
+  or create one from your dashboard.
+
+Set it as `RUSTUNNEL_TOKEN` in the MCP config below. When that variable is set,
+the agent never has to pass the token on individual calls.
+
+## 3. The two server settings
+
+| Setting | Hosted example | Self-hosted example | Local dev |
+|---------|----------------|---------------------|-----------|
+| `--server` (control plane) | `eu.edge.rustunnel.com:4040` | `tunnel.example.com:4040` | `localhost:4040` |
+| `--api` (dashboard REST API) | `https://eu.edge.rustunnel.com:8443` | `https://tunnel.example.com:8443` | `http://localhost:4041` |
+
+Add `--insecure` only for local dev with self-signed certs.
+
+---
+
+## 4. Quick install (any harness)
+
+The installer prompts for your token and writes the right config for the harness
+you pick:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/joaoh82/rustunnel/main/integrations/install.sh | bash
+# or, from a clone:
+./integrations/install.sh
+```
+
+It supports `claude-code`, `claude-desktop`, `codex`, `cursor`, `windsurf`,
+`cline`, and `generic` (prints a snippet). Run `./integrations/install.sh --help`
+for non-interactive flags.
+
+---
+
+## 5. Per-harness configuration
+
+Ready-to-edit templates live in [`integrations/`](../integrations/).
+
+### Claude Code
+
+**Plugin (recommended — zero config):**
+```
+/plugin install rustunnel
+/plugin configure rustunnel     # prompts for server, API URL, token
+```
+See [claude-plugin.md](./claude-plugin.md).
+
+**Manual `.mcp.json`** in your project root — see
+[`integrations/claude-code/.mcp.json`](../integrations/claude-code/.mcp.json):
+```json
+{
+  "mcpServers": {
+    "rustunnel": {
+      "command": "rustunnel-mcp",
+      "args": ["--server", "eu.edge.rustunnel.com:4040", "--api", "https://eu.edge.rustunnel.com:8443"],
+      "env": { "RUSTUNNEL_TOKEN": "<your-token>" }
+    }
+  }
+}
+```
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or
+`%APPDATA%\Claude\claude_desktop_config.json` (Windows) — template:
+[`integrations/claude-desktop/config.json`](../integrations/claude-desktop/config.json).
+Same `mcpServers` shape as above.
+
+### Codex (OpenAI)
+
+Codex reads MCP servers from `~/.codex/config.toml`. Template:
+[`integrations/codex/config.toml`](../integrations/codex/config.toml).
+```toml
+[mcp_servers.rustunnel]
+command = "rustunnel-mcp"
+args = ["--server", "eu.edge.rustunnel.com:4040", "--api", "https://eu.edge.rustunnel.com:8443"]
+env = { RUSTUNNEL_TOKEN = "<your-token>" }
+```
+Codex also reads an [`AGENTS.md`](../AGENTS.md) at the repo root for guidance.
+
+### Cursor
+
+Project: `.cursor/mcp.json`. Global: `~/.cursor/mcp.json`. Template:
+[`integrations/cursor/mcp.json`](../integrations/cursor/mcp.json). Same `mcpServers` shape.
+
+### Windsurf
+
+`~/.codeium/windsurf/mcp_config.json`. Template:
+[`integrations/windsurf/mcp_config.json`](../integrations/windsurf/mcp_config.json). Same shape.
+
+### Cline (VS Code)
+
+`cline_mcp_settings.json` (via the Cline MCP settings UI). Template:
+[`integrations/cline/cline_mcp_settings.json`](../integrations/cline/cline_mcp_settings.json). Same shape.
+
+### Generic / custom agent
+
+Any MCP client uses the same `command` + `args` + `env`. Template:
+[`integrations/generic/mcp.json`](../integrations/generic/mcp.json).
+
+For a programmatic agent, spawn `rustunnel-mcp` and speak newline-delimited
+JSON-RPC 2.0 over stdin/stdout:
+
+```python
+import subprocess, json, os
+
+proc = subprocess.Popen(
+    ["rustunnel-mcp", "--server", "eu.edge.rustunnel.com:4040",
+     "--api", "https://eu.edge.rustunnel.com:8443"],
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+    env={**os.environ, "RUSTUNNEL_TOKEN": "<your-token>"},
+)
+
+def call(method, params=None, _id=[0]):
+    _id[0] += 1
+    msg = {"jsonrpc": "2.0", "id": _id[0], "method": method}
+    if params: msg["params"] = params
+    proc.stdin.write(json.dumps(msg).encode() + b"\n"); proc.stdin.flush()
+    return json.loads(proc.stdout.readline())
+
+call("initialize", {"protocolVersion": "2024-11-05"})
+print(call("tools/call", {"name": "create_tunnel",
+      "arguments": {"local_port": 3000, "protocol": "http"}}))
+```
+
+---
+
+## 6. Available tools
+
+Every authenticated tool accepts an optional `token` argument; omit it when
+`RUSTUNNEL_TOKEN` is set.
+
+| Tool | Purpose |
+|------|---------|
+| `create_tunnel` | Open a tunnel and get a public URL. HTTP/TCP/UDP, P2P, and load-balanced pools |
+| `close_tunnel` | Close a tunnel by ID |
+| `list_tunnels` | List active tunnels |
+| `get_tunnel_history` | Past tunnel activity (audit) |
+| `list_regions` | Available server regions (no auth) |
+| `get_connection_info` | CLI command / config for manual runs (cloud sandboxes) |
+
+### `create_tunnel` arguments
+
+| Argument | When | Description |
+|----------|------|-------------|
+| `local_port` | always | Local port the service listens on |
+| `protocol` | always | `http`, `tcp`, `udp`, or `p2p` |
+| `token` | optional | Falls back to `RUSTUNNEL_TOKEN` |
+| `subdomain` | http | Custom subdomain |
+| `region` | optional | `eu` / `us` / `ap`; omit to auto-select |
+| `local_host` | optional | Forward to another host (default `localhost`) |
+| `secret` | p2p | Shared secret (publisher and subscriber match) |
+| `peer_name` | p2p publish | Publish under this name |
+| `peer_target` | p2p connect | Connect to this published name |
+| `group` + `group_key` | load balancing | Join a pool (http/tcp); members share the key |
+| `health_check` | optional | `{ type: tcp\|http, path, interval_secs, timeout_secs, max_failed, expect_2xx, alert_webhook }` |
+
+See [mcp-server.md](./mcp-server.md) for the full tool reference,
+[load-balancing.md](./load-balancing.md) for pools/health checks, and
+[p2p-tunnels.md](./p2p-tunnels.md) for peer-to-peer details.
+
+---
+
+## 7. Security notes
+
+- Tokens travel to the server over HTTPS. Use `--insecure` only in local dev.
+- The `RUSTUNNEL_TOKEN` env var keeps the token out of tool-call payloads and
+  chat history — prefer it over passing `token` inline.
+- Child `rustunnel` processes spawned by `create_tunnel` are killed when the MCP
+  server exits; temp config files for load-balanced tunnels are cleaned up too.
+- Protect any config file you save: `chmod 600 ~/.rustunnel/config.yml`.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -5,6 +5,12 @@ The `rustunnel-mcp` binary implements the
 stdio, letting AI agents (Claude, GPT-4o, Gemini, custom agents) manage
 tunnels without any manual setup.
 
+> **Just want to wire rustunnel into your harness?** See
+> [agent-integration.md](./agent-integration.md) for copy-paste config for
+> Claude Code, Claude Desktop, Codex, Cursor, Windsurf, Cline, and generic MCP
+> clients, plus a one-command installer (`integrations/install.sh`). This page
+> is the deeper reference for the server and its tools.
+
 ---
 
 ## How it works
@@ -201,15 +207,23 @@ def call(method, params=None, id=1):
 
 ### `create_tunnel`
 
-Open a tunnel to a locally running service and get a public URL.
+Open a tunnel to a locally running service and get a public URL. Handles plain
+HTTP/TCP/UDP tunnels, peer-to-peer tunnels, and load-balanced pools.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `token` | string | yes | API token for authentication |
+| `token` | string | no¹ | API token. ¹Optional when `RUSTUNNEL_TOKEN` is set in the MCP config. |
 | `local_port` | integer | yes | Local port the service is listening on |
-| `protocol` | `"http"` \| `"tcp"` | yes | Tunnel type |
+| `protocol` | `"http"` \| `"tcp"` \| `"udp"` \| `"p2p"` | yes | Tunnel type |
 | `subdomain` | string | no | Custom subdomain for HTTP tunnels |
 | `region` | string | no | Region ID (e.g. `"eu"`, `"us"`, `"ap"`). Omit to auto-select by latency. Use `list_regions` to see options. |
+| `local_host` | string | no | Local hostname to forward to (default `localhost`) |
+| `secret` | string | p2p | Shared P2P secret — publisher and subscriber must match |
+| `peer_name` | string | p2p publish | Publish the local service under this name |
+| `peer_target` | string | p2p connect | Connect to a published P2P tunnel by this name |
+| `group` | string | LB | Load-balancing pool name (http/tcp only) |
+| `group_key` | string | LB | Shared secret for the pool; members must agree |
+| `health_check` | object | no | `{ type: "tcp"\|"http", path, interval_secs, timeout_secs, max_failed, expect_2xx, alert_webhook }` |
 
 **Returns:**
 ```json
@@ -221,11 +235,17 @@ Open a tunnel to a locally running service and get a public URL.
 ```
 
 The MCP server spawns `rustunnel` as a background subprocess and polls the API
-until the tunnel appears (up to 15 seconds). The tunnel stays open until
-`close_tunnel` is called or the MCP server exits.
+until the tunnel appears (up to 15 seconds). Load-balanced tunnels are launched
+via a temporary `rustunnel start` config that is cleaned up automatically. The
+tunnel stays open until `close_tunnel` is called or the MCP server exits.
 
-**Example agent prompt:**
-> "Expose my local server on port 3000 using token abc123."
+**Example agent prompts:**
+> "Expose my local server on port 3000."
+> "Open a P2P tunnel to port 3000 named `my-svc` with secret `hunter2`."
+> "Load-balance ports 3000 and 3001 under subdomain `pool` with an HTTP health check on `/health`."
+
+> **Tip:** set `RUSTUNNEL_TOKEN` once in the MCP config (see the examples above)
+> so you never have to pass `token` on a tool call.
 
 ---
 
@@ -235,7 +255,7 @@ List all currently active tunnels.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `token` | string | yes | API token for authentication |
+| `token` | string | no | API token (optional if `RUSTUNNEL_TOKEN` is set) |
 
 **Returns:** JSON array of tunnel objects from `GET /api/tunnels`.
 
@@ -247,23 +267,26 @@ Force-close a tunnel. The public URL stops working immediately.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `token` | string | yes | API token |
+| `token` | string | no | API token (optional if `RUSTUNNEL_TOKEN` is set) |
 | `tunnel_id` | string | yes | UUID returned by `create_tunnel` or `list_tunnels` |
 
 ---
 
 ### `get_connection_info`
 
-Returns the CLI command string without spawning anything. Use this when the
-MCP server cannot launch subprocesses (cloud sandboxes, containers) or when
-you want to run the CLI yourself.
+Returns the CLI command (and, for load-balanced tunnels, a config file) without
+spawning anything. Use this when the MCP server cannot launch subprocesses
+(cloud sandboxes, containers) or when you want to run the CLI yourself. Accepts
+the **same arguments as `create_tunnel`** (`local_host`, `secret`/`peer_name`/
+`peer_target` for P2P, `group`/`group_key`/`health_check` for load balancing).
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `token` | string | yes | API token |
+| `token` | string | no¹ | API token (¹optional if `RUSTUNNEL_TOKEN` is set) |
 | `local_port` | integer | yes | Local port to expose |
-| `protocol` | `"http"` \| `"tcp"` | yes | Tunnel type |
+| `protocol` | `"http"` \| `"tcp"` \| `"udp"` \| `"p2p"` | yes | Tunnel type |
 | `region` | string | no | Region ID (e.g. `"eu"`, `"us"`). Omit to auto-select. |
+| … | | | plus the optional `create_tunnel` args above |
 
 **Returns:**
 ```json
@@ -301,8 +324,8 @@ Retrieve the history of past tunnels.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `token` | string | yes | API token |
-| `protocol` | `"http"` \| `"tcp"` | no | Filter by protocol |
+| `token` | string | no | API token (optional if `RUSTUNNEL_TOKEN` is set) |
+| `protocol` | `"http"` \| `"tcp"` \| `"udp"` \| `"p2p"` | no | Filter by protocol |
 | `limit` | integer | no | Max entries to return (default: 25) |
 
 ---

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,42 @@
+# rustunnel — agent / harness integrations
+
+Drop-in MCP configuration for connecting rustunnel to AI coding agents, plus a
+one-command installer. Full guide:
+[`docs/agent-integration.md`](../docs/agent-integration.md).
+
+## Quick start
+
+```bash
+./install.sh                 # interactive: pick a harness, paste your token
+./install.sh --harness codex --token rt_xxx
+./install.sh --help
+```
+
+The installer prompts for your API token (get one free at
+<https://rustunnel.com> → Dashboard → API Keys) and writes the right config for
+the harness you choose.
+
+## Templates
+
+| Harness | Template | Config location |
+|---------|----------|-----------------|
+| Claude Code | [`claude-code/.mcp.json`](claude-code/.mcp.json) | `<project>/.mcp.json` (or use the plugin) |
+| Claude Desktop | [`claude-desktop/config.json`](claude-desktop/config.json) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Codex | [`codex/config.toml`](codex/config.toml) | `~/.codex/config.toml` |
+| Cursor | [`cursor/mcp.json`](cursor/mcp.json) | `.cursor/mcp.json` or `~/.cursor/mcp.json` |
+| Windsurf | [`windsurf/mcp_config.json`](windsurf/mcp_config.json) | `~/.codeium/windsurf/mcp_config.json` |
+| Cline | [`cline/cline_mcp_settings.json`](cline/cline_mcp_settings.json) | via the Cline MCP settings UI |
+| Generic / custom | [`generic/mcp.json`](generic/mcp.json) | your client's MCP settings |
+
+In every template, replace `REPLACE_WITH_YOUR_TOKEN` with your API token, and
+swap the `--server` / `--api` values if you self-host (add `--insecure` for
+local self-signed certs).
+
+## Prerequisites
+
+The `rustunnel` and `rustunnel-mcp` binaries must be on your `PATH`:
+
+```bash
+brew tap joaoh82/rustunnel && brew install rustunnel
+# or: make release  (from a clone)
+```

--- a/integrations/claude-code/.mcp.json
+++ b/integrations/claude-code/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "rustunnel": {
+      "command": "rustunnel-mcp",
+      "args": [
+        "--server", "eu.edge.rustunnel.com:4040",
+        "--api", "https://eu.edge.rustunnel.com:8443"
+      ],
+      "env": {
+        "RUSTUNNEL_TOKEN": "REPLACE_WITH_YOUR_TOKEN"
+      }
+    }
+  }
+}

--- a/integrations/claude-desktop/config.json
+++ b/integrations/claude-desktop/config.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "rustunnel": {
+      "command": "rustunnel-mcp",
+      "args": [
+        "--server", "eu.edge.rustunnel.com:4040",
+        "--api", "https://eu.edge.rustunnel.com:8443"
+      ],
+      "env": {
+        "RUSTUNNEL_TOKEN": "REPLACE_WITH_YOUR_TOKEN"
+      }
+    }
+  }
+}

--- a/integrations/cline/cline_mcp_settings.json
+++ b/integrations/cline/cline_mcp_settings.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "rustunnel": {
+      "command": "rustunnel-mcp",
+      "args": [
+        "--server", "eu.edge.rustunnel.com:4040",
+        "--api", "https://eu.edge.rustunnel.com:8443"
+      ],
+      "env": {
+        "RUSTUNNEL_TOKEN": "REPLACE_WITH_YOUR_TOKEN"
+      }
+    }
+  }
+}

--- a/integrations/codex/config.toml
+++ b/integrations/codex/config.toml
@@ -1,0 +1,10 @@
+# Add this block to ~/.codex/config.toml so OpenAI Codex can drive rustunnel.
+#
+# Get a free API token at https://rustunnel.com (Dashboard -> API Keys) and
+# replace the placeholder below. For a self-hosted server, swap the --server and
+# --api values for your own host (add "--insecure" for local self-signed certs).
+
+[mcp_servers.rustunnel]
+command = "rustunnel-mcp"
+args = ["--server", "eu.edge.rustunnel.com:4040", "--api", "https://eu.edge.rustunnel.com:8443"]
+env = { RUSTUNNEL_TOKEN = "REPLACE_WITH_YOUR_TOKEN" }

--- a/integrations/cursor/mcp.json
+++ b/integrations/cursor/mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "rustunnel": {
+      "command": "rustunnel-mcp",
+      "args": [
+        "--server", "eu.edge.rustunnel.com:4040",
+        "--api", "https://eu.edge.rustunnel.com:8443"
+      ],
+      "env": {
+        "RUSTUNNEL_TOKEN": "REPLACE_WITH_YOUR_TOKEN"
+      }
+    }
+  }
+}

--- a/integrations/generic/mcp.json
+++ b/integrations/generic/mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "rustunnel": {
+      "command": "rustunnel-mcp",
+      "args": [
+        "--server", "eu.edge.rustunnel.com:4040",
+        "--api", "https://eu.edge.rustunnel.com:8443"
+      ],
+      "env": {
+        "RUSTUNNEL_TOKEN": "REPLACE_WITH_YOUR_TOKEN"
+      }
+    }
+  }
+}

--- a/integrations/install.sh
+++ b/integrations/install.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# rustunnel agent installer — wires the rustunnel MCP server into an AI harness.
+#
+# Usage:
+#   ./install.sh                         # interactive
+#   ./install.sh --harness codex --token rt_xxx
+#   ./install.sh --harness claude-code --server localhost:4040 \
+#                --api http://localhost:4041 --insecure
+#
+# Supported harnesses: claude-code, claude-desktop, codex, cursor, windsurf,
+#                      cline, generic
+#
+# Docs: https://github.com/joaoh82/rustunnel/blob/main/docs/agent-integration.md
+
+set -euo pipefail
+
+HARNESS=""
+TOKEN="${RUSTUNNEL_TOKEN:-}"
+SERVER="eu.edge.rustunnel.com:4040"
+API="https://eu.edge.rustunnel.com:8443"
+INSECURE=0
+ASSUME_YES=0
+
+usage() {
+  sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --harness)  HARNESS="$2"; shift 2 ;;
+    --token)    TOKEN="$2"; shift 2 ;;
+    --server)   SERVER="$2"; shift 2 ;;
+    --api)      API="$2"; shift 2 ;;
+    --insecure) INSECURE=1; shift ;;
+    --yes|-y)   ASSUME_YES=1; shift ;;
+    -h|--help)  usage 0 ;;
+    *) echo "unknown argument: $1" >&2; usage 1 ;;
+  esac
+done
+
+info()  { printf '\033[36m%s\033[0m\n' "$*"; }
+warn()  { printf '\033[33m%s\033[0m\n' "$*" >&2; }
+err()   { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+
+# ── prerequisites ─────────────────────────────────────────────────────────────
+
+if ! command -v rustunnel-mcp >/dev/null 2>&1; then
+  warn "rustunnel-mcp is not on your PATH."
+  warn "Install it first:  brew tap joaoh82/rustunnel && brew install rustunnel"
+  warn "(or build from source: make release). Continuing — the config will still be written."
+fi
+
+# ── gather inputs ─────────────────────────────────────────────────────────────
+
+if [ -z "$HARNESS" ]; then
+  echo "Which harness do you want to configure?"
+  echo "  1) claude-code     2) claude-desktop   3) codex"
+  echo "  4) cursor          5) windsurf         6) cline       7) generic"
+  printf "Choice [1-7]: "
+  read -r choice
+  case "$choice" in
+    1) HARNESS="claude-code" ;;
+    2) HARNESS="claude-desktop" ;;
+    3) HARNESS="codex" ;;
+    4) HARNESS="cursor" ;;
+    5) HARNESS="windsurf" ;;
+    6) HARNESS="cline" ;;
+    7|"") HARNESS="generic" ;;
+    *) err "invalid choice"; exit 1 ;;
+  esac
+fi
+
+if [ -z "$TOKEN" ]; then
+  echo "Enter your rustunnel API token."
+  echo "  Get one free at https://rustunnel.com (Dashboard -> API Keys),"
+  echo "  or self-hosted: rustunnel token create --name agent"
+  printf "Token: "
+  read -r TOKEN
+fi
+if [ -z "$TOKEN" ]; then
+  err "An API token is required. Aborting."
+  exit 1
+fi
+
+ARGS_JSON="[\"--server\", \"$SERVER\", \"--api\", \"$API\""
+ARGS_TOML="[\"--server\", \"$SERVER\", \"--api\", \"$API\""
+if [ "$INSECURE" -eq 1 ]; then
+  ARGS_JSON="$ARGS_JSON, \"--insecure\""
+  ARGS_TOML="$ARGS_TOML, \"--insecure\""
+fi
+ARGS_JSON="$ARGS_JSON]"
+ARGS_TOML="$ARGS_TOML]"
+
+json_block() {
+  cat <<EOF
+{
+  "mcpServers": {
+    "rustunnel": {
+      "command": "rustunnel-mcp",
+      "args": $ARGS_JSON,
+      "env": { "RUSTUNNEL_TOKEN": "$TOKEN" }
+    }
+  }
+}
+EOF
+}
+
+# Merge the rustunnel server into an existing JSON config (or create it).
+write_json() {
+  target="$1"
+  mkdir -p "$(dirname "$target")"
+  if command -v jq >/dev/null 2>&1 && [ -s "$target" ]; then
+    tmp="$(mktemp)"
+    jq --arg srv "$SERVER" --arg api "$API" --arg tok "$TOKEN" \
+       --argjson args "$ARGS_JSON" \
+       '.mcpServers.rustunnel = {command:"rustunnel-mcp", args:$args, env:{RUSTUNNEL_TOKEN:$tok}}' \
+       "$target" > "$tmp" && mv "$tmp" "$target"
+    info "Updated $target"
+  elif [ -s "$target" ]; then
+    warn "$target already exists and jq is not installed."
+    warn "Add this block manually under \"mcpServers\":"
+    json_block
+  else
+    json_block > "$target"
+    info "Wrote $target"
+  fi
+}
+
+write_codex() {
+  target="$HOME/.codex/config.toml"
+  mkdir -p "$(dirname "$target")"
+  if [ -f "$target" ] && grep -q '\[mcp_servers.rustunnel\]' "$target"; then
+    warn "$target already has an [mcp_servers.rustunnel] block — leaving it untouched."
+    return
+  fi
+  {
+    echo ""
+    echo "[mcp_servers.rustunnel]"
+    echo "command = \"rustunnel-mcp\""
+    echo "args = $ARGS_TOML"
+    echo "env = { RUSTUNNEL_TOKEN = \"$TOKEN\" }"
+  } >> "$target"
+  info "Appended [mcp_servers.rustunnel] to $target"
+}
+
+# ── apply ─────────────────────────────────────────────────────────────────────
+
+case "$HARNESS" in
+  claude-code)
+    write_json "$(pwd)/.mcp.json" ;;
+  claude-desktop)
+    case "$(uname -s)" in
+      Darwin) write_json "$HOME/Library/Application Support/Claude/claude_desktop_config.json" ;;
+      *)      write_json "$HOME/.config/Claude/claude_desktop_config.json" ;;
+    esac ;;
+  codex)
+    write_codex ;;
+  cursor)
+    write_json "$HOME/.cursor/mcp.json" ;;
+  windsurf)
+    write_json "$HOME/.codeium/windsurf/mcp_config.json" ;;
+  cline)
+    warn "Cline stores MCP settings inside VS Code. Open Cline -> MCP Servers -> Configure,"
+    warn "and add this block:"
+    json_block ;;
+  generic)
+    info "Generic MCP config — add this to your client's MCP settings:"
+    json_block ;;
+  *)
+    err "unknown harness: $HARNESS"; exit 1 ;;
+esac
+
+info ""
+info "Done. Restart your harness (or reload its MCP servers) to pick up rustunnel."
+info "Then try: \"Create an HTTP tunnel to my service on port 3000.\""

--- a/integrations/windsurf/mcp_config.json
+++ b/integrations/windsurf/mcp_config.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "rustunnel": {
+      "command": "rustunnel-mcp",
+      "args": [
+        "--server", "eu.edge.rustunnel.com:4040",
+        "--api", "https://eu.edge.rustunnel.com:8443"
+      ],
+      "env": {
+        "RUSTUNNEL_TOKEN": "REPLACE_WITH_YOUR_TOKEN"
+      }
+    }
+  }
+}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rustunnel",
-  "version": "1.0.0",
-  "description": "Expose local services via secure tunnels. Create public HTTPS/TCP URLs for webhooks, demos, and AI agent workflows.",
+  "version": "1.1.0",
+  "description": "Expose local services via secure tunnels. Create public HTTPS/TCP/UDP URLs, peer-to-peer tunnels, and load-balanced pools for webhooks, demos, and AI agent workflows.",
   "author": {
     "name": "rustunnel",
     "url": "https://rustunnel.com"

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -56,9 +56,18 @@ Once installed, just ask Claude:
 
 > "Open an HTTP tunnel to port 8080 with subdomain myapp."
 
+> "Tunnel my Postgres on port 5432 over TCP."
+
+> "Open a P2P tunnel to port 3000 named `my-svc` with secret `hunter2`."
+
+> "Load-balance ports 3000 and 3001 under subdomain `pool` with a `/health` check."
+
 > "List my active tunnels."
 
 > "Close tunnel a1b2c3d4-..."
+
+Your token is read from the `RUSTUNNEL_TOKEN` env var configured at install
+time, so you never have to repeat it.
 
 ## Available Tools
 
@@ -71,8 +80,16 @@ Once installed, just ask Claude:
 | `get_tunnel_history` | View past tunnel activity |
 | `get_connection_info` | Get the CLI command (for cloud sandboxes) |
 
+## Other harnesses
+
+Not using Claude Code? The same MCP server works with Claude Desktop, Codex,
+Cursor, Windsurf, Cline, and custom agents — see the
+[Agent Integration Guide](https://github.com/joaoh82/rustunnel/blob/main/docs/agent-integration.md)
+or run `integrations/install.sh`.
+
 ## Links
 
 - [GitHub](https://github.com/joaoh82/rustunnel)
 - [Documentation](https://docs.rustunnel.com)
+- [Agent Integration Guide](https://github.com/joaoh82/rustunnel/blob/main/docs/agent-integration.md)
 - [MCP Server Guide](https://docs.rustunnel.com/guides/mcp-server)

--- a/plugins/claude-code/skills/rustunnel/SKILL.md
+++ b/plugins/claude-code/skills/rustunnel/SKILL.md
@@ -1,212 +1,228 @@
 ---
 name: rustunnel
-description: "Expose local services via secure tunnels using rustunnel MCP server. Create public URLs for local HTTP/TCP services for testing, webhooks, and deployment."
-version: 1.0.0
+description: "Expose local services via secure tunnels using rustunnel. Create public HTTPS/TCP/UDP URLs, peer-to-peer tunnels, and load-balanced pools for testing, webhooks, demos, and deployment — from any AI agent or harness."
+version: 2.0.0
 author: rustunnel
-tags: [tunnel, ngrok, expose, devops, deployment, testing, webhooks]
+tags: [tunnel, ngrok, expose, devops, deployment, testing, webhooks, p2p, load-balancing]
 ---
 
-# Rustunnel - Secure Tunnel Management
+# Rustunnel — Secure Tunnel Management
 
-Expose local services (HTTP/TCP) through public URLs using rustunnel. Perfect for testing webhooks, sharing local development, and deployment workflows.
+Expose local services (HTTP / TCP / UDP / P2P) through public URLs using
+rustunnel. Perfect for testing webhooks, sharing local development, database
+access, and AI agent workflows. Works through the **rustunnel MCP server**, so
+any MCP-capable harness (Claude Code, Claude Desktop, Codex, Cursor, Windsurf,
+Cline, or a custom agent) can drive it.
 
 ## When to Use
 
-- **Webhook testing** - Expose local server to receive webhooks from external services
-- **Demo sharing** - Share local development with stakeholders
-- **CI/CD integration** - Expose preview environments
-- **Database access** - Expose local TCP services (PostgreSQL, Redis, etc.)
-- **Mobile testing** - Test mobile apps against local backend
-
-## IMPORTANT: Use MCP Tools, Not CLI
-
-**Always use MCP tools for tunnel management.** They handle lifecycle automatically.
-
-| Method | Lifecycle | Recommended |
-|--------|-----------|-------------|
-| **MCP tools** (create_tunnel, close_tunnel) | Automatic cleanup | Yes |
-| **CLI** (rustunnel http 3000) | Manual process management | Only for cloud sandboxes |
-
-**Why MCP tools?**
-- Automatic cleanup when closed
-- No orphaned processes
-- Proper tunnel lifecycle management
-- Returns tunnel_id for tracking
+- **Webhook testing** — receive webhooks from Stripe/GitHub/etc. on a local server
+- **Demo sharing** — share local development with stakeholders
+- **CI/CD & previews** — expose preview environments
+- **Database / TCP access** — expose PostgreSQL, Redis, SSH, raw TCP
+- **UDP services** — game servers, DNS, custom UDP protocols
+- **Peer-to-peer** — direct, NAT-punched connections between two peers
+- **Load balancing** — spread traffic across multiple local backends with health checks
 
 ---
 
-## Token
+## Authentication — you need an API token (one-time)
 
-The API token is configured when the plugin is enabled and is available via the
-`RUSTUNNEL_TOKEN` environment variable. Read it from there when making tool calls —
-**do not ask the user for their token**.
+rustunnel requires an API token. **Get one once, then reuse it:**
 
-```
-token = env("RUSTUNNEL_TOKEN")
-```
+1. **Hosted (rustunnel.com):** sign up free at <https://rustunnel.com> →
+   **Dashboard → API Keys** → create a key.
+2. **Self-hosted:** create one with `rustunnel token create --name agent`
+   (needs the server admin token), or from your dashboard.
+
+**Where the token lives (in priority order):**
+
+1. The `RUSTUNNEL_TOKEN` environment variable, set once in your MCP client
+   config. **This is the recommended setup** — when it's set, you do **not**
+   need to pass `token` on tool calls and you should **not** ask the user for it
+   again.
+2. A `token` argument passed explicitly to a tool call.
+3. `~/.rustunnel/config.yml` (`auth_token:`) for the CLI.
+
+**If no token is configured**, ask the user once: "What's your rustunnel API
+token? Get one free at https://rustunnel.com → Dashboard → API Keys." Then
+prefer storing it as `RUSTUNNEL_TOKEN` in the MCP config so it persists.
+
+---
+
+## IMPORTANT: Prefer MCP Tools over the raw CLI
+
+Use the MCP tools for tunnel management — they handle the process lifecycle
+automatically (no orphaned processes, automatic cleanup, tunnel IDs for tracking).
+Only fall back to the CLI (`get_connection_info`) when the agent **cannot** spawn
+subprocesses (e.g. a cloud sandbox).
+
+| Method | Lifecycle | Use it when |
+|--------|-----------|-------------|
+| **MCP tools** (`create_tunnel`, `close_tunnel`) | Automatic cleanup | Default |
+| **CLI** (via `get_connection_info`) | Manual (user runs it) | Cloud sandbox / no subprocess |
 
 ---
 
 ## MCP Tools
 
-### create_tunnel
+### `create_tunnel`
 
-Expose a local port and get a public URL.
+Open a tunnel and get a public URL. The token may be omitted when
+`RUSTUNNEL_TOKEN` is set.
 
-**Parameters:**
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
-| `token` | string | yes | API token (read from `RUSTUNNEL_TOKEN` env var) |
+| `token` | string | no¹ | API token (¹required unless `RUSTUNNEL_TOKEN` is set) |
 | `local_port` | integer | yes | Local port to expose |
-| `protocol` | "http" \| "tcp" | yes | Tunnel type |
+| `protocol` | `"http"` \| `"tcp"` \| `"udp"` \| `"p2p"` | yes | Tunnel type |
 | `subdomain` | string | no | Custom subdomain (HTTP only) |
-| `region` | string | no | Region ID (e.g. `"eu"`, `"us"`, `"ap"`). Omit to auto-select. Use `list_regions` to see options. |
+| `region` | string | no | `"eu"`, `"us"`, `"ap"`. Omit to auto-select by latency |
+| `local_host` | string | no | Local hostname to forward to (default `localhost`) |
+| `secret` | string | p2p only | Shared secret; publisher and subscriber must match |
+| `peer_name` | string | p2p publish | Publish the local service under this name |
+| `peer_target` | string | p2p connect | Connect to a published P2P tunnel by this name |
+| `group` | string | LB | Load-balancing pool name (http/tcp only) |
+| `group_key` | string | LB | Shared secret for the pool; members must agree |
+| `health_check` | object | no | Health probe — see below |
+
+`health_check` object: `{ type: "tcp"|"http", path, interval_secs, timeout_secs, max_failed, expect_2xx, alert_webhook }`.
 
 **Returns:**
 ```json
-{
-  "public_url": "https://abc123.edge.rustunnel.com",
-  "tunnel_id": "a1b2c3d4-...",
-  "protocol": "http"
-}
+{ "public_url": "https://abc123.eu.edge.rustunnel.com", "tunnel_id": "a1b2c3d4-...", "protocol": "http" }
 ```
 
-**Lifecycle:** Tunnel stays open until `close_tunnel` is called or MCP server exits.
+Tunnel stays open until `close_tunnel` is called or the MCP server exits.
 
-### close_tunnel
+### `close_tunnel`
 
-Close a tunnel by ID. Public URL stops working immediately.
+Close a tunnel by ID. The public URL stops working immediately.
 
-**Parameters:**
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
-| `token` | string | yes | API token |
-| `tunnel_id` | string | yes | UUID from create_tunnel |
+| `token` | string | no¹ | API token |
+| `tunnel_id` | string | yes | UUID from `create_tunnel` / `list_tunnels` |
 
-**This is the proper way to close tunnels.** No orphaned processes.
+### `list_tunnels`
 
-### list_tunnels
+List active tunnels (public URL, protocol, traffic count). `token` optional¹.
 
-List all currently active tunnels.
+### `get_tunnel_history`
 
-**Parameters:**
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| `token` | string | yes | API token |
+Past tunnels (duration, owning token). Params: `token` (optional¹),
+`protocol` (filter, optional), `limit` (default 25).
 
-**Returns:** JSON array of tunnel objects.
+### `list_regions`
 
-### get_tunnel_history
+Available server regions. No auth required.
 
-Retrieve history of past tunnels.
+### `get_connection_info`
 
-**Parameters:**
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| `token` | string | yes | API token |
-| `protocol` | "http" \| "tcp" | no | Filter by protocol |
-| `limit` | integer | no | Max entries (default: 25) |
-
-### list_regions
-
-List available tunnel server regions. No authentication required.
-
-**Parameters:** None
-
-**Returns:** JSON array of region objects:
-```json
-[
-  { "id": "eu", "name": "Europe", "location": "Helsinki, FI", "host": "eu.edge.rustunnel.com", "control_port": 4040, "active": true }
-]
-```
-
-### get_connection_info
-
-Returns the CLI command string without spawning anything. Use when MCP can't
-spawn subprocesses (cloud sandboxes, containers) or you prefer running the CLI yourself.
-
-**Parameters:**
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| `token` | string | yes | API token |
-| `local_port` | integer | yes | Local port to expose |
-| `protocol` | "http" \| "tcp" | yes | Tunnel type |
-| `region` | string | no | Region ID (e.g. `"eu"`). Omit to auto-select. |
-
-**Returns:**
-```json
-{
-  "cli_command": "rustunnel http 3000 --server edge.rustunnel.com:4040 --token abc123",
-  "server": "edge.rustunnel.com:4040",
-  "install_url": "https://github.com/joaoh82/rustunnel/releases/latest"
-}
-```
+Returns the CLI command (and, for load-balanced tunnels, a config file) to run
+the client manually — without spawning anything. Use in cloud sandboxes. Accepts
+the same arguments as `create_tunnel`.
 
 ---
 
 ## Common Workflows
 
-### 1. Expose Local API
-
+### Expose a local web app
 ```
-1. Read token from RUSTUNNEL_TOKEN env var
-2. Create tunnel: create_tunnel(token, local_port=3000, protocol="http")
-3. Store tunnel_id for later cleanup
-4. Return public_url to user
-5. When done: close_tunnel(token, tunnel_id)
+create_tunnel(local_port=3000, protocol="http")
+→ return public_url; close_tunnel(tunnel_id) when done
 ```
 
-### 2. Custom Subdomain
-
+### Custom subdomain
 ```
-1. Read token from RUSTUNNEL_TOKEN env var
-2. create_tunnel(token, local_port=5173, protocol="http", subdomain="myapp-preview")
-3. Return URL: https://myapp-preview.edge.rustunnel.com
-4. close_tunnel(token, tunnel_id) when done
+create_tunnel(local_port=5173, protocol="http", subdomain="myapp-preview")
 ```
 
-### 3. TCP Tunnel (Database)
-
+### Database / TCP
 ```
-1. Read token from RUSTUNNEL_TOKEN env var
-2. create_tunnel(token, local_port=5432, protocol="tcp")
-3. Return tcp://host:port for connection
-4. close_tunnel(token, tunnel_id) when done
+create_tunnel(local_port=5432, protocol="tcp")  → host:port to connect
 ```
 
-### 4. Cloud Sandbox (CLI Fallback)
-
+### UDP service
 ```
-1. Read token from RUSTUNNEL_TOKEN env var
-2. get_connection_info(token, local_port=3000, protocol="http")
-3. Output CLI command for user to run locally
-4. User runs command
-5. list_tunnels(token) to verify and get public_url
-6. When done, user Ctrl+C the CLI process
+create_tunnel(local_port=27015, protocol="udp")
+```
+
+### Peer-to-peer — publish, then connect
+```
+# Publisher (machine A)
+create_tunnel(local_port=3000, protocol="p2p", secret="shared", peer_name="my-svc")
+# Subscriber (machine B)
+create_tunnel(local_port=8000, protocol="p2p", secret="shared", peer_target="my-svc")
+```
+
+### Load-balanced pool with health checks
+Run one `create_tunnel` per backend; members sharing `(group, group_key)` form
+one pool (requires the edge to have `[load_balancing] enabled = true`):
+```
+create_tunnel(local_port=3000, protocol="http", subdomain="pool",
+              group="web", group_key="shared-secret",
+              health_check={ "type": "http", "path": "/health", "interval_secs": 10 })
+create_tunnel(local_port=3001, protocol="http", subdomain="pool",
+              group="web", group_key="shared-secret",
+              health_check={ "type": "http", "path": "/health" })
+```
+
+### Cloud sandbox (CLI fallback)
+```
+get_connection_info(local_port=3000, protocol="http")
+→ output the command for the user to run locally
+→ list_tunnels() to confirm and fetch public_url
 ```
 
 ---
 
-## Architecture
+## Prerequisites
 
+The `rustunnel` CLI must be installed and on `PATH` (the MCP server spawns it):
+
+```bash
+# Homebrew (macOS/Linux)
+brew tap joaoh82/rustunnel && brew install rustunnel
+
+# Or build from source
+git clone https://github.com/joaoh82/rustunnel.git && cd rustunnel
+make release   # builds rustunnel, rustunnel-mcp
 ```
-Internet ──── :443 ────▶ rustunnel-server ────▶ WebSocket ────▶ rustunnel-client ────▶ localhost:PORT
-                              │
-                        Dashboard (:8443)
-                        REST API
+
+## Adding rustunnel to your harness
+
+See **[docs/agent-integration.md](https://github.com/joaoh82/rustunnel/blob/main/docs/agent-integration.md)**
+for copy-paste MCP config for Claude Code, Claude Desktop, Codex, Cursor,
+Windsurf, Cline, and generic/custom agents — plus a one-command installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/joaoh82/rustunnel/main/integrations/install.sh | bash
+```
+
+A minimal MCP config looks like:
+```json
+{
+  "mcpServers": {
+    "rustunnel": {
+      "command": "rustunnel-mcp",
+      "args": ["--server", "eu.edge.rustunnel.com:4040", "--api", "https://eu.edge.rustunnel.com:8443"],
+      "env": { "RUSTUNNEL_TOKEN": "<your-token>" }
+    }
+  }
+}
 ```
 
 ## Security Notes
 
-- Tokens are sent over HTTPS (use `--insecure` only in local dev)
-- MCP tools handle process cleanup automatically
-- Tunnels are closed when MCP server exits
-- Token is stored securely by Claude Code plugin system
-
----
+- Tokens travel over HTTPS (use `--insecure` only in local dev with self-signed certs).
+- MCP tools clean up subprocesses automatically; tunnels close when the MCP server exits.
+- Protect the config file: `chmod 600 ~/.rustunnel/config.yml`.
 
 ## Resources
 
-- [GitHub Repository](https://github.com/joaoh82/rustunnel)
-- [MCP Server Documentation](https://docs.rustunnel.com/guides/mcp-server)
-- [Plugin Documentation](https://docs.rustunnel.com/guides/claude-plugin)
+- [GitHub](https://github.com/joaoh82/rustunnel)
+- [Agent Integration Guide](https://github.com/joaoh82/rustunnel/blob/main/docs/agent-integration.md)
+- [MCP Server Docs](https://github.com/joaoh82/rustunnel/blob/main/docs/mcp-server.md)
+- [Load Balancing](https://github.com/joaoh82/rustunnel/blob/main/docs/load-balancing.md)
+- [P2P Tunnels](https://github.com/joaoh82/rustunnel/blob/main/docs/p2p-tunnels.md)

--- a/skills/rustunnel/SKILL.md
+++ b/skills/rustunnel/SKILL.md
@@ -1,336 +1,228 @@
 ---
 name: rustunnel
-description: "Expose local services via secure tunnels using rustunnel MCP server. Create public URLs for local HTTP/TCP services for testing, webhooks, and deployment."
-version: 1.3.1
-author: OpenClaw
-tags: [tunnel, ngrok, expose, devops, deployment, testing, webhooks]
+description: "Expose local services via secure tunnels using rustunnel. Create public HTTPS/TCP/UDP URLs, peer-to-peer tunnels, and load-balanced pools for testing, webhooks, demos, and deployment — from any AI agent or harness."
+version: 2.0.0
+author: rustunnel
+tags: [tunnel, ngrok, expose, devops, deployment, testing, webhooks, p2p, load-balancing]
 ---
 
-# Rustunnel - Secure Tunnel Management
+# Rustunnel — Secure Tunnel Management
 
-Expose local services (HTTP/TCP) through public URLs using rustunnel. Perfect for testing webhooks, sharing local development, and deployment workflows.
+Expose local services (HTTP / TCP / UDP / P2P) through public URLs using
+rustunnel. Perfect for testing webhooks, sharing local development, database
+access, and AI agent workflows. Works through the **rustunnel MCP server**, so
+any MCP-capable harness (Claude Code, Claude Desktop, Codex, Cursor, Windsurf,
+Cline, or a custom agent) can drive it.
 
 ## When to Use
 
-- **Webhook testing** - Expose local server to receive webhooks from external services
-- **Demo sharing** - Share local development with stakeholders
-- **CI/CD integration** - Expose preview environments
-- **Database access** - Expose local TCP services (PostgreSQL, Redis, etc.)
-- **Mobile testing** - Test mobile apps against local backend
+- **Webhook testing** — receive webhooks from Stripe/GitHub/etc. on a local server
+- **Demo sharing** — share local development with stakeholders
+- **CI/CD & previews** — expose preview environments
+- **Database / TCP access** — expose PostgreSQL, Redis, SSH, raw TCP
+- **UDP services** — game servers, DNS, custom UDP protocols
+- **Peer-to-peer** — direct, NAT-punched connections between two peers
+- **Load balancing** — spread traffic across multiple local backends with health checks
 
-## ⚠️ IMPORTANT: Use MCP Tools, Not CLI
+---
 
-**Always use MCP tools for tunnel management.** They handle lifecycle automatically.
+## Authentication — you need an API token (one-time)
 
-| Method | Lifecycle | Recommended |
+rustunnel requires an API token. **Get one once, then reuse it:**
+
+1. **Hosted (rustunnel.com):** sign up free at <https://rustunnel.com> →
+   **Dashboard → API Keys** → create a key.
+2. **Self-hosted:** create one with `rustunnel token create --name agent`
+   (needs the server admin token), or from your dashboard.
+
+**Where the token lives (in priority order):**
+
+1. The `RUSTUNNEL_TOKEN` environment variable, set once in your MCP client
+   config. **This is the recommended setup** — when it's set, you do **not**
+   need to pass `token` on tool calls and you should **not** ask the user for it
+   again.
+2. A `token` argument passed explicitly to a tool call.
+3. `~/.rustunnel/config.yml` (`auth_token:`) for the CLI.
+
+**If no token is configured**, ask the user once: "What's your rustunnel API
+token? Get one free at https://rustunnel.com → Dashboard → API Keys." Then
+prefer storing it as `RUSTUNNEL_TOKEN` in the MCP config so it persists.
+
+---
+
+## IMPORTANT: Prefer MCP Tools over the raw CLI
+
+Use the MCP tools for tunnel management — they handle the process lifecycle
+automatically (no orphaned processes, automatic cleanup, tunnel IDs for tracking).
+Only fall back to the CLI (`get_connection_info`) when the agent **cannot** spawn
+subprocesses (e.g. a cloud sandbox).
+
+| Method | Lifecycle | Use it when |
 |--------|-----------|-------------|
-| **MCP tools** (create_tunnel, close_tunnel) | Automatic cleanup | ✅ Yes |
-| **CLI** (rustunnel http 3000) | Manual process management | ❌ Only for cloud sandboxes |
-
-**Why MCP tools?**
-- Automatic cleanup when closed
-- No orphaned processes
-- Proper tunnel lifecycle management
-- Returns tunnel_id for tracking
+| **MCP tools** (`create_tunnel`, `close_tunnel`) | Automatic cleanup | Default |
+| **CLI** (via `get_connection_info`) | Manual (user runs it) | Cloud sandbox / no subprocess |
 
 ---
 
-## Configuration File
+## MCP Tools
 
-**Location:** `~/.rustunnel/config.yml`
+### `create_tunnel`
 
-This file stores your server address and auth token. The agent will read from this file instead of asking every time.
+Open a tunnel and get a public URL. The token may be omitted when
+`RUSTUNNEL_TOKEN` is set.
 
-**Format:**
-```yaml
-# rustunnel configuration
-# Documentation: https://github.com/joaoh82/rustunnel
-
-server: edge.rustunnel.com:4040
-auth_token: your-token-here
-
-tunnels:
-  expense_tracker:
-    proto: http
-    local_port: 3000
-  # api:
-  #   proto: http
-  #   local_port: 8080
-  #   subdomain: myapi
-```
-
-## First-Time Setup
-
-**Before using tunnels, ensure config exists:**
-
-1. **Check if config file exists:** `~/.rustunnel/config.yml`
-2. **If not, ask user:** "What's your rustunnel auth token and server address?"
-3. **Create config file directly:**
-   ```bash
-   mkdir -p ~/.rustunnel
-   chmod 700 ~/.rustunnel
-   ```
-4. **Write config with user's token:**
-   ```yaml
-   server: <user-provided-server>
-   auth_token: <user-provided-token>
-   ```
-5. **Set permissions:** `chmod 600 ~/.rustunnel/config.yml`
-
----
-
-## Agent Workflow
-
-**Always follow this sequence:**
-
-### Step 1: Check Config
-
-```bash
-# Check if config exists
-cat ~/.rustunnel/config.yml
-```
-
-**If config exists with auth_token:** Read token and proceed.
-
-**If config missing:**
-1. Ask user: "What's your rustunnel auth token and server address?"
-2. Create config file directly:
-   ```bash
-   mkdir -p ~/.rustunnel
-   chmod 700 ~/.rustunnel
-   ```
-3. Write config with user's token:
-   ```yaml
-   server: <user-provided-server>
-   auth_token: <user-provided-token>
-   ```
-4. Set permissions: `chmod 600 ~/.rustunnel/config.yml`
-
-### Step 2: Read Token from Config
-
-When making tool calls, read `auth_token` from `~/.rustunnel/config.yml`:
-```yaml
-auth_token: your-token-here
-server: edge.rustunnel.com:4040
-```
-
-Use these values in tool calls - **don't ask the user every time.**
-
-### Step 3: Use MCP Tools
-
-With token from config, call MCP tools directly.
-
----
-
-## MCP Tools (Recommended)
-
-### create_tunnel
-
-Expose a local port and get a public URL.
-
-**Parameters:**
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
-| `token` | string | yes | API token (read from config) |
+| `token` | string | no¹ | API token (¹required unless `RUSTUNNEL_TOKEN` is set) |
 | `local_port` | integer | yes | Local port to expose |
-| `protocol` | "http" \| "tcp" | yes | Tunnel type |
+| `protocol` | `"http"` \| `"tcp"` \| `"udp"` \| `"p2p"` | yes | Tunnel type |
 | `subdomain` | string | no | Custom subdomain (HTTP only) |
-| `region` | string | no | Region ID (e.g. `"eu"`, `"us"`, `"ap"`). Omit to auto-select. Use `list_regions` to see options. |
+| `region` | string | no | `"eu"`, `"us"`, `"ap"`. Omit to auto-select by latency |
+| `local_host` | string | no | Local hostname to forward to (default `localhost`) |
+| `secret` | string | p2p only | Shared secret; publisher and subscriber must match |
+| `peer_name` | string | p2p publish | Publish the local service under this name |
+| `peer_target` | string | p2p connect | Connect to a published P2P tunnel by this name |
+| `group` | string | LB | Load-balancing pool name (http/tcp only) |
+| `group_key` | string | LB | Shared secret for the pool; members must agree |
+| `health_check` | object | no | Health probe — see below |
+
+`health_check` object: `{ type: "tcp"|"http", path, interval_secs, timeout_secs, max_failed, expect_2xx, alert_webhook }`.
 
 **Returns:**
 ```json
-{
-  "public_url": "https://abc123.edge.rustunnel.com",
-  "tunnel_id": "a1b2c3d4-...",
-  "protocol": "http"
-}
+{ "public_url": "https://abc123.eu.edge.rustunnel.com", "tunnel_id": "a1b2c3d4-...", "protocol": "http" }
 ```
 
-**Lifecycle:** Tunnel stays open until `close_tunnel` is called or MCP server exits.
+Tunnel stays open until `close_tunnel` is called or the MCP server exits.
 
-### close_tunnel
+### `close_tunnel`
 
-Close a tunnel by ID. Public URL stops working immediately.
+Close a tunnel by ID. The public URL stops working immediately.
 
-**Parameters:**
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
-| `token` | string | yes | API token |
-| `tunnel_id` | string | yes | UUID from create_tunnel |
+| `token` | string | no¹ | API token |
+| `tunnel_id` | string | yes | UUID from `create_tunnel` / `list_tunnels` |
 
-**This is the proper way to close tunnels.** No orphaned processes.
+### `list_tunnels`
 
-### list_tunnels
+List active tunnels (public URL, protocol, traffic count). `token` optional¹.
 
-List all currently active tunnels.
+### `get_tunnel_history`
 
-**Parameters:**
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| `token` | string | yes | API token (read from config) |
+Past tunnels (duration, owning token). Params: `token` (optional¹),
+`protocol` (filter, optional), `limit` (default 25).
 
-**Returns:** JSON array of tunnel objects.
+### `list_regions`
 
-### get_tunnel_history
+Available server regions. No auth required.
 
-Retrieve history of past tunnels.
+### `get_connection_info`
 
-**Parameters:**
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| `token` | string | yes | API token |
-| `protocol` | "http" \| "tcp" | no | Filter by protocol |
-| `limit` | integer | no | Max entries (default: 25) |
-
-### list_regions
-
-List available tunnel server regions. No authentication required.
-
-**Parameters:** None
-
-**Returns:** JSON array of region objects:
-```json
-[
-  { "id": "eu", "name": "Europe", "location": "Helsinki, FI", "host": "eu.edge.rustunnel.com", "control_port": 4040, "active": true }
-]
-```
-
-### get_connection_info
-
-Returns the CLI command string without spawning anything. Use when MCP can't
-spawn subprocesses (cloud sandboxes, containers) or you prefer running the CLI yourself.
-
-**Parameters:**
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| `token` | string | yes | API token |
-| `local_port` | integer | yes | Local port to expose |
-| `protocol` | "http" \| "tcp" | yes | Tunnel type |
-| `region` | string | no | Region ID (e.g. `"eu"`). Omit to auto-select. |
-
-**Returns:**
-```json
-{
-  "cli_command": "rustunnel http 3000 --server edge.rustunnel.com:4040 --token abc123",
-  "server": "edge.rustunnel.com:4040",
-  "install_url": "https://github.com/joaoh82/rustunnel/releases/latest"
-}
-```
+Returns the CLI command (and, for load-balanced tunnels, a config file) to run
+the client manually — without spawning anything. Use in cloud sandboxes. Accepts
+the same arguments as `create_tunnel`.
 
 ---
 
 ## Common Workflows
 
----
-
-## Common Workflows
-
-### 1. Expose Local API (MCP Tools)
-
+### Expose a local web app
 ```
-1. Read auth_token from ~/.rustunnel/config.yml
-2. Create tunnel: create_tunnel(token, local_port=3000, protocol="http")
-3. Store tunnel_id for later cleanup
-4. Return public_url to user
-5. When done: close_tunnel(token, tunnel_id)
+create_tunnel(local_port=3000, protocol="http")
+→ return public_url; close_tunnel(tunnel_id) when done
 ```
 
-### 2. Custom Subdomain
-
+### Custom subdomain
 ```
-1. Read auth_token from config
-2. create_tunnel(token, local_port=5173, protocol="http", subdomain="myapp-preview")
-3. Return URL: https://myapp-preview.edge.rustunnel.com
-4. close_tunnel(token, tunnel_id) when done
+create_tunnel(local_port=5173, protocol="http", subdomain="myapp-preview")
 ```
 
-### 3. TCP Tunnel (Database)
-
+### Database / TCP
 ```
-1. Read auth_token from config
-2. create_tunnel(token, local_port=5432, protocol="tcp")
-3. Return tcp://host:port for connection
-4. close_tunnel(token, tunnel_id) when done
+create_tunnel(local_port=5432, protocol="tcp")  → host:port to connect
 ```
 
-### 4. Cloud Sandbox (CLI Fallback)
-
+### UDP service
 ```
-1. Read auth_token from config
-2. get_connection_info(token, local_port=3000, protocol="http")
-3. Output CLI command for user to run locally
-4. User runs command
-5. list_tunnels(token) to verify and get public_url
-6. When done, user Ctrl+C the CLI process
+create_tunnel(local_port=27015, protocol="udp")
+```
+
+### Peer-to-peer — publish, then connect
+```
+# Publisher (machine A)
+create_tunnel(local_port=3000, protocol="p2p", secret="shared", peer_name="my-svc")
+# Subscriber (machine B)
+create_tunnel(local_port=8000, protocol="p2p", secret="shared", peer_target="my-svc")
+```
+
+### Load-balanced pool with health checks
+Run one `create_tunnel` per backend; members sharing `(group, group_key)` form
+one pool (requires the edge to have `[load_balancing] enabled = true`):
+```
+create_tunnel(local_port=3000, protocol="http", subdomain="pool",
+              group="web", group_key="shared-secret",
+              health_check={ "type": "http", "path": "/health", "interval_secs": 10 })
+create_tunnel(local_port=3001, protocol="http", subdomain="pool",
+              group="web", group_key="shared-secret",
+              health_check={ "type": "http", "path": "/health" })
+```
+
+### Cloud sandbox (CLI fallback)
+```
+get_connection_info(local_port=3000, protocol="http")
+→ output the command for the user to run locally
+→ list_tunnels() to confirm and fetch public_url
 ```
 
 ---
 
 ## Prerequisites
 
-1. **Rustunnel MCP server installed:**
-   ```bash
-   # Homebrew (macOS/Linux)
-   brew tap joaoh82/rustunnel
-   brew install rustunnel
-   
-   # Or build from source
-   git clone https://github.com/joaoh82/rustunnel.git
-   cd rustunnel
-   make release-mcp
-   sudo install -m755 target/release/rustunnel-mcp /usr/local/bin/rustunnel-mcp
-   ```
+The `rustunnel` CLI must be installed and on `PATH` (the MCP server spawns it):
 
-2. **Config file:** `~/.rustunnel/config.yml` with `auth_token` set
+```bash
+# Homebrew (macOS/Linux)
+brew tap joaoh82/rustunnel && brew install rustunnel
 
-## MCP Configuration
+# Or build from source
+git clone https://github.com/joaoh82/rustunnel.git && cd rustunnel
+make release   # builds rustunnel, rustunnel-mcp
+```
 
-Add to your MCP client config:
+## Adding rustunnel to your harness
+
+See **[docs/agent-integration.md](https://github.com/joaoh82/rustunnel/blob/main/docs/agent-integration.md)**
+for copy-paste MCP config for Claude Code, Claude Desktop, Codex, Cursor,
+Windsurf, Cline, and generic/custom agents — plus a one-command installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/joaoh82/rustunnel/main/integrations/install.sh | bash
+```
+
+A minimal MCP config looks like:
 ```json
 {
   "mcpServers": {
     "rustunnel": {
       "command": "rustunnel-mcp",
-      "args": [
-        "--server", "edge.rustunnel.com:4040",
-        "--api", "https://edge.rustunnel.com:8443"
-      ]
+      "args": ["--server", "eu.edge.rustunnel.com:4040", "--api", "https://eu.edge.rustunnel.com:8443"],
+      "env": { "RUSTUNNEL_TOKEN": "<your-token>" }
     }
   }
 }
 ```
 
-**Note:** The MCP server address should match the `server` in `~/.rustunnel/config.yml`.
-
----
-
-## Architecture
-
-```
-Internet ──── :443 ────▶ rustunnel-server ────▶ WebSocket ────▶ rustunnel-client ────▶ localhost:PORT
-                              │
-                        Dashboard (:8443)
-                        REST API
-```
-
 ## Security Notes
 
-- Tokens are sent over HTTPS (use `--insecure` only in local dev)
-- MCP tools handle process cleanup automatically
-- Tunnels are closed when MCP server exits
-- Config file should be protected: `chmod 600 ~/.rustunnel/config.yml`
-
----
-
-## Related Skills
-
-- **vercel-deploy** - Deploy to Vercel for production hosting
-- **here-now** - Instant static file hosting
-- **backend** - Backend service patterns
-- **nodejs-patterns** - Node.js deployment patterns
+- Tokens travel over HTTPS (use `--insecure` only in local dev with self-signed certs).
+- MCP tools clean up subprocesses automatically; tunnels close when the MCP server exits.
+- Protect the config file: `chmod 600 ~/.rustunnel/config.yml`.
 
 ## Resources
 
-- [GitHub Repository](https://github.com/joaoh82/rustunnel)
-- [MCP Server Documentation](https://github.com/joaoh82/rustunnel/blob/main/docs/mcp-server.md)
-- [API Reference](https://github.com/joaoh82/rustunnel/blob/main/docs/api-reference.md)
+- [GitHub](https://github.com/joaoh82/rustunnel)
+- [Agent Integration Guide](https://github.com/joaoh82/rustunnel/blob/main/docs/agent-integration.md)
+- [MCP Server Docs](https://github.com/joaoh82/rustunnel/blob/main/docs/mcp-server.md)
+- [Load Balancing](https://github.com/joaoh82/rustunnel/blob/main/docs/load-balancing.md)
+- [P2P Tunnels](https://github.com/joaoh82/rustunnel/blob/main/docs/p2p-tunnels.md)


### PR DESCRIPTION
## Goal

Make rustunnel trivial to add to **any** LLM/agent harness, and expose **every** tunnel feature through the MCP server — so anyone talking to a harness can say *"create a tunnel for this service on this port"*, *"load-balance these two backends"*, *"open a P2P tunnel"*, etc.

Getting an API key (sign up at rustunnel.com, or `rustunnel token create` for self-hosted) remains the one required user step — and the installer, skill, and docs now all surface it consistently.

## What changed

### MCP server (`rustunnel-mcp`)
- **`RUSTUNNEL_TOKEN` is now honored.** The server reads it at startup and uses it as the default for every tool call, so `token` is optional. The Claude Code plugin already set this env var but the server ignored it — that's fixed, and a clear "how to get a key" message is returned when no token is configured.
- **Full CLI parity in `create_tunnel` / `get_connection_info`:**
  - HTTP / TCP / UDP
  - `local_host` (forward to another host)
  - **P2P** — `secret` + `peer_name` (publish) or `peer_target` (connect)
  - **Load balancing** — `group` + `group_key` (http/tcp), optional `health_check` (`tcp`/`http`, path, intervals, alert webhook). Launched via a temporary `rustunnel start` config that's cleaned up automatically when the tunnel closes or the server exits.
- Command/config construction refactored into pure functions with **12 unit tests**.

### Multi-harness packaging
- **`docs/agent-integration.md`** — one-stop guide with copy-paste config for Claude Code, Claude Desktop, Codex, Cursor, Windsurf, Cline, and generic/custom MCP clients (incl. a programmatic example).
- **`integrations/`** — per-harness config templates + **`install.sh`**, which prompts for the API token and writes the correct config (merges into existing JSON via `jq`, appends a TOML block for Codex).
- **`AGENTS.md`** at the repo root for Codex/agent discovery.
- Unified & refreshed the **rustunnel skill** (both copies) and updated `README.md`, `docs/mcp-server.md`, and the Claude Code plugin (`README`, `plugin.json` → 1.1.0).

## Testing
- `cargo test -p rustunnel-mcp` — **12 passing** (token resolution, inline/P2P arg building, LB YAML generation, escaping).
- `cargo fmt --all --check`, `cargo clippy -p rustunnel-mcp --all-targets -D warnings`, `cargo check --workspace` — all clean.
- `cargo test -p rustunnel-protocol -p rustunnel-client` — pass (no regressions).
- **End-to-end smoke test** driving the built binary over stdio: `tools/list` exposes the new schema (only `local_port`+`protocol` required), env-token fallback works, and P2P / load-balanced command+config generation is correct.
- `install.sh` validated for the codex, cursor (fresh + jq-merge preserving existing servers), and generic paths.

> ⚠️ The full DB-backed `cargo test --workspace` (Postgres) was **not** run — Docker/Postgres isn't available in this environment. Only the MCP crate's logic changed, and it has no DB dependency. CI (which starts Postgres) should run the full suite.

https://claude.ai/code/session_01K4jyDQ17Hgk3ZPGvtPUNer

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4jyDQ17Hgk3ZPGvtPUNer)_