### PR TITLE
Add MCP registry listing (server.json + rustunnel-mcp crate README)

### DIFF
--- a/crates/rustunnel-mcp/Cargo.toml
+++ b/crates/rustunnel-mcp/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["network-programming", "command-line-utilities", "development-tool
 license = "AGPL-3.0"
 repository = "https://github.com/joaoh82/rustunnel"
 homepage = "https://rustunnel.com"
-readme = "../../README.md"
+readme = "README.md"
 
 [[bin]]
 name = "rustunnel-mcp"

--- a/crates/rustunnel-mcp/README.md
+++ b/crates/rustunnel-mcp/README.md
@@ -1,0 +1,66 @@
+# rustunnel-mcp
+
+Expose any localhost service so an AI agent can reach it — public HTTPS/TCP/UDP
+URLs via six MCP tools. Open source, self-hostable.
+
+`rustunnel-mcp` is the [Model Context Protocol](https://modelcontextprotocol.io)
+server for [rustunnel](https://rustunnel.com), an open-source tunnel server
+written in Rust. Any MCP-compatible agent (Claude Code, Claude Desktop, Cursor,
+Windsurf, Cline, Codex) can give a local service a public URL in one tool call:
+test webhooks against a local server, share a dev build, or let another agent
+or device reach localhost.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `create_tunnel` | Open a tunnel and get a public URL (HTTP/TCP/UDP, P2P, load-balanced pools) |
+| `list_tunnels` | List active tunnels / recover a public URL |
+| `close_tunnel` | Close a tunnel by ID |
+| `get_connection_info` | Get the CLI command instead of spawning (sandboxes) |
+| `list_regions` | List edge regions (eu / us / ap) |
+| `get_tunnel_history` | Audit past tunnel activity |
+
+## Install
+
+```bash
+# Homebrew (installs rustunnel CLI + rustunnel-mcp)
+brew tap joaoh82/rustunnel && brew install rustunnel
+
+# Cargo
+cargo install rustunnel-mcp
+```
+
+> The MCP server spawns the `rustunnel` CLI to open tunnels — both binaries
+> must be on `PATH`. With a cargo-only install, grab the CLI from
+> [GitHub releases](https://github.com/joaoh82/rustunnel/releases/latest) or
+> the Homebrew tap.
+
+## Configure your agent
+
+Get a free API token at [rustunnel.com](https://rustunnel.com) (Dashboard →
+API Keys), then add to your MCP client config (`.mcp.json`, `.cursor/mcp.json`,
+etc.):
+
+```json
+{
+  "mcpServers": {
+    "rustunnel": {
+      "command": "rustunnel-mcp",
+      "args": ["--server", "eu.edge.rustunnel.com:4040", "--api", "https://eu.edge.rustunnel.com:8443"],
+      "env": { "RUSTUNNEL_TOKEN": "<your-token>" }
+    }
+  }
+}
+```
+
+Self-hosting? Point `--server` / `--api` at your own instance — the same
+server binary is free under AGPL.
+
+## Links
+
+- Website: <https://rustunnel.com>
+- Agent manual (copy-paste recipes): <https://rustunnel.com/agents.md>
+- Per-harness setup: <https://rustunnel.com/docs/guides/agent-integration>
+- Source: <https://github.com/joaoh82/rustunnel>
+- MCP Registry name: `mcp-name: io.github.joaoh82/rustunnel`

--- a/server.json
+++ b/server.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.joaoh82/rustunnel",
+  "title": "rustunnel",
+  "description": "Expose any localhost service so an AI agent can reach it — public HTTPS/TCP/UDP URLs via six MCP tools. Open source, self-hostable.",
+  "repository": {
+    "url": "https://github.com/joaoh82/rustunnel",
+    "source": "github"
+  },
+  "websiteUrl": "https://rustunnel.com",
+  "version": "0.8.0",
+  "packages": [
+    {
+      "registryType": "cargo",
+      "identifier": "rustunnel-mcp",
+      "version": "0.8.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "named",
+          "name": "--server",
+          "value": "eu.edge.rustunnel.com:4040",
+          "description": "rustunnel control-plane address (your own host:4040 when self-hosting)"
+        },
+        {
+          "type": "named",
+          "name": "--api",
+          "value": "https://eu.edge.rustunnel.com:8443",
+          "description": "rustunnel dashboard REST API base URL"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "RUSTUNNEL_TOKEN",
+          "description": "API token from rustunnel.com → Dashboard → API Keys (or your self-hosted admin token)",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Groundwork for listing rustunnel in the official MCP registry (TUNNEL-16 W1):

- `server.json` — registry entry (`io.github.joaoh82/rustunnel`, schema 2025-12-11) using the `cargo` package type pointing at the `rustunnel-mcp` crate, with `--server`/`--api` arguments and the `RUSTUNNEL_TOKEN` env var declared.
- `crates/rustunnel-mcp/README.md` — crate-specific README for the crates.io page, containing the visible `mcp-name:` ownership token the registry validator checks (crates.io strips HTML comments, so it must be visible text). `Cargo.toml` now points at it.

After merge the flow is: `cargo publish -p rustunnel-mcp` (0.8.0) → `mcp-publisher login github` → `mcp-publisher publish`.

`cargo package -p rustunnel-mcp` verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)