### PR TITLE
Glama ownership + ghcr MCP image + oci registry package

### DIFF
--- a/.github/workflows/publish-mcp-image.yml
+++ b/.github/workflows/publish-mcp-image.yml
@@ -1,0 +1,79 @@
+# Builds the rustunnel-mcp Docker image (linux/amd64 + linux/arm64) from the
+# release binaries and pushes it to ghcr.io/joaoh82/rustunnel-mcp. Called by
+# release.yml after each release; dispatchable from the Actions tab to build
+# an image for an existing release.
+#
+# One-time setup: after the first push, make the ghcr package PUBLIC
+# (github.com → profile → Packages → rustunnel-mcp → settings → visibility) —
+# the MCP registry and Glama both need to pull it anonymously.
+name: Publish MCP Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build from (e.g. v0.8.1)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Compute version
+        id: meta
+        run: |
+          TAG="${{ inputs.tag }}"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download linux release binaries
+        env:
+          TAG: ${{ inputs.tag }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p ctx/binaries/amd64 ctx/binaries/arm64
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern "rustunnel-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            --pattern "rustunnel-v${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+          tar -xzf "rustunnel-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz" -C ctx/binaries/amd64
+          tar -xzf "rustunnel-v${VERSION}-aarch64-unknown-linux-gnu.tar.gz" -C ctx/binaries/arm64
+          cp deploy/docker/Dockerfile.mcp ctx/Dockerfile
+          ls -lR ctx/
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ctx
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/joaoh82/rustunnel-mcp:${{ steps.meta.outputs.version }}
+            ghcr.io/joaoh82/rustunnel-mcp:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,9 +284,21 @@ jobs:
             "joaoh82/rustunnel" \
             "joaoh82/homebrew-rustunnel"
 
+  publish-mcp-image:
+    name: Publish MCP Docker image
+    needs: [publish]
+    if: ${{ !contains(github.ref_name, '-') }}
+    uses: ./.github/workflows/publish-mcp-image.yml
+    with:
+      tag: ${{ github.ref_name }}
+    permissions:
+      contents: read
+      packages: write
+
   publish-mcp-registry:
     name: Publish to MCP Registry
-    needs: [publish]
+    # Image first: the registry's oci ownership check pulls the image manifest.
+    needs: [publish, publish-mcp-image]
     # Skip pre-releases, same as the Homebrew update.
     if: ${{ !contains(github.ref_name, '-') }}
     uses: ./.github/workflows/publish-mcp.yml

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -1,0 +1,27 @@
+# Image for rustunnel-mcp — the MCP server plus the rustunnel CLI it spawns.
+# Built by .github/workflows/publish-mcp-image.yml from the release binaries
+# (no compilation here): the build context contains binaries/<arch>/ dirs
+# with the linux-gnu builds for amd64 and arm64.
+#
+# Used by MCP clients that run servers in containers (e.g. the Glama
+# inspector) and listed as an `oci` package in the official MCP registry.
+# Note: to tunnel a service running on the HOST, pass `local_host` as
+# `host.docker.internal` (macOS/Windows) or run with `--network host` (Linux).
+FROM debian:stable-slim
+ARG TARGETARCH
+
+# CA roots for the TLS connections to the control plane and REST API.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY binaries/${TARGETARCH}/rustunnel /usr/local/bin/rustunnel
+COPY binaries/${TARGETARCH}/rustunnel-mcp /usr/local/bin/rustunnel-mcp
+
+# Ownership label the official MCP registry checks for oci packages.
+LABEL io.modelcontextprotocol.server.name="io.github.joaoh82/rustunnel"
+LABEL org.opencontainers.image.source="https://github.com/joaoh82/rustunnel"
+LABEL org.opencontainers.image.description="rustunnel MCP server — give AI agents public HTTPS/TCP/UDP URLs for any localhost service"
+LABEL org.opencontainers.image.licenses="AGPL-3.0"
+
+ENTRYPOINT ["/usr/local/bin/rustunnel-mcp"]

--- a/deploy/mcpb/make-server-json.sh
+++ b/deploy/mcpb/make-server-json.sh
@@ -28,5 +28,21 @@ packages=$(
   done | jq -s .
 )
 
+# Add the ghcr image as an oci package — but only when it is anonymously
+# pullable: the registry verifies oci ownership by reading the image label,
+# and a private/missing package would fail the whole publish. (The package
+# must be made public once, in the GitHub Packages settings.)
+IMAGE_REPO="joaoh82/rustunnel-mcp"
+ghcr_token=$(curl -fsSL "https://ghcr.io/token?scope=repository:$IMAGE_REPO:pull" | jq -r '.token // empty' || true)
+if [[ -n "$ghcr_token" ]] && curl -fsSL -o /dev/null \
+    -H "Authorization: Bearer $ghcr_token" \
+    -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json" \
+    "https://ghcr.io/v2/$IMAGE_REPO/manifests/$VERSION" 2>/dev/null; then
+  packages=$(jq --arg id "ghcr.io/$IMAGE_REPO:$VERSION" \
+    '. + [{registryType: "oci", identifier: $id, transport: {type: "stdio"}}]' <<<"$packages")
+else
+  echo "warning: ghcr.io/$IMAGE_REPO:$VERSION not anonymously pullable — skipping oci package" >&2
+fi
+
 jq --arg v "$VERSION" --argjson pkgs "$packages" \
   '.version = $v | .packages = $pkgs' "$BASE"

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["joaoh82"]
+}


### PR DESCRIPTION
Follow-up to the [Glama listing](https://glama.ai/mcp/servers/joaoh82/rustunnel) (claimed, but showing "quality: not tested / this server cannot be installed" — Glama's inspector can't launch a bare Rust binary):

- **`glama.json`** — pins maintainer ownership in-repo per [Glama's convention](https://glama.ai/blog/2025-07-08-what-is-glamajson).
- **`deploy/docker/Dockerfile.mcp`** — rustunnel-mcp + the rustunnel CLI on debian-slim, built straight from release binaries, with the `io.modelcontextprotocol.server.name` ownership label.
- **`publish-mcp-image.yml`** — multi-arch (amd64/arm64) push to `ghcr.io/joaoh82/rustunnel-mcp:{version,latest}` on every release; dispatchable for existing tags (run it for v0.8.1 after merging).
- **`make-server-json.sh`** — adds an `oci` package to the official MCP registry entry when the image is anonymously pullable (guarded so a private/missing package can't fail the publish). `oci` is production-accepted today (488 live servers).

Verified locally: image builds from real v0.8.1 assets (label + `rustunnel 0.8.1` smoke test), generator guard warns-and-skips correctly, workflow YAML parses.

## After merge (operator)
1. Dispatch "Publish MCP Docker image" for `v0.8.1` from the Actions tab.
2. Make the `rustunnel-mcp` ghcr package **public** (Packages → settings → visibility) — required for the registry's oci check and Glama's pull.
3. In Glama's listing settings: set the description to the agentic one-liner ("Expose any localhost service so an AI agent can reach it — public HTTPS/TCP/UDP URLs via six MCP tools. Open source, self-hostable.") and configure the Docker image `ghcr.io/joaoh82/rustunnel-mcp:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)