### PR TITLE
MCPB bundles + automated MCP-registry publishing; bump to 0.8.1

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -31,8 +31,12 @@ jobs:
       contents: read
 
     steps:
+      # Check out the tag being published so server.json and the generator
+      # script match the release, even on manual re-runs from the Actions tab.
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Download .mcpb checksums from the release
         env:
@@ -54,9 +58,18 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
 
+      # Pinned (this job holds an OIDC credential for our registry namespace —
+      # don't run an unpinned upstream binary with it). Checksum comes from the
+      # same release's checksums file; bump the tag deliberately.
       - name: Install mcp-publisher
+        env:
+          PUBLISHER_TAG: v1.7.9
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          ASSET="mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"
+          BASE="https://github.com/modelcontextprotocol/registry/releases/download/${PUBLISHER_TAG}"
+          curl -fsSLO "${BASE}/${ASSET}"
+          curl -fsSL "${BASE}/registry_${PUBLISHER_TAG#v}_checksums.txt" | grep " ${ASSET}\$" | sha256sum -c -
+          tar xzf "${ASSET}" mcp-publisher
 
       - name: Authenticate to MCP Registry
         run: ./mcp-publisher login github-oidc

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,65 @@
+# Publishes server.json to the official MCP registry
+# (registry.modelcontextprotocol.io) using GitHub OIDC — no tokens or device
+# codes. Called by release.yml after each release, and runnable any time from
+# the Actions tab (workflow_dispatch) to retry a publish — e.g. after the
+# registry deploys support for a new package type.
+#
+# Packages are generated from the release's .mcpb assets by
+# deploy/mcpb/make-server-json.sh; the checked-in server.json provides the
+# static fields (and a cargo package the production registry doesn't accept
+# yet — the script drops it until registry > v1.7.9 ships).
+name: Publish to MCP Registry
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v0.8.1)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC authentication with the MCP registry
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download .mcpb checksums from the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p shas
+          gh release download "${{ inputs.tag }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "rustunnel-mcp-*.mcpb.sha256" \
+            --dir shas
+          ls -l shas/
+
+      - name: Generate server.json
+        run: |
+          VERSION="${TAG#v}"
+          ./deploy/mcpb/make-server-json.sh "$VERSION" shas server.json > server.publish.json
+          mv server.publish.json server.json
+          jq '{name, version, packages: [.packages[] | {registryType, identifier}]}' server.json
+        env:
+          TAG: ${{ inputs.tag }}
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,9 +177,53 @@ jobs:
             rustunnel-server-linux-x86_64.sha256
           retention-days: 1
 
