### PR TITLE
Make token optional in universal bundle config

### DIFF
--- a/deploy/mcpb/manifest.universal.template.json
+++ b/deploy/mcpb/manifest.universal.template.json
@@ -76,9 +76,9 @@
     "token": {
       "type": "string",
       "title": "API token",
-      "description": "Create one free at rustunnel.com → Dashboard → API Keys (or use your self-hosted admin token).",
+      "description": "Create one free at rustunnel.com → Dashboard → API Keys (or use your self-hosted admin token). Optional at startup — the server boots and lists tools without it; creating tunnels requires it.",
       "sensitive": true,
-      "required": true
+      "required": false
     }
   },
   "compatibility": {


### PR DESCRIPTION
Smithery's quality rubric awards "Optional config" (15pt) to servers
that start without required user config — and rustunnel-mcp genuinely
does: it boots and lists tools tokenless; only tunnel creation needs
one. server/api_url already have defaults. Description text now states
the startup-vs-usage distinction honestly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
