### PR TITLE
Mark all universal-bundle user_config fields optional

### DIFF
--- a/deploy/mcpb/manifest.universal.template.json
+++ b/deploy/mcpb/manifest.universal.template.json
@@ -64,14 +64,14 @@
       "title": "Tunnel server address",
       "description": "Control-plane address. Hosted: eu.edge.rustunnel.com:4040 (or us/ap). Self-hosted: your-host:4040.",
       "default": "eu.edge.rustunnel.com:4040",
-      "required": true
+      "required": false
     },
     "api_url": {
       "type": "string",
       "title": "Dashboard API URL",
       "description": "REST API base URL. Hosted: https://eu.edge.rustunnel.com:8443 (match the server region). Self-hosted: https://your-host:8443.",
       "default": "https://eu.edge.rustunnel.com:8443",
-      "required": true
+      "required": false
     },
     "token": {
       "type": "string",


### PR DESCRIPTION
Smithery's "Optional config" criterion (15pt) checks the required
flags on every user_config field, not just whether defaults exist —
server and api_url have hosted-EU defaults and the token is unneeded
at startup, so required:false is honest for all three. Republished as
release 44c32335.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
