### PR TITLE
Shorten server.json description to registry limit

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.joaoh82/rustunnel",
   "title": "rustunnel",
-  "description": "Expose any localhost service so an AI agent can reach it — public HTTPS/TCP/UDP URLs via six MCP tools. Open source, self-hostable.",
+  "description": "Give AI agents public HTTPS/TCP/UDP URLs for any localhost service. Open source, self-hostable.",
   "repository": {
     "url": "https://github.com/joaoh82/rustunnel",
     "source": "github"


### PR DESCRIPTION
The live MCP registry enforces a 100-char description limit (ours was 133). New description: "Give AI agents public HTTPS/TCP/UDP URLs for any localhost service. Open source, self-hostable." (95 chars).

Publishing is still blocked on the production registry deploying `registryType: cargo` support (documented on their main, rejected by the live validator: "unsupported registry type: cargo"). `rustunnel-mcp@0.8.0` is already on crates.io with the ownership token in its README, so once cargo support deploys, `mcp-publisher login github && mcp-publisher publish` is all that's left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)