### PR TITLE
Add universal multi-OS MCPB bundle for Smithery

### DIFF
--- a/deploy/mcpb/build-mcpb-universal.sh
+++ b/deploy/mcpb/build-mcpb-universal.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Build the "universal" MCPB bundle: one .mcpb carrying binaries for macOS
+# (Apple Silicon), Linux (x86_64 musl, static), and Windows (x86_64), selected
+# at install time via the manifest's mcp_config.platform_overrides. Used for
+# registries that take a single bundle per listing (e.g. Smithery), unlike the
+# per-target bundles build-mcpb.sh produces for the official MCP registry.
+#
+# Usage: build-mcpb-universal.sh <version> <out-dir>
+#   Downloads the three release archives for v<version> via gh, repacks them,
+#   and writes rustunnel-mcp-universal.mcpb (+ .sha256) into <out-dir>.
+set -euo pipefail
+
+VERSION=$1
+OUT_DIR=$2
+
+mkdir -p "$OUT_DIR"
+OUT_DIR=$(cd "$OUT_DIR" && pwd)
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TEMPLATE="$SCRIPT_DIR/manifest.universal.template.json"
+REPO="joaoh82/rustunnel"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/dl" "$WORK/bundle/server"/{darwin,linux,win32}
+
+gh release download "v$VERSION" --repo "$REPO" --dir "$WORK/dl" \
+  --pattern "rustunnel-v${VERSION}-aarch64-apple-darwin.tar.gz" \
+  --pattern "rustunnel-v${VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+  --pattern "rustunnel-v${VERSION}-x86_64-pc-windows-msvc.zip"
+
+extract() { # <archive> <dest> <exe-suffix>
+  local archive=$1 dest=$2 exe=$3 tmp
+  tmp=$(mktemp -d)
+  case "$archive" in
+    *.zip) unzip -q "$archive" -d "$tmp" ;;
+    *) tar -xzf "$archive" -C "$tmp" ;;
+  esac
+  for bin in "rustunnel-mcp$exe" "rustunnel$exe"; do
+    local src
+    src=$(find "$tmp" -name "$bin" -type f | head -1)
+    [[ -n "$src" ]] || { echo "binary $bin not found in $archive" >&2; exit 1; }
+    cp "$src" "$dest/"
+    chmod +x "$dest/$bin"
+  done
+  rm -rf "$tmp"
+}
+
+extract "$WORK/dl/rustunnel-v${VERSION}-aarch64-apple-darwin.tar.gz"      "$WORK/bundle/server/darwin" ""
+extract "$WORK/dl/rustunnel-v${VERSION}-x86_64-unknown-linux-musl.tar.gz" "$WORK/bundle/server/linux"  ""
+extract "$WORK/dl/rustunnel-v${VERSION}-x86_64-pc-windows-msvc.zip"       "$WORK/bundle/server/win32"  ".exe"
+
+sed "s/__VERSION__/$VERSION/g" "$TEMPLATE" > "$WORK/bundle/manifest.json"
+jq empty "$WORK/bundle/manifest.json"
+
+BUNDLE="$OUT_DIR/rustunnel-mcp-universal.mcpb"
+rm -f "$BUNDLE"
+(cd "$WORK/bundle" && zip -qr "$BUNDLE" .)
+
+(cd "$OUT_DIR" && { sha256sum "$(basename "$BUNDLE")" 2>/dev/null \
+  || shasum -a 256 "$(basename "$BUNDLE")"; } > "$(basename "$BUNDLE").sha256")
+
+echo "built $BUNDLE"
+
+# NOTE: the universal template intentionally omits the optional `tools` array
+# — Smithery's deploy validator (2026-06) rejects MCPB tool entries that only
+# carry name+description, and Smithery introspects tools at runtime anyway.

