### PR TITLE
Add Cursor/Open Plugins listing assets: root .mcp.json, plugin manifest, Add-to-Cursor badge

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "rustunnel": {
+      "command": "rustunnel-mcp",
+      "args": [
+        "--server", "eu.edge.rustunnel.com:4040",
+        "--api", "https://eu.edge.rustunnel.com:8443"
+      ],
+      "env": {
+        "RUSTUNNEL_TOKEN": "REPLACE_WITH_YOUR_TOKEN"
+      }
+    }
+  }
+}

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "rustunnel",
+  "description": "Expose any localhost service so an AI agent can reach it — public HTTPS/TCP/UDP URLs via six MCP tools. Open source, self-hostable.",
+  "homepage": "https://rustunnel.com"
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Expose local services through a public server over encrypted WebSocket connectio
 
 You can self-host or use our managed service.
 
+**Using an AI agent?** rustunnel ships an [MCP server](https://rustunnel.com/docs/guides/mcp-server) — one-click setup for Cursor (then add your [API token](https://rustunnel.com)):
+
+[![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=rustunnel&config=eyJjb21tYW5kIjoicnVzdHVubmVsLW1jcCIsImFyZ3MiOlsiLS1zZXJ2ZXIiLCJldS5lZGdlLnJ1c3R1bm5lbC5jb206NDA0MCIsIi0tYXBpIiwiaHR0cHM6Ly9ldS5lZGdlLnJ1c3R1bm5lbC5jb206ODQ0MyJdLCJlbnYiOnsiUlVTVFVOTkVMX1RPS0VOIjoiWU9VUl9UT0tFTiJ9fQ==)
+
+For Claude Code, Claude Desktop, Windsurf, and others, see the [agent integration guide](https://rustunnel.com/docs/guides/agent-integration) or the agent manual at [rustunnel.com/agents.md](https://rustunnel.com/agents.md).
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
cursor.directory (now Cursor's official community-plugin surface; the
old cursor/mcp-servers repo is archived) auto-detects MCP servers from
a root .mcp.json and reads listing metadata from .plugin/plugin.json
(Open Plugins spec). The README gains the official Add-to-Cursor
one-click install badge (web deeplink variant, clickable on GitHub;
base64 config verified to decode to the standard server config).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
