### PR TITLE
Fix publish-mcp-image: don't check out the tag being built

### DIFF
--- a/.github/workflows/publish-mcp-image.yml
+++ b/.github/workflows/publish-mcp-image.yml
@@ -29,10 +29,11 @@ jobs:
       packages: write
 
     steps:
+      # Deliberately NOT pinned to inputs.tag: the Dockerfile and this
+      # workflow are tooling, not release content — older tags predate them.
+      # Only the binaries (gh release download below) come from the tag.
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag }}
 
       - name: Compute version
         id: meta


### PR DESCRIPTION
Checking out inputs.tag broke dispatch runs for tags that predate the
Dockerfile (v0.8.1: "cp: cannot stat deploy/docker/Dockerfile.mcp").
The Dockerfile and workflow are tooling, not release content — use the
workflow's own ref and take only the binaries from the tag.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