+  build-mcpb:
+    name: Package MCPB bundles
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download client/MCP artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: archives/
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Repack archives into .mcpb bundles
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          mkdir -p mcpb-out
+          # One bundle per OS/arch the registry should offer. linux x86_64
+          # uses the musl build (fully static — runs on any distro).
+          for target in \
+            aarch64-apple-darwin \
+            x86_64-apple-darwin \
+            x86_64-unknown-linux-musl \
+            aarch64-unknown-linux-gnu \
+            x86_64-pc-windows-msvc; do
+            archive=$(ls archives/rustunnel-v${VERSION}-${target}.tar.gz archives/rustunnel-v${VERSION}-${target}.zip 2>/dev/null | head -1)
+            if [[ -z "$archive" ]]; then
+              echo "::error::no archive found for ${target}"
+              exit 1
+            fi
+            ./deploy/mcpb/build-mcpb.sh "$VERSION" "$target" "$archive" mcpb-out
+          done
+          ls -lh mcpb-out/
+
+      - name: Upload MCPB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-mcpb
+          path: mcpb-out/*
+          retention-days: 1
+
   publish:
     name: Create GitHub Release
-    needs: [build, build-server]
+    needs: [build, build-server, build-mcpb]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -231,3 +275,15 @@ jobs:
             "${{ github.ref_name }}" \
             "joaoh82/rustunnel" \
             "joaoh82/homebrew-rustunnel"
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: [publish]
+    # Skip pre-releases, same as the Homebrew update.
+    if: ${{ !contains(github.ref_name, '-') }}
+    uses: ./.github/workflows/publish-mcp.yml
+    with:
+      tag: ${{ github.ref_name }}
+    permissions:
+      id-token: write
+      contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Pattern also matches release-server-* / release-mcpb on re-runs;
+      # harmless — the loop below selects exact filenames.
       - name: Download client/MCP artifacts
         uses: actions/download-artifact@v4
         with:
@@ -199,13 +201,19 @@ jobs:
           mkdir -p mcpb-out
           # One bundle per OS/arch the registry should offer. linux x86_64
           # uses the musl build (fully static — runs on any distro).
+          # (No aarch64-musl build exists in the matrix, so the linux arm64
+          # bundle is glibc-based and won't run on Alpine ARM hosts.)
           for target in \
             aarch64-apple-darwin \
             x86_64-apple-darwin \
             x86_64-unknown-linux-musl \
             aarch64-unknown-linux-gnu \
             x86_64-pc-windows-msvc; do
-            archive=$(ls archives/rustunnel-v${VERSION}-${target}.tar.gz archives/rustunnel-v${VERSION}-${target}.zip 2>/dev/null | head -1)
+            archive=""
+            for ext in tar.gz zip; do
+              f="archives/rustunnel-v${VERSION}-${target}.${ext}"
+              if [[ -f "$f" ]]; then archive=$f; break; fi
+            done
             if [[ -z "$archive" ]]; then
               echo "::error::no archive found for ${target}"
               exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-client"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-mcp"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "clap",
  "reqwest 0.12.28",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-protocol"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-server"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arc-swap",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ socket2 = { version = "0.5", features = ["all"] }
 quinn = "0.11"
 sentry = { version = "0.47", default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "rustls", "tracing", "logs"] }
 sentry-tracing = "0.47"
-rustunnel-protocol = { path = "crates/rustunnel-protocol", version = "0.8.0" }
+rustunnel-protocol = { path = "crates/rustunnel-protocol", version = "0.8.1" }

--- a/crates/rustunnel-client/Cargo.toml
+++ b/crates/rustunnel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-client"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "CLI client for rustunnel — open-source secure tunnel server. Expose local HTTP/HTTPS/TCP/UDP services from your machine to a public URL."
 keywords = ["tunnel", "ngrok", "cli", "webhook", "reverse-proxy"]

--- a/crates/rustunnel-mcp/Cargo.toml
+++ b/crates/rustunnel-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-mcp"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "MCP (Model Context Protocol) server for rustunnel. Lets AI agents (Claude Code, Cursor, Windsurf) create and manage public tunnels to local services from inside an agent session."
 keywords = ["mcp", "tunnel", "claude", "ai-agent", "webhook"]

--- a/crates/rustunnel-mcp/src/tools.rs
+++ b/crates/rustunnel-mcp/src/tools.rs
@@ -62,6 +62,36 @@ fn resolve_token(args: &Value, state: &State) -> Option<String> {
     )
 }
 
+/// Locate the `rustunnel` CLI binary that `create_tunnel` spawns.
+///
+/// Resolution order:
+/// 1. `RUSTUNNEL_CLI` env var — set by packaged installs (e.g. the MCPB
+///    bundle points it at the CLI shipped inside the bundle).
+/// 2. A `rustunnel` binary sitting next to this `rustunnel-mcp` executable —
+///    covers bundles and tarball installs without any configuration.
+/// 3. Plain `rustunnel`, resolved through `PATH` (the historical behaviour).
+fn resolve_cli_path() -> PathBuf {
+    if let Ok(p) = std::env::var("RUSTUNNEL_CLI") {
+        if !p.trim().is_empty() {
+            return PathBuf::from(p);
+        }
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let name = if cfg!(windows) {
+                "rustunnel.exe"
+            } else {
+                "rustunnel"
+            };
+            let sibling = dir.join(name);
+            if sibling.is_file() {
+                return sibling;
+            }
+        }
+    }
+    PathBuf::from("rustunnel")
+}
+
 // ── tool definitions (returned by tools/list) ─────────────────────────────────
 
 pub fn tool_definitions() -> Vec<Value> {
@@ -536,7 +566,8 @@ async fn create_tunnel(args: &Value, state: &Arc<State>) -> Value {
     };
 
     // Build and spawn the CLI command.
-    let mut cmd = tokio::process::Command::new("rustunnel");
+    let cli = resolve_cli_path();
+    let mut cmd = tokio::process::Command::new(&cli);
     cmd.args(&plan.args)
         // Suppress CLI output so it doesn't interfere with MCP stdio.
         .stdin(std::process::Stdio::null())
@@ -547,8 +578,10 @@ async fn create_tunnel(args: &Value, state: &Arc<State>) -> Value {
         Err(e) => {
             cleanup_temp(&plan.temp_config);
             return tool_err(format!(
-                "failed to spawn rustunnel: {e}. \
-                Is the 'rustunnel' binary installed and in PATH?"
+                "failed to spawn rustunnel ({}): {e}. \
+                Install the 'rustunnel' CLI and put it on PATH, \
+                or point the RUSTUNNEL_CLI env var at the binary.",
+                cli.display()
             ));
         }
     };
@@ -892,5 +925,18 @@ mod tests {
     #[test]
     fn yaml_str_escapes() {
         assert_eq!(yaml_str("a\"b\\c"), "\"a\\\"b\\\\c\"");
+    }
+
+    #[test]
+    fn resolve_cli_path_prefers_env_var() {
+        // Serialize env mutation: cargo runs tests in parallel within one
+        // process, but no other test in this crate touches RUSTUNNEL_CLI.
+        std::env::set_var("RUSTUNNEL_CLI", "/opt/custom/rustunnel");
+        assert_eq!(resolve_cli_path(), PathBuf::from("/opt/custom/rustunnel"));
+        std::env::set_var("RUSTUNNEL_CLI", "   ");
+        // Whitespace-only is treated as unset → sibling lookup or PATH name.
+        let p = resolve_cli_path();
+        assert!(p == std::path::Path::new("rustunnel") || p.ends_with("rustunnel"));
+        std::env::remove_var("RUSTUNNEL_CLI");
     }
 }

--- a/crates/rustunnel-mcp/src/tools.rs
+++ b/crates/rustunnel-mcp/src/tools.rs
@@ -71,10 +71,14 @@ fn resolve_token(args: &Value, state: &State) -> Option<String> {
 ///    covers bundles and tarball installs without any configuration.
 /// 3. Plain `rustunnel`, resolved through `PATH` (the historical behaviour).
 fn resolve_cli_path() -> PathBuf {
-    if let Ok(p) = std::env::var("RUSTUNNEL_CLI") {
-        if !p.trim().is_empty() {
-            return PathBuf::from(p);
-        }
+    resolve_cli_path_from(std::env::var("RUSTUNNEL_CLI").ok().as_deref())
+}
+
+/// Pure resolution logic, split out so it can be unit-tested without
+/// mutating process environment (env mutation races with parallel tests).
+fn resolve_cli_path_from(env_override: Option<&str>) -> PathBuf {
+    if let Some(p) = env_override.map(str::trim).filter(|p| !p.is_empty()) {
+        return PathBuf::from(p);
     }
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
@@ -928,15 +932,25 @@ mod tests {
     }
 
     #[test]
-    fn resolve_cli_path_prefers_env_var() {
-        // Serialize env mutation: cargo runs tests in parallel within one
-        // process, but no other test in this crate touches RUSTUNNEL_CLI.
-        std::env::set_var("RUSTUNNEL_CLI", "/opt/custom/rustunnel");
-        assert_eq!(resolve_cli_path(), PathBuf::from("/opt/custom/rustunnel"));
-        std::env::set_var("RUSTUNNEL_CLI", "   ");
-        // Whitespace-only is treated as unset → sibling lookup or PATH name.
-        let p = resolve_cli_path();
-        assert!(p == std::path::Path::new("rustunnel") || p.ends_with("rustunnel"));
-        std::env::remove_var("RUSTUNNEL_CLI");
+    fn resolve_cli_path_prefers_env_override() {
+        assert_eq!(
+            resolve_cli_path_from(Some("/opt/custom/rustunnel")),
+            PathBuf::from("/opt/custom/rustunnel")
+        );
+        // Surrounding whitespace is trimmed off the override.
+        assert_eq!(
+            resolve_cli_path_from(Some("  /opt/custom/rustunnel ")),
+            PathBuf::from("/opt/custom/rustunnel")
+        );
+        // Whitespace-only / unset → sibling lookup or bare PATH name.
+        for empty in [Some("   "), None] {
+            let p = resolve_cli_path_from(empty);
+            let name = if cfg!(windows) {
+                "rustunnel.exe"
+            } else {
+                "rustunnel"
+            };
+            assert!(p.ends_with(name));
+        }
     }
 }

--- a/crates/rustunnel-protocol/Cargo.toml
+++ b/crates/rustunnel-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-protocol"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "Shared protocol types for rustunnel — the open-source secure tunnel server. Used by rustunnel-server, rustunnel-client, and rustunnel-mcp."
 keywords = ["tunnel", "ngrok", "protocol", "rustunnel"]

--- a/crates/rustunnel-server/Cargo.toml
+++ b/crates/rustunnel-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-server"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "Self-hosted, secure tunnel server in Rust. Exposes local HTTP/HTTPS/TCP/UDP services via TLS-encrypted WebSocket. Open-source ngrok alternative with multi-region and Prometheus metrics."
 keywords = ["tunnel", "ngrok", "self-hosted", "reverse-proxy", "webhook"]

--- a/deploy/mcpb/build-mcpb.sh
+++ b/deploy/mcpb/build-mcpb.sh
@@ -19,6 +19,10 @@ TARGET=$2
 ARCHIVE=$3
 OUT_DIR=$4
 
+# Resolve to an absolute path up front — later steps cd into temp dirs.
+mkdir -p "$OUT_DIR"
+OUT_DIR=$(cd "$OUT_DIR" && pwd)
+
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 TEMPLATE="$SCRIPT_DIR/manifest.template.json"
 
@@ -31,7 +35,7 @@ esac
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
-mkdir -p "$WORK/extract" "$WORK/bundle/server" "$OUT_DIR"
+mkdir -p "$WORK/extract" "$WORK/bundle/server"
 
 case "$ARCHIVE" in
   *.zip)    unzip -q "$ARCHIVE" -d "$WORK/extract" ;;
@@ -59,7 +63,7 @@ jq empty "$WORK/bundle/manifest.json"
 
 BUNDLE="$OUT_DIR/rustunnel-mcp-$TARGET.mcpb"
 rm -f "$BUNDLE"
-(cd "$WORK/bundle" && zip -qr "$(cd "$OUT_DIR" && pwd)/$(basename "$BUNDLE")" .)
+(cd "$WORK/bundle" && zip -qr "$BUNDLE" .)
 
 (cd "$OUT_DIR" && { sha256sum "$(basename "$BUNDLE")" 2>/dev/null \
   || shasum -a 256 "$(basename "$BUNDLE")"; } > "$(basename "$BUNDLE").sha256")

--- a/deploy/mcpb/build-mcpb.sh
+++ b/deploy/mcpb/build-mcpb.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Repack one rustunnel release archive into an MCPB bundle
+# (https://github.com/anthropics/mcpb) for the official MCP registry and
+# MCPB-aware clients (Claude Desktop double-click install).
+#
+# Usage: build-mcpb.sh <version> <target-triple> <archive> <out-dir>
+#   version        e.g. 0.8.1 (no leading v)
+#   target-triple  e.g. aarch64-apple-darwin
+#   archive        path to rustunnel-v<version>-<target>.tar.gz (or .zip)
+#   out-dir        where rustunnel-mcp-<target>.mcpb (+ .sha256) is written
+#
+# The bundle contains BOTH binaries: rustunnel-mcp (entry point) and the
+# rustunnel CLI it spawns, wired together via the RUSTUNNEL_CLI env var in
+# the manifest (requires rustunnel-mcp >= 0.8.1).
+set -euo pipefail
+
+VERSION=$1
+TARGET=$2
+ARCHIVE=$3
+OUT_DIR=$4
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TEMPLATE="$SCRIPT_DIR/manifest.template.json"
+
+case "$TARGET" in
+  *apple-darwin*) PLATFORM=darwin EXE="" ;;
+  *windows*)      PLATFORM=win32  EXE=".exe" ;;
+  *linux*)        PLATFORM=linux  EXE="" ;;
+  *) echo "unknown target: $TARGET" >&2; exit 1 ;;
+esac
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/extract" "$WORK/bundle/server" "$OUT_DIR"
+
+case "$ARCHIVE" in
+  *.zip)    unzip -q "$ARCHIVE" -d "$WORK/extract" ;;
+  *.tar.gz) tar -xzf "$ARCHIVE" -C "$WORK/extract" ;;
+  *) echo "unknown archive format: $ARCHIVE" >&2; exit 1 ;;
+esac
+
+for bin in "rustunnel-mcp$EXE" "rustunnel$EXE"; do
+  src=$(find "$WORK/extract" -name "$bin" -type f | head -1)
+  if [[ -z "$src" ]]; then
+    echo "binary $bin not found in $ARCHIVE" >&2
+    exit 1
+  fi
+  cp "$src" "$WORK/bundle/server/"
+  chmod +x "$WORK/bundle/server/$bin"
+done
+
+sed -e "s/__VERSION__/$VERSION/g" \
+    -e "s/__PLATFORM__/$PLATFORM/g" \
+    -e "s/__EXE__/$EXE/g" \
+    "$TEMPLATE" > "$WORK/bundle/manifest.json"
+
+# Validate the generated manifest is well-formed JSON.
+jq empty "$WORK/bundle/manifest.json"
+
+BUNDLE="$OUT_DIR/rustunnel-mcp-$TARGET.mcpb"
+rm -f "$BUNDLE"
+(cd "$WORK/bundle" && zip -qr "$(cd "$OUT_DIR" && pwd)/$(basename "$BUNDLE")" .)
+
+(cd "$OUT_DIR" && { sha256sum "$(basename "$BUNDLE")" 2>/dev/null \
+  || shasum -a 256 "$(basename "$BUNDLE")"; } > "$(basename "$BUNDLE").sha256")
+
+echo "built $BUNDLE"

--- a/deploy/mcpb/make-server-json.sh
+++ b/deploy/mcpb/make-server-json.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Generate the server.json payload published to the official MCP registry.
+#
+# Usage: make-server-json.sh <version> <sha-dir> [base-server-json] > server.json
+#   version  e.g. 0.8.1 (no leading v)
+#   sha-dir  directory containing rustunnel-mcp-<target>.mcpb.sha256 files
+#
+# Static fields (name, description, repository, ...) come from the repo's
+# server.json; this script overrides the version and replaces `packages` with
+# one mcpb entry per bundle found in sha-dir. The checked-in cargo package is
+# intentionally dropped: the production registry does not accept
+# registryType "cargo" yet (live on their staging since 2026-06-03; re-add
+# here once a registry release > v1.7.9 reaches production).
+set -euo pipefail
+
+VERSION=$1
+SHA_DIR=$2
+BASE=${3:-server.json}
+REPO_URL="https://github.com/joaoh82/rustunnel"
+
+packages=$(
+  for f in "$SHA_DIR"/rustunnel-mcp-*.mcpb.sha256; do
+    [[ -e "$f" ]] || { echo "no .mcpb.sha256 files in $SHA_DIR" >&2; exit 1; }
+    name=$(basename "$f" .sha256)
+    sha=$(awk '{print $1}' "$f")
+    jq -n --arg url "$REPO_URL/releases/download/v$VERSION/$name" --arg sha "$sha" \
+      '{registryType: "mcpb", identifier: $url, fileSha256: $sha, transport: {type: "stdio"}}'
+  done | jq -s .
+)
+
+jq --arg v "$VERSION" --argjson pkgs "$packages" \
+  '.version = $v | .packages = $pkgs' "$BASE"

--- a/deploy/mcpb/manifest.template.json
+++ b/deploy/mcpb/manifest.template.json
@@ -1,0 +1,71 @@
+{
+  "manifest_version": "0.3",
+  "name": "rustunnel",
+  "display_name": "rustunnel",
+  "version": "__VERSION__",
+  "description": "Give AI agents public HTTPS/TCP/UDP URLs for any localhost service. Open source, self-hostable.",
+  "long_description": "rustunnel exposes services running on localhost through public URLs — test webhooks against a local server, share a dev build, or let another agent or device reach a local port. This bundle ships the rustunnel-mcp MCP server plus the rustunnel CLI it drives, so no separate install is needed. Six tools cover the full lifecycle: create_tunnel, list_tunnels, close_tunnel, get_connection_info, list_regions, get_tunnel_history — including custom subdomains, region pinning, P2P, and load-balanced pools with health checks. Use the managed cloud at rustunnel.com (free tier available) or point it at your own self-hosted server (AGPL).",
+  "author": {
+    "name": "rustunnel",
+    "url": "https://rustunnel.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joaoh82/rustunnel"
+  },
+  "homepage": "https://rustunnel.com",
+  "documentation": "https://rustunnel.com/docs/guides/mcp-server",
+  "server": {
+    "type": "binary",
+    "entry_point": "server/rustunnel-mcp__EXE__",
+    "mcp_config": {
+      "command": "${__dirname}/server/rustunnel-mcp__EXE__",
+      "args": [
+        "--server",
+        "${user_config.server}",
+        "--api",
+        "${user_config.api_url}"
+      ],
+      "env": {
+        "RUSTUNNEL_TOKEN": "${user_config.token}",
+        "RUSTUNNEL_CLI": "${__dirname}/server/rustunnel__EXE__"
+      }
+    }
+  },
+  "tools": [
+    { "name": "create_tunnel", "description": "Open a tunnel to a local service and get a public URL (HTTP/TCP/UDP, P2P, load-balanced pools)" },
+    { "name": "list_tunnels", "description": "List active tunnels and their public URLs" },
+    { "name": "close_tunnel", "description": "Close a tunnel by ID" },
+    { "name": "get_connection_info", "description": "Get the CLI command for a tunnel instead of spawning it" },
+    { "name": "list_regions", "description": "List edge regions (eu / us / ap)" },
+    { "name": "get_tunnel_history", "description": "Audit past tunnel activity" }
+  ],
+  "keywords": ["tunnel", "ngrok", "webhook", "localhost", "https", "expose", "ai-agent"],
+  "license": "AGPL-3.0",
+  "user_config": {
+    "server": {
+      "type": "string",
+      "title": "Tunnel server address",
+      "description": "Control-plane address. Hosted: eu.edge.rustunnel.com:4040 (or us/ap). Self-hosted: your-host:4040.",
+      "default": "eu.edge.rustunnel.com:4040",
+      "required": true
+    },
+    "api_url": {
+      "type": "string",
+      "title": "Dashboard API URL",
+      "description": "REST API base URL. Hosted: https://eu.edge.rustunnel.com:8443 (match the server region). Self-hosted: https://your-host:8443.",
+      "default": "https://eu.edge.rustunnel.com:8443",
+      "required": true
+    },
+    "token": {
+      "type": "string",
+      "title": "API token",
+      "description": "Create one free at rustunnel.com → Dashboard → API Keys (or use your self-hosted admin token).",
+      "sensitive": true,
+      "required": true
+    }
+  },
+  "compatibility": {
+    "platforms": ["__PLATFORM__"]
+  }
+}

--- a/server.json
+++ b/server.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "websiteUrl": "https://rustunnel.com",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "packages": [
     {
       "registryType": "cargo",
       "identifier": "rustunnel-mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Why

The production MCP registry rejects `registryType: "cargo"` — support merged upstream 2026-06-03 ([registry#1207](https://github.com/modelcontextprotocol/registry/pull/1207)) but is live only on their staging; prod is pinned to their v1.7.9 image from 2026-05-12 with no deployment schedule. A full crawl of the live registry (11,608 servers) shows exactly five accepted package types — and **MCPB is the production-proven path for binary servers** (454 live packages; Rust precedent: `c2pa-mcp` ships one bundle per target; Go: kubeshark ships 6).

## What

- **`rustunnel-mcp` CLI resolution** (the one blocking code change): `create_tunnel` used to spawn `rustunnel` strictly via PATH. Now: `RUSTUNNEL_CLI` env var → sibling binary next to the executable → PATH. The MCPB bundle ships *both* binaries and wires them via `RUSTUNNEL_CLI`, so a Claude Desktop double-click install needs no separate CLI install. Spawn errors now name the resolved path and the override.
- **`deploy/mcpb/`**: manifest template (passes official `@anthropic-ai/mcpb validate`), `build-mcpb.sh` (repacks a release archive into a `.mcpb` — tested against real v0.8.0 darwin/windows assets, including the relative-out-dir path CI uses), `make-server-json.sh` (registry packages from `.mcpb.sha256` sidecars).
- **`release.yml`**: `build-mcpb` job packs 5 bundles (darwin arm64/x64, linux musl-x64 / gnu-arm64, windows x64) into the release; `publish-mcp-registry` job publishes to the registry after the release ships.
- **`publish-mcp.yml`**: reusable (`workflow_call`) + manually dispatchable with a tag input — retry a publish any time from the Actions tab. OIDC auth (no device codes), `mcp-publisher` pinned with checksum verification.
- **0.8.1 version bump** so the bundled binaries contain the new resolution logic.

The repo `server.json` keeps the cargo package as the future-facing default; the publish workflow swaps in the mcpb packages until a registry release > v1.7.9 reaches production (then cargo can be re-added to the generator).

## Verification

- `make check` clean; 13/13 rustunnel-mcp tests (new: CLI resolution incl. trim/empty cases)
- `build-mcpb.sh` run against real v0.8.0 assets (darwin tar.gz + windows zip): bundles contain both binaries + manifest; manifests pass `npx @anthropic-ai/mcpb validate`; windows manifest gets `.exe` entry point and `RUSTUNNEL_CLI`
- `make-server-json.sh` output validates against the registry's 2025-12-11 server.schema.json shape used by live mcpb servers
- Code-reviewed; all findings fixed (incl. a real CI-breaking relative-path bug in the zip step, reproduced then re-verified fixed)

## After merge

Tag `v0.8.1` → release pipeline builds binaries + bundles + publishes to the MCP registry automatically. I can run the tag step on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)