--- a/deploy/mcpb/manifest.universal.template.json
+++ b/deploy/mcpb/manifest.universal.template.json
@@ -1,0 +1,91 @@
+{
+  "manifest_version": "0.3",
+  "name": "rustunnel",
+  "display_name": "rustunnel",
+  "version": "__VERSION__",
+  "description": "Give AI agents public HTTPS/TCP/UDP URLs for any localhost service. Open source, self-hostable.",
+  "long_description": "rustunnel exposes services running on localhost through public URLs — test webhooks against a local server, share a dev build, or let another agent or device reach a local port. This bundle ships the rustunnel-mcp MCP server plus the rustunnel CLI it drives for macOS (Apple Silicon), Linux (x86_64, static), and Windows (x86_64). Six tools cover the full lifecycle: create_tunnel, list_tunnels, close_tunnel, get_connection_info, list_regions, get_tunnel_history — including custom subdomains, region pinning, P2P, and load-balanced pools with health checks. Use the managed cloud at rustunnel.com (free tier available) or point it at your own self-hosted server (AGPL).",
+  "author": {
+    "name": "rustunnel",
+    "url": "https://rustunnel.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joaoh82/rustunnel"
+  },
+  "homepage": "https://rustunnel.com",
+  "documentation": "https://rustunnel.com/docs/guides/mcp-server",
+  "server": {
+    "type": "binary",
+    "entry_point": "server/darwin/rustunnel-mcp",
+    "mcp_config": {
+      "command": "${__dirname}/server/darwin/rustunnel-mcp",
+      "args": [
+        "--server",
+        "${user_config.server}",
+        "--api",
+        "${user_config.api_url}"
+      ],
+      "env": {
+        "RUSTUNNEL_TOKEN": "${user_config.token}",
+        "RUSTUNNEL_CLI": "${__dirname}/server/darwin/rustunnel"
+      },
+      "platform_overrides": {
+        "linux": {
+          "command": "${__dirname}/server/linux/rustunnel-mcp",
+          "env": {
+            "RUSTUNNEL_TOKEN": "${user_config.token}",
+            "RUSTUNNEL_CLI": "${__dirname}/server/linux/rustunnel"
+          }
+        },
+        "win32": {
+          "command": "${__dirname}/server/win32/rustunnel-mcp.exe",
+          "env": {
+            "RUSTUNNEL_TOKEN": "${user_config.token}",
+            "RUSTUNNEL_CLI": "${__dirname}/server/win32/rustunnel.exe"
+          }
+        }
+      }
+    }
+  },
+  "keywords": [
+    "tunnel",
+    "ngrok",
+    "webhook",
+    "localhost",
+    "https",
+    "expose",
+    "ai-agent"
+  ],
+  "license": "AGPL-3.0",
+  "user_config": {
+    "server": {
+      "type": "string",
+      "title": "Tunnel server address",
+      "description": "Control-plane address. Hosted: eu.edge.rustunnel.com:4040 (or us/ap). Self-hosted: your-host:4040.",
+      "default": "eu.edge.rustunnel.com:4040",
+      "required": true
+    },
+    "api_url": {
+      "type": "string",
+      "title": "Dashboard API URL",
+      "description": "REST API base URL. Hosted: https://eu.edge.rustunnel.com:8443 (match the server region). Self-hosted: https://your-host:8443.",
+      "default": "https://eu.edge.rustunnel.com:8443",
+      "required": true
+    },
+    "token": {
+      "type": "string",
+      "title": "API token",
+      "description": "Create one free at rustunnel.com → Dashboard → API Keys (or use your self-hosted admin token).",
+      "sensitive": true,
+      "required": true
+    }
+  },
+  "compatibility": {
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ]
+  }
+}


### PR DESCRIPTION
One .mcpb carrying darwin-arm64, linux-x86_64 (musl), and windows-x86_64
binaries, selected via mcp_config.platform_overrides — for registries
that take a single bundle per listing. Published to Smithery as
joaoh82/rustunnel (release 7a7abecd, status SUCCESS). The template
omits the optional `tools` array: Smithery's validator rejects
name+description-only tool entries; tools are introspected at runtime.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
