### PR TITLE
Agent-friendly CLI + MCP: --json NDJSON events, self-describing errors, when-to-use tool descriptions (TUNNEL-16 W6)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tower-http = { version = "0.5", features = ["cors", "fs", "set-header"] }
 sha2 = "0.10"
 hex = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 serde_yaml = "0.9"
 console = "0.15"
 indicatif = "0.17"

--- a/README.md
+++ b/README.md
@@ -813,9 +813,10 @@ Events:
 | `error` | Fatal error; process exits with code 1 | `code` (`config`/`auth`/`tunnel`/`connection`/`protocol`/`io`), `message`, `hint` |
 | `token_created` | `token create --json` succeeded | `token`, `name`, `id` |
 
-Diagnostics still go to stderr, so stdout stays valid NDJSON. The auth
-token can also be supplied via the `RUSTUNNEL_TOKEN` environment variable
-instead of `--token`.
+Diagnostics still go to stderr, so stdout stays valid NDJSON. For the
+`http`, `tcp`, `udp`, and `p2p` commands the auth token can also be
+supplied via the `RUSTUNNEL_TOKEN` environment variable instead of
+`--token` (`start` reads tokens from the config file).
 
 ### Config file
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can self-host or use our managed service.
   - [Installation](#installation)
   - [Setup wizard](#setup-wizard)
   - [Quick start (CLI flags)](#quick-start-cli-flags)
+  - [Machine-readable output (`--json`)](#machine-readable-output---json)
   - [Config file](#config-file)
   - [Token management](#token-management)
 - [Port reference](#port-reference)
@@ -786,6 +787,35 @@ rustunnel tcp 5432 \
 # Disable automatic reconnection
 rustunnel http 3000 --no-reconnect
 ```
+
+### Machine-readable output (`--json`)
+
+All tunnel-running commands (`http`, `tcp`, `udp`, `p2p`, `start`) and
+`token create` accept a `--json` flag. With it, stdout emits NDJSON —
+one JSON event object per line — instead of the human-readable startup
+box, which makes the CLI easy to drive from scripts and AI agents:
+
+```bash
+rustunnel http 3000 --json --token YOUR_AUTH_TOKEN
+```
+
+```json
+{"event":"tunnel_ready","protocol":"http","public_url":"https://myapp.eu.edge.rustunnel.com","local_port":3000,"local_host":"localhost","tunnel_id":"6f9a…","name":"myapp"}
+```
+
+Events:
+
+| Event | When | Fields |
+|-------|------|--------|
+| `tunnel_ready` | Tunnel registered and accepting traffic | `protocol`, `public_url`, `public_addr` (host:port, tcp/udp only), `local_port`, `local_host`, `tunnel_id`, `name` |
+| `reconnecting` | Connection dropped, retry scheduled | `attempt`, `reason`, `delay_secs` |
+| `reconnected` | Reconnect succeeded (fresh `tunnel_ready` events follow) | — |
+| `error` | Fatal error; process exits with code 1 | `code` (`config`/`auth`/`tunnel`/`connection`/`protocol`/`io`), `message`, `hint` |
+| `token_created` | `token create --json` succeeded | `token`, `name`, `id` |
+
+Diagnostics still go to stderr, so stdout stays valid NDJSON. The auth
+token can also be supplied via the `RUSTUNNEL_TOKEN` environment variable
+instead of `--token`.
 
 ### Config file
 

--- a/crates/rustunnel-client/src/config.rs
+++ b/crates/rustunnel-client/src/config.rs
@@ -21,6 +21,11 @@ pub struct ClientConfig {
     /// Auth token sent in the `Auth` control frame.
     pub auth_token: Option<String>,
 
+    /// Where `auth_token` came from (`--token` flag, env var, config file…).
+    /// Runtime-only — used to make auth error messages self-describing.
+    #[serde(skip)]
+    pub auth_token_source: Option<String>,
+
     /// Skip TLS certificate verification (for local development only).
     #[serde(default)]
     pub insecure: bool,
@@ -208,7 +213,12 @@ impl ClientConfig {
                 path.as_ref().display()
             ))
         })?;
-        serde_yaml::from_str(&raw).map_err(|e| Error::Config(format!("invalid config YAML: {e}")))
+        let mut cfg: Self = serde_yaml::from_str(&raw)
+            .map_err(|e| Error::Config(format!("invalid config YAML: {e}")))?;
+        if cfg.auth_token.is_some() {
+            cfg.auth_token_source = Some(format!("config file {}", path.as_ref().display()));
+        }
+        Ok(cfg)
     }
 
     /// Validate that required fields are present.

--- a/crates/rustunnel-client/src/control.rs
+++ b/crates/rustunnel-client/src/control.rs
@@ -51,6 +51,7 @@ use rustunnel_protocol::{decode_frame, encode_frame, ControlFrame, TunnelProtoco
 use crate::config::{ClientConfig, TunnelDef};
 use crate::display::{self, TunnelDisplay};
 use crate::error::{Error, Result};
+use crate::output;
 use crate::proxy;
 
 // ── timeouts & intervals ──────────────────────────────────────────────────────
@@ -243,7 +244,13 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
     } else {
         tokio_tungstenite::connect_async(&ctrl_url).await
     }
-    .map_err(|e| Error::Connection(format!("control WS: {e}")))?;
+    .map_err(|e| {
+        Error::Connection(format!(
+            "cannot reach {} ({e}) — check network/DNS, or pass --server <host:port> \
+             or --region <eu|us|ap> to pick a different edge",
+            config.server
+        ))
+    })?;
 
     sp.set_message("Authenticating…");
 
@@ -258,39 +265,57 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
     )
     .await?;
 
-    let (session_id, server_supports_lb) =
-        match recv_frame_timeout(&mut ctrl_ws, AUTH_TIMEOUT).await? {
-            ControlFrame::AuthOk {
-                session_id,
-                server_version,
-            } => {
-                info!(%session_id, %server_version, "authenticated");
-                // TUNNEL-7 Phase 6: gate emission of the new wire fields and
-                // probe-loop spawning on server version. An older edge that
-                // doesn't recognise `TunnelHealthy` / `TunnelUnhealthy` would
-                // log a `decode_frame` warning per frame; we just refrain
-                // from sending them.
-                let supports_lb = crate::version::server_supports_load_balancing(&server_version);
-                if !supports_lb {
-                    debug!(
-                        %server_version,
-                        "server does not advertise TUNNEL-7 load-balancing support; \
-                         group fields and health probes will be suppressed for this session"
-                    );
-                }
-                (session_id, supports_lb)
+    let (session_id, server_supports_lb) = match recv_frame_timeout(&mut ctrl_ws, AUTH_TIMEOUT)
+        .await
+        .map_err(|e| with_server_context(e, &config.server))?
+    {
+        ControlFrame::AuthOk {
+            session_id,
+            server_version,
+        } => {
+            info!(%session_id, %server_version, "authenticated");
+            // TUNNEL-7 Phase 6: gate emission of the new wire fields and
+            // probe-loop spawning on server version. An older edge that
+            // doesn't recognise `TunnelHealthy` / `TunnelUnhealthy` would
+            // log a `decode_frame` warning per frame; we just refrain
+            // from sending them.
+            let supports_lb = crate::version::server_supports_load_balancing(&server_version);
+            if !supports_lb {
+                debug!(
+                    %server_version,
+                    "server does not advertise TUNNEL-7 load-balancing support; \
+                     group fields and health probes will be suppressed for this session"
+                );
             }
-            ControlFrame::AuthError { message } => {
-                sp.finish_and_clear();
-                return Err(Error::Auth(message));
-            }
-            other => {
-                sp.finish_and_clear();
-                return Err(Error::Connection(format!(
-                    "unexpected frame during auth: {other:?}"
-                )));
-            }
-        };
+            (session_id, supports_lb)
+        }
+        ControlFrame::AuthError { message } => {
+            sp.finish_and_clear();
+            let token_desc = if config.auth_token.as_deref().unwrap_or("").is_empty() {
+                "no auth token was provided".to_string()
+            } else {
+                format!(
+                    "the token came from the {}",
+                    config
+                        .auth_token_source
+                        .as_deref()
+                        .unwrap_or("client configuration")
+                )
+            };
+            return Err(Error::Auth(format!(
+                "server {} rejected authentication: {message} ({token_desc}) — \
+                     get a token at https://rustunnel.com (Dashboard -> API Keys), \
+                     or for a self-hosted server create one with `rustunnel token create`",
+                config.server
+            )));
+        }
+        other => {
+            sp.finish_and_clear();
+            return Err(Error::Connection(format!(
+                "unexpected frame during auth: {other:?}"
+            )));
+        }
+    };
 
     sp.set_message("Registering tunnels…");
 
@@ -488,16 +513,44 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
     }
 
     // 5. Print startup display ————————————————————————————————————————————
-    let display_tunnels: Vec<TunnelDisplay> = registered
-        .iter()
-        .map(|(t, url)| TunnelDisplay {
-            name: t.subdomain.clone().unwrap_or_else(|| "tunnel".into()),
-            proto: t.proto.clone(),
-            local: format!("{}:{}", t.local_host, t.local_port),
-            public_url: url.clone(),
-        })
-        .collect();
-    display::print_startup_box(&display_tunnels);
+    //    Human mode: startup box. JSON mode: one NDJSON `tunnel_ready` event
+    //    per tunnel (preceded by `reconnected` when this is a re-connect).
+    if output::json_mode() {
+        if output::take_reconnect_pending() {
+            output::emit(&output::Event::Reconnected);
+        }
+        for (t, url) in &registered {
+            // P2P subscribers don't register a tunnel and have no URL of
+            // their own — report the target they are wired to instead.
+            let url = if url.is_empty() {
+                match &t.p2p_target {
+                    Some(target) => format!("p2p://{target}"),
+                    None => continue,
+                }
+            } else {
+                url.clone()
+            };
+            output::emit(&output::Event::tunnel_ready(
+                &t.proto,
+                &url,
+                t.local_port,
+                &t.local_host,
+                t.registered_tunnel_id.map(|id| id.to_string()),
+                t.subdomain.clone().or_else(|| t.p2p_name.clone()),
+            ));
+        }
+    } else {
+        let display_tunnels: Vec<TunnelDisplay> = registered
+            .iter()
+            .map(|(t, url)| TunnelDisplay {
+                name: t.subdomain.clone().unwrap_or_else(|| "tunnel".into()),
+                proto: t.proto.clone(),
+                local: format!("{}:{}", t.local_host, t.local_port),
+                public_url: url.clone(),
+            })
+            .collect();
+        display::print_startup_box(&display_tunnels);
+    }
 
     // 6. Spawn health-probe tasks for tunnels with a health_check ─────────
     //    Each probe task writes `TunnelHealthy` / `TunnelUnhealthy` frames
@@ -901,6 +954,15 @@ async fn drive_client_mux(mut conn: DataConn, stream_tx: mpsc::Sender<(Uuid, Yam
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Append the server address to connection-class errors so timeout/closed
+/// messages say *which* server did not answer.
+fn with_server_context(e: Error, server: &str) -> Error {
+    match e {
+        Error::Connection(msg) => Error::Connection(format!("{msg} (server {server})")),
+        other => other,
+    }
+}
 
 fn proto_to_enum(proto: &str) -> Result<TunnelProtocol> {
     match proto.to_lowercase().as_str() {

--- a/crates/rustunnel-client/src/display.rs
+++ b/crates/rustunnel-client/src/display.rs
@@ -113,7 +113,11 @@ pub fn print_request(method: &str, path: &str, status: u16, duration_ms: u64) {
 }
 
 /// Create a spinner for an in-progress operation (e.g. connecting).
+/// Hidden in `--json` mode so output stays machine-readable.
 pub fn spinner(msg: &str) -> ProgressBar {
+    if crate::output::json_mode() {
+        return ProgressBar::hidden();
+    }
     let pb = ProgressBar::new_spinner();
     pb.set_style(
         ProgressStyle::with_template("{spinner:.cyan} {msg}")

--- a/crates/rustunnel-client/src/error.rs
+++ b/crates/rustunnel-client/src/error.rs
@@ -23,4 +23,44 @@ pub enum Error {
     Io(#[from] std::io::Error),
 }
 
+impl Error {
+    /// Stable machine-readable error code (snake_case variant name), used as
+    /// the `code` field of the `--json` error event.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Error::Config(_) => "config",
+            Error::Auth(_) => "auth",
+            Error::Tunnel(_) => "tunnel",
+            Error::Connection(_) => "connection",
+            Error::Protocol(_) => "protocol",
+            Error::Io(_) => "io",
+        }
+    }
+
+    /// One-line recovery hint for agents/users, when one exists for the
+    /// error category. Emitted as the `hint` field of the `--json` error event.
+    pub fn hint(&self) -> Option<&'static str> {
+        match self {
+            Error::Config(_) => Some(
+                "run `rustunnel setup` to create ~/.rustunnel/config.yml, \
+                 or pass --server <host:port> and --token <token> directly",
+            ),
+            Error::Auth(_) => Some(
+                "pass a valid token with --token or the RUSTUNNEL_TOKEN env var; \
+                 get one at https://rustunnel.com (Dashboard -> API Keys), or for a \
+                 self-hosted server create one with `rustunnel token create`",
+            ),
+            Error::Connection(_) => Some(
+                "check network connectivity and the server address; \
+                 pass --server <host:port> or --region <eu|us|ap> to pick a different edge",
+            ),
+            Error::Tunnel(_) => Some(
+                "the server rejected the tunnel registration; \
+                 try a different --subdomain or check the server-side limits",
+            ),
+            Error::Protocol(_) | Error::Io(_) => None,
+        }
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/rustunnel-client/src/error.rs
+++ b/crates/rustunnel-client/src/error.rs
@@ -45,6 +45,13 @@ impl Error {
                 "run `rustunnel setup` to create ~/.rustunnel/config.yml, \
                  or pass --server <host:port> and --token <token> directly",
             ),
+            // Auth failures from `token create` use the dashboard admin
+            // token (--admin-token), not the tunnel auth token — the message
+            // mentions "admin token", so key the hint off that.
+            Error::Auth(msg) if msg.contains("admin token") => Some(
+                "pass the server's admin token with --admin-token \
+                 (set as [auth] admin_token in the server config)",
+            ),
             Error::Auth(_) => Some(
                 "pass a valid token with --token or the RUSTUNNEL_TOKEN env var; \
                  get one at https://rustunnel.com (Dashboard -> API Keys), or for a \
@@ -64,3 +71,29 @@ impl Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_hint_points_at_admin_token_for_token_create_failures() {
+        // Message produced by `token create` on a 401/403 mentions "admin token".
+        let e = Error::Auth(
+            "token creation rejected by localhost:4040 (401): denied — \
+             pass a valid --admin-token (the server's admin token)"
+                .into(),
+        );
+        let hint = e.hint().unwrap();
+        assert!(hint.contains("--admin-token"));
+        assert!(!hint.contains("--token "));
+    }
+
+    #[test]
+    fn auth_hint_points_at_token_for_tunnel_auth_failures() {
+        let e = Error::Auth("server eu.edge.rustunnel.com:4040 rejected authentication".into());
+        let hint = e.hint().unwrap();
+        assert!(hint.contains("--token"));
+        assert!(hint.contains("RUSTUNNEL_TOKEN"));
+    }
+}

--- a/crates/rustunnel-client/src/main.rs
+++ b/crates/rustunnel-client/src/main.rs
@@ -242,8 +242,10 @@ async fn run_tunnel(proto: &str, args: TunnelArgs) -> error::Result<()> {
 
     let mut cfg = ClientConfig::load_default()?;
 
-    // Token and insecure apply unconditionally.
-    if let Some(t) = args.token {
+    // Token and insecure apply unconditionally. An empty/whitespace-only
+    // value (e.g. `RUSTUNNEL_TOKEN=""` filling the arg via clap's env
+    // support) counts as absent so it never clobbers a config-file token.
+    if let Some(t) = args.token.filter(|t| !t.trim().is_empty()) {
         cfg.auth_token = Some(t);
         cfg.auth_token_source = Some("--token flag / RUSTUNNEL_TOKEN env var".into());
     }
@@ -285,7 +287,9 @@ async fn run_p2p(args: P2pArgs) -> error::Result<()> {
 
     let mut cfg = ClientConfig::load_default()?;
 
-    if let Some(t) = args.token {
+    // Empty/whitespace-only token (e.g. `RUSTUNNEL_TOKEN=""`) counts as
+    // absent so it never clobbers a config-file token.
+    if let Some(t) = args.token.filter(|t| !t.trim().is_empty()) {
         cfg.auth_token = Some(t);
         cfg.auth_token_source = Some("--token flag / RUSTUNNEL_TOKEN env var".into());
     }

--- a/crates/rustunnel-client/src/main.rs
+++ b/crates/rustunnel-client/src/main.rs
@@ -11,6 +11,7 @@ mod control;
 mod display;
 mod error;
 mod health;
+mod output;
 mod p2p_direct;
 mod proxy;
 mod reconnect;
@@ -78,7 +79,7 @@ struct TunnelArgs {
     server: Option<String>,
 
     /// Auth token (overrides config file)
-    #[arg(long)]
+    #[arg(long, env = "RUSTUNNEL_TOKEN")]
     token: Option<String>,
 
     /// Local hostname to forward to
@@ -97,6 +98,12 @@ struct TunnelArgs {
     /// Skip TLS certificate verification (local dev only — do not use in production)
     #[arg(long)]
     insecure: bool,
+
+    /// Emit machine-readable NDJSON events (one JSON object per line) on
+    /// stdout instead of human-readable output. Events: tunnel_ready,
+    /// reconnecting, reconnected, error.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Args, Clone)]
@@ -121,7 +128,7 @@ struct P2pArgs {
     server: Option<String>,
 
     /// Auth token (overrides config file)
-    #[arg(long)]
+    #[arg(long, env = "RUSTUNNEL_TOKEN")]
     token: Option<String>,
 
     /// Local hostname to forward to
@@ -139,6 +146,12 @@ struct P2pArgs {
     /// Skip TLS certificate verification (local dev only)
     #[arg(long)]
     insecure: bool,
+
+    /// Emit machine-readable NDJSON events (one JSON object per line) on
+    /// stdout instead of human-readable output. Events: tunnel_ready,
+    /// reconnecting, reconnected, error.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Args)]
@@ -146,6 +159,12 @@ struct StartArgs {
     /// Path to config file (default: ~/.rustunnel/config.yml)
     #[arg(long, short)]
     config: Option<PathBuf>,
+
+    /// Emit machine-readable NDJSON events (one JSON object per line) on
+    /// stdout instead of human-readable output. Events: tunnel_ready,
+    /// reconnecting, reconnected, error.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Args)]
@@ -169,6 +188,11 @@ enum TokenAction {
         /// Admin token for authentication
         #[arg(long)]
         admin_token: Option<String>,
+
+        /// Emit the created token as a single machine-readable JSON line
+        /// ({"event":"token_created",...}) instead of human-readable output
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -185,7 +209,16 @@ async fn main() {
     let cli = Cli::parse();
 
     if let Err(e) = run(cli).await {
-        eprintln!("error: {e}");
+        if output::json_mode() {
+            // Machine-readable fatal error: one JSON line on stdout, exit 1.
+            output::emit(&output::Event::Error {
+                code: e.code().to_string(),
+                message: e.to_string(),
+                hint: e.hint().map(str::to_string),
+            });
+        } else {
+            eprintln!("error: {e}");
+        }
         std::process::exit(1);
     }
 }
@@ -205,11 +238,14 @@ async fn run(cli: Cli) -> error::Result<()> {
 // ── subcommand handlers ───────────────────────────────────────────────────────
 
 async fn run_tunnel(proto: &str, args: TunnelArgs) -> error::Result<()> {
+    output::set_json_mode(args.json);
+
     let mut cfg = ClientConfig::load_default()?;
 
     // Token and insecure apply unconditionally.
     if let Some(t) = args.token {
         cfg.auth_token = Some(t);
+        cfg.auth_token_source = Some("--token flag / RUSTUNNEL_TOKEN env var".into());
     }
     if args.insecure {
         cfg.insecure = true;
@@ -240,16 +276,18 @@ async fn run_tunnel(proto: &str, args: TunnelArgs) -> error::Result<()> {
     if args.no_reconnect {
         control::connect(&cfg, &tunnels).await
     } else {
-        reconnect::run_with_reconnect(cfg, tunnels).await;
-        Ok(())
+        reconnect::run_with_reconnect(cfg, tunnels).await
     }
 }
 
 async fn run_p2p(args: P2pArgs) -> error::Result<()> {
+    output::set_json_mode(args.json);
+
     let mut cfg = ClientConfig::load_default()?;
 
     if let Some(t) = args.token {
         cfg.auth_token = Some(t);
+        cfg.auth_token_source = Some("--token flag / RUSTUNNEL_TOKEN env var".into());
     }
     if args.insecure {
         cfg.insecure = true;
@@ -286,12 +324,13 @@ async fn run_p2p(args: P2pArgs) -> error::Result<()> {
     if args.no_reconnect {
         control::connect(&cfg, &tunnels).await
     } else {
-        reconnect::run_with_reconnect(cfg, tunnels).await;
-        Ok(())
+        reconnect::run_with_reconnect(cfg, tunnels).await
     }
 }
 
 async fn run_start(args: StartArgs) -> error::Result<()> {
+    output::set_json_mode(args.json);
+
     let mut cfg = match args.config {
         Some(path) => ClientConfig::load_from(&path)?,
         None => ClientConfig::load_default()?,
@@ -312,8 +351,7 @@ async fn run_start(args: StartArgs) -> error::Result<()> {
     }
 
     let tunnels: Vec<TunnelDef> = cfg.tunnels.values().cloned().collect();
-    reconnect::run_with_reconnect(cfg, tunnels).await;
-    Ok(())
+    reconnect::run_with_reconnect(cfg, tunnels).await
 }
 
 async fn run_token(cmd: TokenCmd) -> error::Result<()> {
@@ -322,7 +360,10 @@ async fn run_token(cmd: TokenCmd) -> error::Result<()> {
             name,
             server,
             admin_token,
+            json,
         } => {
+            output::set_json_mode(json);
+
             let dashboard = server.unwrap_or_else(|| "localhost:4040".to_string());
             let token = admin_token.unwrap_or_default();
 
@@ -334,22 +375,40 @@ async fn run_token(cmd: TokenCmd) -> error::Result<()> {
                 .json(&serde_json::json!({ "label": name }))
                 .send()
                 .await
-                .map_err(|e| error::Error::Connection(e.to_string()))?;
+                .map_err(|e| {
+                    error::Error::Connection(format!(
+                        "cannot reach dashboard API at {url} ({e}) — \
+                         pass --server <host:port> of the dashboard API"
+                    ))
+                })?;
 
             if resp.status().is_success() {
-                let body: serde_json::Value = resp
-                    .json()
-                    .await
-                    .map_err(|e| error::Error::Connection(e.to_string()))?;
-                println!("Token created:");
-                println!("  id:    {}", body["id"].as_str().unwrap_or("?"));
-                println!("  token: {}", body["token"].as_str().unwrap_or("?"));
-                println!("  label: {}", body["label"].as_str().unwrap_or("?"));
+                let body: serde_json::Value = resp.json().await.map_err(|e| {
+                    error::Error::Connection(format!("invalid response from {url}: {e}"))
+                })?;
+                if output::json_mode() {
+                    output::emit(&output::Event::TokenCreated {
+                        token: body["token"].as_str().unwrap_or("?").to_string(),
+                        name: body["label"].as_str().unwrap_or(&name).to_string(),
+                        id: body["id"].as_str().map(str::to_string),
+                    });
+                } else {
+                    println!("Token created:");
+                    println!("  id:    {}", body["id"].as_str().unwrap_or("?"));
+                    println!("  token: {}", body["token"].as_str().unwrap_or("?"));
+                    println!("  label: {}", body["label"].as_str().unwrap_or("?"));
+                }
             } else {
                 let status = resp.status();
                 let text = resp.text().await.unwrap_or_default();
+                if status.as_u16() == 401 || status.as_u16() == 403 {
+                    return Err(error::Error::Auth(format!(
+                        "token creation rejected by {dashboard} ({status}): {text} — \
+                         pass a valid --admin-token (the server's admin token)"
+                    )));
+                }
                 return Err(error::Error::Connection(format!(
-                    "token creation failed ({status}): {text}"
+                    "token creation failed ({status} from {dashboard}): {text}"
                 )));
             }
         }
@@ -478,6 +537,9 @@ fn init_tracing() {
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
         )
         .with_target(false)
+        // Diagnostics go to stderr so stdout stays clean for tunnel output
+        // (and valid NDJSON in --json mode).
+        .with_writer(std::io::stderr)
         .compact()
         .init();
 }

--- a/crates/rustunnel-client/src/output.rs
+++ b/crates/rustunnel-client/src/output.rs
@@ -126,7 +126,16 @@ pub fn emit(event: &Event) {
     // Event serialization is infallible: no maps with non-string keys, no
     // custom Serialize impls.
     let line = serde_json::to_string(event).expect("NDJSON event serialization cannot fail");
-    println!("{line}");
+    // Rust ignores SIGPIPE, so when the NDJSON consumer closes the pipe early
+    // (`rustunnel ... --json | head -1`) the write fails with BrokenPipe
+    // instead of killing the process. `println!` would panic on that; treat it
+    // as a normal end of output and exit cleanly.
+    use std::io::Write;
+    if let Err(e) = writeln!(std::io::stdout().lock(), "{line}") {
+        if e.kind() == std::io::ErrorKind::BrokenPipe {
+            std::process::exit(0);
+        }
+    }
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────

--- a/crates/rustunnel-client/src/output.rs
+++ b/crates/rustunnel-client/src/output.rs
@@ -1,0 +1,247 @@
+//! Output routing: human-readable (default) vs machine-readable NDJSON (`--json`).
+//!
+//! When `--json` is passed, stdout carries one JSON object per line (NDJSON)
+//! instead of the human-readable startup box / progress text. Each line is a
+//! self-contained event object with an `"event"` discriminator field:
+//!
+//! ```json
+//! {"event":"tunnel_ready","protocol":"http","public_url":"https://x.example.com","local_port":3000,...}
+//! {"event":"reconnecting","attempt":1,"reason":"connection error: ...","delay_secs":1.0}
+//! {"event":"reconnected"}
+//! {"event":"error","code":"connection","message":"...","hint":"..."}
+//! {"event":"token_created","token":"...","name":"..."}
+//! ```
+//!
+//! Human-readable output is unchanged when the flag is absent. Diagnostics
+//! (tracing, spinner) always go to stderr, so stdout stays valid NDJSON.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use serde::Serialize;
+
+static JSON_MODE: AtomicBool = AtomicBool::new(false);
+
+/// Set once at startup from the `--json` CLI flag.
+pub fn set_json_mode(enabled: bool) {
+    JSON_MODE.store(enabled, Ordering::Relaxed);
+}
+
+/// True when `--json` was passed: stdout must carry only NDJSON events.
+pub fn json_mode() -> bool {
+    JSON_MODE.load(Ordering::Relaxed)
+}
+
+// Tracks an in-progress reconnect so that the next successful connection can
+// emit a `reconnected` event before its `tunnel_ready` events.
+static RECONNECT_PENDING: AtomicBool = AtomicBool::new(false);
+
+/// Record that a reconnect attempt is in progress.
+pub fn note_reconnecting() {
+    RECONNECT_PENDING.store(true, Ordering::Relaxed);
+}
+
+/// Consume the pending-reconnect marker. Returns true exactly once after
+/// `note_reconnecting` was called.
+pub fn take_reconnect_pending() -> bool {
+    RECONNECT_PENDING.swap(false, Ordering::Relaxed)
+}
+
+/// One NDJSON event. Serialized as a single JSON object with an `"event"`
+/// discriminator (snake_case variant name).
+#[derive(Debug, Serialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum Event {
+    /// A tunnel is registered and ready to receive traffic.
+    /// `public_url` is always set; `public_addr` (host:port) is additionally
+    /// set for tcp/udp tunnels.
+    TunnelReady {
+        protocol: String,
+        public_url: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        public_addr: Option<String>,
+        local_port: u16,
+        local_host: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tunnel_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+    },
+    /// The connection dropped; the client will retry after `delay_secs`.
+    Reconnecting {
+        attempt: u32,
+        reason: String,
+        delay_secs: f64,
+    },
+    /// A reconnect attempt succeeded; fresh `tunnel_ready` events follow.
+    Reconnected,
+    /// Fatal error — the process exits with code 1 after this line.
+    Error {
+        code: String,
+        message: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        hint: Option<String>,
+    },
+    /// `rustunnel token create` succeeded.
+    TokenCreated {
+        token: String,
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+}
+
+impl Event {
+    /// Build a `tunnel_ready` event, deriving `public_addr` from `public_url`
+    /// for tcp/udp tunnels (`tcp://host:port` → `host:port`).
+    pub fn tunnel_ready(
+        protocol: &str,
+        public_url: &str,
+        local_port: u16,
+        local_host: &str,
+        tunnel_id: Option<String>,
+        name: Option<String>,
+    ) -> Self {
+        let public_addr = public_url
+            .strip_prefix("tcp://")
+            .or_else(|| public_url.strip_prefix("udp://"))
+            .map(str::to_string);
+        Event::TunnelReady {
+            protocol: protocol.to_string(),
+            public_url: public_url.to_string(),
+            public_addr,
+            local_port,
+            local_host: local_host.to_string(),
+            tunnel_id,
+            name,
+        }
+    }
+}
+
+/// Write one event as a single NDJSON line to stdout. No-op unless `--json`
+/// mode is active, so call sites can emit unconditionally.
+pub fn emit(event: &Event) {
+    if !json_mode() {
+        return;
+    }
+    // Event serialization is infallible: no maps with non-string keys, no
+    // custom Serialize impls.
+    let line = serde_json::to_string(event).expect("NDJSON event serialization cannot fail");
+    println!("{line}");
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tunnel_ready_http_serializes_with_public_url_only() {
+        let ev = Event::tunnel_ready(
+            "http",
+            "https://myapp.edge.rustunnel.com",
+            3000,
+            "localhost",
+            Some("a1b2".into()),
+            Some("myapp".into()),
+        );
+        let json = serde_json::to_string(&ev).unwrap();
+        assert_eq!(
+            json,
+            r#"{"event":"tunnel_ready","protocol":"http","public_url":"https://myapp.edge.rustunnel.com","local_port":3000,"local_host":"localhost","tunnel_id":"a1b2","name":"myapp"}"#
+        );
+    }
+
+    #[test]
+    fn tunnel_ready_tcp_derives_public_addr() {
+        let ev = Event::tunnel_ready(
+            "tcp",
+            "tcp://edge.rustunnel.com:20001",
+            5432,
+            "localhost",
+            None,
+            None,
+        );
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(v["event"], "tunnel_ready");
+        assert_eq!(v["public_url"], "tcp://edge.rustunnel.com:20001");
+        assert_eq!(v["public_addr"], "edge.rustunnel.com:20001");
+        assert!(v.get("tunnel_id").is_none());
+        assert!(v.get("name").is_none());
+    }
+
+    #[test]
+    fn tunnel_ready_udp_derives_public_addr() {
+        let ev = Event::tunnel_ready(
+            "udp",
+            "udp://edge.rustunnel.com:30001",
+            27015,
+            "localhost",
+            None,
+            None,
+        );
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
+        assert_eq!(v["public_addr"], "edge.rustunnel.com:30001");
+    }
+
+    #[test]
+    fn error_event_shape() {
+        let ev = Event::Error {
+            code: "connection".into(),
+            message: "cannot reach host".into(),
+            hint: Some("check network".into()),
+        };
+        assert_eq!(
+            serde_json::to_string(&ev).unwrap(),
+            r#"{"event":"error","code":"connection","message":"cannot reach host","hint":"check network"}"#
+        );
+    }
+
+    #[test]
+    fn error_event_omits_missing_hint() {
+        let ev = Event::Error {
+            code: "io".into(),
+            message: "broken pipe".into(),
+            hint: None,
+        };
+        assert_eq!(
+            serde_json::to_string(&ev).unwrap(),
+            r#"{"event":"error","code":"io","message":"broken pipe"}"#
+        );
+    }
+
+    #[test]
+    fn reconnect_and_token_events() {
+        let ev = Event::Reconnecting {
+            attempt: 2,
+            reason: "heartbeat timeout".into(),
+            delay_secs: 2.0,
+        };
+        assert_eq!(
+            serde_json::to_string(&ev).unwrap(),
+            r#"{"event":"reconnecting","attempt":2,"reason":"heartbeat timeout","delay_secs":2.0}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&Event::Reconnected).unwrap(),
+            r#"{"event":"reconnected"}"#
+        );
+        let ev = Event::TokenCreated {
+            token: "tok".into(),
+            name: "ci".into(),
+            id: Some("42".into()),
+        };
+        assert_eq!(
+            serde_json::to_string(&ev).unwrap(),
+            r#"{"event":"token_created","token":"tok","name":"ci","id":"42"}"#
+        );
+    }
+
+    #[test]
+    fn reconnect_pending_is_consumed_once() {
+        note_reconnecting();
+        assert!(take_reconnect_pending());
+        assert!(!take_reconnect_pending());
+    }
+}

--- a/crates/rustunnel-client/src/reconnect.rs
+++ b/crates/rustunnel-client/src/reconnect.rs
@@ -14,6 +14,8 @@ use tracing::{info, warn};
 
 use crate::config::{ClientConfig, TunnelDef};
 use crate::control;
+use crate::error::{Error, Result};
+use crate::output;
 
 const INITIAL_DELAY: Duration = Duration::from_secs(1);
 const MAX_DELAY: Duration = Duration::from_secs(60);
@@ -22,18 +24,28 @@ const JITTER: f64 = 0.20; // ±20 %
 
 /// Run `connect` with exponential-backoff retry on failure.
 ///
-/// Returns only when the connection ends cleanly (e.g. Ctrl-C) or after a
-/// fatal, non-retryable error.
-pub async fn run_with_reconnect(config: ClientConfig, tunnels: Vec<TunnelDef>) {
+/// Returns `Ok(())` when the connection ends cleanly (e.g. Ctrl-C) and
+/// `Err(_)` on a fatal, non-retryable error (auth rejection).
+pub async fn run_with_reconnect(config: ClientConfig, tunnels: Vec<TunnelDef>) -> Result<()> {
     let mut delay = INITIAL_DELAY;
     let mut attempt: u32 = 0;
+    let mut last_error = String::new();
 
     loop {
         if attempt > 0 {
-            eprintln!(
-                "  Reconnecting in {:.1}s (attempt {attempt})…",
-                delay.as_secs_f64()
-            );
+            output::note_reconnecting();
+            if output::json_mode() {
+                output::emit(&output::Event::Reconnecting {
+                    attempt,
+                    reason: last_error.clone(),
+                    delay_secs: delay.as_secs_f64(),
+                });
+            } else {
+                eprintln!(
+                    "  Reconnecting in {:.1}s (attempt {attempt})…",
+                    delay.as_secs_f64()
+                );
+            }
             tokio::time::sleep(delay).await;
             delay = next_delay(delay);
         }
@@ -44,16 +56,15 @@ pub async fn run_with_reconnect(config: ClientConfig, tunnels: Vec<TunnelDef>) {
             Ok(()) => {
                 // Clean exit (e.g. Ctrl-C) — stop retrying.
                 info!("connection closed cleanly");
-                return;
+                return Ok(());
             }
             Err(e) => {
                 // Auth failures are fatal — no point retrying.
-                let err_str = e.to_string();
-                if err_str.contains("auth") || err_str.contains("Auth") {
-                    eprintln!("  Fatal: {e}");
-                    return;
+                if matches!(e, Error::Auth(_)) {
+                    return Err(e);
                 }
                 warn!("connection error: {e}");
+                last_error = e.to_string();
                 attempt += 1;
             }
         }

--- a/crates/rustunnel-client/src/reconnect.rs
+++ b/crates/rustunnel-client/src/reconnect.rs
@@ -25,7 +25,8 @@ const JITTER: f64 = 0.20; // ±20 %
 /// Run `connect` with exponential-backoff retry on failure.
 ///
 /// Returns `Ok(())` when the connection ends cleanly (e.g. Ctrl-C) and
-/// `Err(_)` on a fatal, non-retryable error (auth rejection).
+/// `Err(_)` on a fatal, non-retryable error (auth or tunnel-registration
+/// rejection).
 pub async fn run_with_reconnect(config: ClientConfig, tunnels: Vec<TunnelDef>) -> Result<()> {
     let mut delay = INITIAL_DELAY;
     let mut attempt: u32 = 0;
@@ -59,8 +60,7 @@ pub async fn run_with_reconnect(config: ClientConfig, tunnels: Vec<TunnelDef>) -
                 return Ok(());
             }
             Err(e) => {
-                // Auth failures are fatal — no point retrying.
-                if matches!(e, Error::Auth(_)) {
+                if is_fatal(&e) {
                     return Err(e);
                 }
                 warn!("connection error: {e}");
@@ -73,10 +73,42 @@ pub async fn run_with_reconnect(config: ClientConfig, tunnels: Vec<TunnelDef>) -
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
+/// Deterministic server rejections where retrying cannot help:
+/// - `Auth` — invalid/revoked token; the server will keep rejecting it.
+/// - `Tunnel` — registration refused (subdomain taken, tunnel limit reached).
+///
+/// Connection/IO/protocol errors are transient and stay retryable.
+fn is_fatal(e: &Error) -> bool {
+    matches!(e, Error::Auth(_) | Error::Tunnel(_))
+}
+
 fn next_delay(current: Duration) -> Duration {
     let mut rng = rand::thread_rng();
     let jitter_factor = 1.0 + rng.gen_range(-JITTER..=JITTER);
     let next_secs =
         (current.as_secs_f64() * MULTIPLIER * jitter_factor).min(MAX_DELAY.as_secs_f64());
     Duration::from_secs_f64(next_secs)
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_and_tunnel_errors_are_fatal() {
+        assert!(is_fatal(&Error::Auth("bad token".into())));
+        assert!(is_fatal(&Error::Tunnel("subdomain already taken".into())));
+    }
+
+    #[test]
+    fn transient_errors_are_retryable() {
+        assert!(!is_fatal(&Error::Connection("connection refused".into())));
+        assert!(!is_fatal(&Error::Io(std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "pipe"
+        ))));
+        assert!(!is_fatal(&Error::Config("missing server".into())));
+    }
 }

--- a/crates/rustunnel-mcp/src/tools.rs
+++ b/crates/rustunnel-mcp/src/tools.rs
@@ -86,6 +86,9 @@ pub fn tool_definitions() -> Vec<Value> {
         serde_json::json!({
             "name": "create_tunnel",
             "description": "Open a tunnel to a locally running service and get a public URL. \
+                Use this when the user or task needs a public URL for a service running \
+                locally — webhook testing, sharing a dev server, or letting another agent \
+                or device reach localhost. \
                 Spawns the rustunnel CLI as a subprocess — the tunnel stays open until \
                 close_tunnel is called or the MCP server exits.\n\
                 \n\
@@ -122,8 +125,9 @@ pub fn tool_definitions() -> Vec<Value> {
         serde_json::json!({
             "name": "list_tunnels",
             "description": "List all tunnels currently open on this server. Returns the public \
-                URL, protocol, and traffic count for each active tunnel. Use this to check \
-                whether your tunnel is still running or to find the public URL of an existing tunnel.",
+                URL, protocol, and traffic count for each active tunnel. Use this when you \
+                need to check whether a tunnel is still running, recover the public URL of \
+                an existing tunnel, or find a tunnel_id to pass to close_tunnel.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -134,7 +138,9 @@ pub fn tool_definitions() -> Vec<Value> {
         serde_json::json!({
             "name": "close_tunnel",
             "description": "Force-close a specific tunnel by its ID. The public URL stops \
-                working immediately. Use list_tunnels to find the tunnel_id.",
+                working immediately. Use this when a tunnel is no longer needed or public \
+                access must be revoked right away — e.g. after a webhook test or demo \
+                finishes. Use list_tunnels to find the tunnel_id.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -147,9 +153,10 @@ pub fn tool_definitions() -> Vec<Value> {
         serde_json::json!({
             "name": "get_connection_info",
             "description": "Get the CLI command (and, for load-balanced tunnels, a config file) \
-                needed to create a tunnel manually — without spawning anything. Use this when the \
-                MCP server cannot spawn subprocesses (e.g. cloud sandbox) or when you prefer to \
-                run the client yourself. Accepts the same arguments as create_tunnel.",
+                needed to create a tunnel manually — without spawning anything. Use this when \
+                the MCP server cannot spawn subprocesses (e.g. cloud sandbox), when the tunnel \
+                must outlive the MCP server, or when you prefer to run the client yourself. \
+                Accepts the same arguments as create_tunnel.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -172,14 +179,16 @@ pub fn tool_definitions() -> Vec<Value> {
         serde_json::json!({
             "name": "list_regions",
             "description": "List available tunnel server regions with their IDs, names, \
-                and locations. Use this to pick a specific region for create_tunnel. \
+                and locations. Use this when you need to pick a specific `region` for \
+                create_tunnel or check which edge locations exist. \
                 No authentication required.",
             "inputSchema": { "type": "object", "properties": {} }
         }),
         serde_json::json!({
             "name": "get_tunnel_history",
             "description": "Retrieve the history of past tunnels, including their duration and \
-                which token opened them. Useful for auditing activity or debugging dropped tunnels.",
+                which token opened them. Use this when auditing past tunnel activity or \
+                debugging why a tunnel dropped or is no longer listed by list_tunnels.",
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -489,12 +489,13 @@ This table summarises all flags across all commands:
 | Flag | Commands | Description |
 |------|----------|-------------|
 | `--server <host:port>` | http, tcp | Tunnel server address (bypasses region selection) |
-| `--token <token>` | http, tcp | Auth token (overrides config) |
+| `--token <token>` | http, tcp | Auth token (overrides config; also read from `RUSTUNNEL_TOKEN`) |
 | `--subdomain <name>` | http | Requested HTTP subdomain |
 | `--local-host <host>` | http, tcp | Local hostname (default: `localhost`) |
 | `--region <id>` | http, tcp | Region: `eu`, `us`, `ap`, or `auto`. Ignored if `--server` is set. |
 | `--no-reconnect` | http, tcp | Exit on failure instead of reconnecting |
 | `--insecure` | http, tcp | Skip TLS certificate verification |
+| `--json` | http, tcp, udp, p2p, start, token create | Emit machine-readable NDJSON events on stdout instead of human output |
 | `-c, --config <path>` | start | Config file path |
 | `--name <label>` | token create | Token label (required) |
 | `--admin-token <token>` | token create | Admin token for dashboard API |
@@ -610,6 +611,16 @@ Color coding:
 - Public URL — **bold green**
 - Border — cyan
 
+### JSON output (`--json`)
+
+With `--json`, the spinner and startup box are suppressed and stdout instead carries NDJSON — one JSON event object per line — for scripts and AI agents:
+
+```json
+{"event":"tunnel_ready","protocol":"http","public_url":"https://myapp.tunnel.example.com","local_port":3000,"local_host":"localhost","tunnel_id":"6f9a…","name":"myapp"}
+```
+
+Events: `tunnel_ready` (includes `public_addr` host:port for tcp/udp), `reconnecting` (`attempt`, `reason`, `delay_secs`), `reconnected`, `error` (`code`, `message`, `hint`; exit code 1 follows), and `token_created` (for `token create --json`). Diagnostics still go to stderr.
+
 ### Graceful shutdown
 
 Press `Ctrl-C` to cleanly close the tunnel and exit. The control WebSocket is closed before the process exits.
@@ -621,6 +632,7 @@ Press `Ctrl-C` to cleanly close the tunnel and exit. The control WebSocket is cl
 | Variable | Description |
 |----------|-------------|
 | `RUST_LOG` | Log level filter (e.g. `debug`, `info`, `warn`, `rustunnel=debug`). Default: `warn`. |
+| `RUSTUNNEL_TOKEN` | Auth token, used when `--token` is not passed. Takes precedence over the config file. |
 
 **Examples:**
 
@@ -635,7 +647,7 @@ RUST_LOG=rustunnel=debug rustunnel http 3000
 RUST_LOG=error rustunnel http 3000
 ```
 
-Log output goes to **stderr**. Normal tunnel output (startup box, reconnect messages) goes to **stdout**.
+Log output and human-readable reconnect notices go to **stderr**. Normal tunnel output (startup box, or NDJSON events with `--json`) goes to **stdout**.
 
 ---
 
@@ -646,7 +658,7 @@ Log output goes to **stderr**. Normal tunnel output (startup box, reconnect mess
 | `config error: server address is required` | No `--server` flag and no config file | Add `server:` to `~/.rustunnel/config.yml` or pass `--server` |
 | `auth failed: <message>` | Token invalid or revoked | Create a new token at [rustunnel.com](https://rustunnel.com) (Dashboard → API Keys) or with `rustunnel token create` for self-hosted setups |
 | `tunnel error: <message>` | Subdomain already in use or server limit reached | Use a different `--subdomain` or wait |
-| `connection error: control WS: …` | Can't reach the server | Check network, firewall, and server address |
+| `connection error: cannot reach <server> (…)` | Can't reach the server | Check network, firewall, and server address; pass `--server <host:port>` or `--region <id>` |
 | `connection error: heartbeat timeout` | Server stopped responding to pings | Transient — reconnect loop will retry |
 | `connection error: timeout waiting for server response` | Auth/registration timed out (10 s) | Check server health; may be overloaded |
 | `no tunnels defined in config file` | `rustunnel start` with an empty `tunnels:` map | Add at least one tunnel to the config |

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -564,6 +564,7 @@ Each delay has ±20% random jitter to prevent thundering-herd reconnects when a 
 The following errors cause an immediate exit — retrying would not help:
 
 - **Auth failed** — invalid or revoked token. Fix: create a new token at [rustunnel.com](https://rustunnel.com) (Dashboard → API Keys) and update your config.
+- **Tunnel error** — the server rejected the registration (subdomain already taken, tunnel limit reached). Fix: pick a different `--subdomain` or close an existing tunnel.
 - **Config error** — missing required fields. Fix: check your `~/.rustunnel/config.yml`.
 
 ### Disabling reconnect
@@ -632,7 +633,7 @@ Press `Ctrl-C` to cleanly close the tunnel and exit. The control WebSocket is cl
 | Variable | Description |
 |----------|-------------|
 | `RUST_LOG` | Log level filter (e.g. `debug`, `info`, `warn`, `rustunnel=debug`). Default: `warn`. |
-| `RUSTUNNEL_TOKEN` | Auth token, used when `--token` is not passed. Takes precedence over the config file. |
+| `RUSTUNNEL_TOKEN` | Auth token for the `http`, `tcp`, `udp`, and `p2p` commands, used when `--token` is not passed (takes precedence over the config file; empty values are ignored). `start` reads tokens from the config file only, and `token create` authenticates with `--admin-token`. |
 
 **Examples:**
 


### PR DESCRIPTION
## What

W6 of **TUNNEL-16 — Agentic SEO**: make the CLI and MCP server pleasant for AI agents to drive.

- **`--json` (additive)** on `http`/`tcp`/`udp`/`p2p`/`start`/`token create`: NDJSON events on stdout — `tunnel_ready` (with `public_url` / `public_addr`), `reconnecting` (attempt/reason/delay), `reconnected`, `error` (stable `code` + `message` + recovery `hint`), `token_created`. Default human output unchanged; spinner hidden and tracing routed to stderr in JSON mode.
- **Self-describing errors**: connection errors name the server attempted; auth errors name the token source and where to get a token; `Error::code()`/`Error::hint()` power the JSON `error` event.
- **MCP tool descriptions**: all six tools now lead with the imperative and include an explicit "Use this when…" sentence (string-only changes, no schema changes).
- **`--token` now also reads `RUSTUNNEL_TOKEN`** (empty/whitespace values ignored so they can't clobber a config-file token); docs scoped accurately (`start` reads the config file; `token create` uses `--admin-token`).

## Bugs fixed in passing

- Tracing logs went to **stdout** (docs already claimed stderr) — would have corrupted NDJSON and already polluted piped output.
- Auth failure under the default reconnect loop **exited 0**; now propagates and exits 1.
- Deterministic server rejections (`Error::Tunnel`, e.g. subdomain taken) retried forever under reconnect; now fatal — agents get one `error` event and exit 1.
- `--json | head -1` style early-closing consumers caused a broken-pipe **panic (exit 101)**; now a silent exit 0.

## Verification

- `make check` (fmt + clippy `-D warnings`) and `cargo build --workspace` clean.
- Full `cargo test --workspace` against a disposable postgres:16: all suites pass (local 5432 is occupied by an unrelated container). Final branch: 32/32 in client+mcp crates, incl. 12 new tests (NDJSON shapes, reconnect fatality, hint dispatch).
- Manual: unreachable server with `--json` → exactly one valid JSON error line, exit 1; live server kill/restart → `reconnecting…` → `reconnected` → `tunnel_ready` sequence, every line valid JSON.

## Release note

rustunnel.com/agents.md and the published skill say `--json` lands in **rustunnel ≥ 0.8** — recommend releasing this as **0.8.0** (and updating the brew tap). If it ships under a different version, update `web/content/agents.md` + `skills/rustunnel/SKILL.md` in rustunnel-web.

Companion PRs: joaoh82/rustunnel-web#34, joaoh82/docs#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)