### PR TITLE
Add Smithery badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/joaoh82/rustunnel/actions/workflows/ci.yml/badge.svg)](https://github.com/joaoh82/rustunnel/actions/workflows/ci.yml)
 [![License: AGPLv3](https://img.shields.io/badge/License-AGPLv3-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.76%2B-orange.svg)](https://www.rust-lang.org)
+[![smithery badge](https://smithery.ai/badge/joaoh82/rustunnel)](https://smithery.ai/servers/joaoh82/rustunnel)
 
 ![rustunnel logo](images/rustunnel-logo-light.png)
 


### PR DESCRIPTION
Satisfies Smithery's backlink verification check (their scanner looks
for a link to the server page in the README) and shows the live
listing badge.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
