### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-client"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-mcp"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "clap",
  "reqwest 0.12.28",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-protocol"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-server"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ socket2 = { version = "0.5", features = ["all"] }
 quinn = "0.11"
 sentry = { version = "0.47", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls", "tracing", "logs"] }
 sentry-tracing = "0.47"
-rustunnel-protocol = { path = "crates/rustunnel-protocol", version = "0.7.8" }
+rustunnel-protocol = { path = "crates/rustunnel-protocol", version = "0.8.0" }

--- a/crates/rustunnel-client/Cargo.toml
+++ b/crates/rustunnel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-client"
-version = "0.7.8"
+version = "0.8.0"
 edition = "2021"
 description = "CLI client for rustunnel — open-source secure tunnel server. Expose local HTTP/HTTPS/TCP/UDP services from your machine to a public URL."
 keywords = ["tunnel", "ngrok", "cli", "webhook", "reverse-proxy"]

--- a/crates/rustunnel-mcp/Cargo.toml
+++ b/crates/rustunnel-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-mcp"
-version = "0.7.8"
+version = "0.8.0"
 edition = "2021"
 description = "MCP (Model Context Protocol) server for rustunnel. Lets AI agents (Claude Code, Cursor, Windsurf) create and manage public tunnels to local services from inside an agent session."
 keywords = ["mcp", "tunnel", "claude", "ai-agent", "webhook"]

--- a/crates/rustunnel-protocol/Cargo.toml
+++ b/crates/rustunnel-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-protocol"
-version = "0.7.8"
+version = "0.8.0"
 edition = "2021"
 description = "Shared protocol types for rustunnel — the open-source secure tunnel server. Used by rustunnel-server, rustunnel-client, and rustunnel-mcp."
 keywords = ["tunnel", "ngrok", "protocol", "rustunnel"]

--- a/crates/rustunnel-server/Cargo.toml
+++ b/crates/rustunnel-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-server"
-version = "0.7.8"
+version = "0.8.0"
 edition = "2021"
 description = "Self-hosted, secure tunnel server in Rust. Exposes local HTTP/HTTPS/TCP/UDP services via TLS-encrypted WebSocket. Open-source ngrok alternative with multi-region and Prometheus metrics."
 keywords = ["tunnel", "ngrok", "self-hosted", "reverse-proxy", "webhook"]


### PR DESCRIPTION
Version bump for the agent-friendly CLI release (#77): `--json` NDJSON events, `RUSTUNNEL_TOKEN` env support, self-describing errors, MCP when-to-use descriptions. Tagging `v0.8.0` after merge triggers the release pipeline (6 targets + server binary + automatic Homebrew tap update).

0.8.0 matches the "rustunnel ≥ 0.8" claim already live on rustunnel.com/agents.md and the published skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)