### PR TITLE
Embed live tool definitions in the universal MCPB manifest

### DIFF
--- a/deploy/mcpb/build-mcpb-universal.sh
+++ b/deploy/mcpb/build-mcpb-universal.sh
@@ -51,6 +51,26 @@ extract "$WORK/dl/rustunnel-v${VERSION}-x86_64-unknown-linux-musl.tar.gz" "$WORK
 extract "$WORK/dl/rustunnel-v${VERSION}-x86_64-pc-windows-msvc.zip"       "$WORK/bundle/server/win32"  ".exe"
 
 sed "s/__VERSION__/$VERSION/g" "$TEMPLATE" > "$WORK/bundle/manifest.json"
+
+# Embed the live tool definitions (name/description/inputSchema) introspected
+# from the bundled binary for this host OS — Smithery scores listings on
+# tool-definition quality, and name+description-only entries fail their
+# deploy validation outright.
+case "$(uname -s)" in
+  Darwin) HOST_BIN="$WORK/bundle/server/darwin/rustunnel-mcp" ;;
+  Linux)  HOST_BIN="$WORK/bundle/server/linux/rustunnel-mcp" ;;
+  *)      HOST_BIN="" ;;
+esac
+if [[ -n "$HOST_BIN" ]]; then
+  python3 "$SCRIPT_DIR/introspect-tools.py" "$HOST_BIN" > "$WORK/tools.json"
+  jq --slurpfile tools "$WORK/tools.json" '.tools = $tools[0]' \
+    "$WORK/bundle/manifest.json" > "$WORK/manifest.tmp"
+  mv "$WORK/manifest.tmp" "$WORK/bundle/manifest.json"
+  echo "embedded $(jq length "$WORK/tools.json") tool definitions"
+else
+  echo "warning: unsupported host OS — manifest ships without tool definitions" >&2
+fi
+
 jq empty "$WORK/bundle/manifest.json"
 
 BUNDLE="$OUT_DIR/rustunnel-mcp-universal.mcpb"

--- a/deploy/mcpb/introspect-tools.py
+++ b/deploy/mcpb/introspect-tools.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Print the tools/list of an MCP stdio server as JSON.
+
+Usage: introspect-tools.py <path-to-mcp-binary> [args...]
+
+Used by build-mcpb-universal.sh to embed the live tool definitions
+(name/description/inputSchema) into the bundle manifest — registries like
+Smithery score listings on tool-definition quality, and this keeps the
+manifest in lockstep with the binary it ships.
+"""
+import json
+import subprocess
+import sys
+
+proc = subprocess.Popen(
+    sys.argv[1:],
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.DEVNULL,
+)
+
+
+def call(method, params, id):
+    msg = {"jsonrpc": "2.0", "id": id, "method": method, "params": params}
+    proc.stdin.write((json.dumps(msg) + "\n").encode())
+    proc.stdin.flush()
+    return json.loads(proc.stdout.readline())
+
+
+call(
+    "initialize",
+    {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "introspect-tools", "version": "0"},
+    },
+    1,
+)
+tools = call("tools/list", {}, 2)["result"]["tools"]
+proc.kill()
+json.dump(tools, sys.stdout, indent=2)
+print()


### PR DESCRIPTION
build-mcpb-universal.sh now introspects the bundled binary
(introspect-tools.py speaks MCP over stdio) and injects the full
tools/list — name, description, inputSchema — into the manifest.
Smithery requires schema-bearing tool entries (name+description-only
fails their deploy validation) and scores listings on tool-definition
quality; the previous workaround of omitting the array passed
validation but tanked the quality score (33/100).

Note: the official MCPB validator does NOT recognize inputSchema in
manifest tools, so this stays exclusive to the universal bundle — the
per-target bundles for the official MCP registry remain spec-pure.

Republished to Smithery as release 52976aa8 (accepted, 6 tools live).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
