### PR TITLE
ci: publish rustunnel-server image to GHCR on release tags

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,99 @@
+# Builds the rustunnel-server Docker image (linux/amd64 + linux/arm64) from
+# deploy/Dockerfile and pushes it to ghcr.io/joaoh82/rustunnel-server. Called by
+# release.yml on stable tags; dispatchable from the Actions tab to (re)build an
+# image for an existing tag — use this once to seed the package, then make it
+# PUBLIC (github.com → profile → Packages → rustunnel-server → settings →
+# visibility) so `docker pull` works without auth.
+#
+# Note: the arm64 layer is built under QEMU emulation (the Rust server + the
+# Next.js dashboard both compile inside the image), so a cold run is slow; the
+# buildx GHA cache keeps subsequent runs reasonable.
+name: Publish server Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build from (e.g. v0.8.1)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # Build from the tagged source so the image contains that version's code.
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Compute image metadata
+        id: meta
+        run: |
+          TAG="${{ inputs.tag }}"
+          VERSION="${TAG#v}"
+          # Always publish the immutable version tag. Only move :latest for
+          # stable releases — pre-release tags carry a hyphen (e.g. v1.0.0-rc1).
+          TAGS="ghcr.io/joaoh82/rustunnel-server:${VERSION}"
+          if [[ "$TAG" != *-* ]]; then
+            TAGS="${TAGS}"$'\n'"ghcr.io/joaoh82/rustunnel-server:latest"
+          fi
+          {
+            echo "version=${VERSION}"
+            echo "revision=$(git rev-parse HEAD)"
+            echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "tags<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            REVISION=${{ steps.meta.outputs.revision }}
+          # Re-asserted here (not only in the Dockerfile) so the labels — above
+          # all image.source, which links the package to this repo and renders
+          # the README on the package page — are present even when (re)building
+          # an older tag whose Dockerfile predates them.
+          labels: |
+            org.opencontainers.image.source=https://github.com/joaoh82/rustunnel
+            org.opencontainers.image.url=https://github.com/joaoh82/rustunnel
+            org.opencontainers.image.documentation=https://github.com/joaoh82/rustunnel/blob/main/README.md
+            org.opencontainers.image.title=rustunnel-server
+            org.opencontainers.image.description=rustunnel — self-hosted secure tunnel server (HTTP/TCP/UDP reverse proxy with TLS, live dashboard, and Prometheus metrics)
+            org.opencontainers.image.licenses=AGPL-3.0
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+            org.opencontainers.image.revision=${{ steps.meta.outputs.revision }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,6 +295,18 @@ jobs:
       contents: read
       packages: write
 
+  publish-server-image:
+    name: Publish server Docker image
+    needs: [publish]
+    # Skip pre-releases (tags with a hyphen, e.g. v1.0.0-rc1) — stable only.
+    if: ${{ !contains(github.ref_name, '-') }}
+    uses: ./.github/workflows/release-docker.yml
+    with:
+      tag: ${{ github.ref_name }}
+    permissions:
+      contents: read
+      packages: write
+
   publish-mcp-registry:
     name: Publish to MCP Registry
     # Image first: the registry's oci ownership check pulls the image manifest.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-full test fmt lint check install-hooks release release-server release-client \
-        release-mcp docker-build docker-run docker-run-monitoring docker-stop docker-logs \
+        release-mcp docker-build docker-push docker-run docker-run-monitoring docker-stop docker-logs \
         deploy deploy-client update-server db-start db-stop dev-setup clean help
 
 # ── configuration ─────────────────────────────────────────────────────────────
@@ -8,6 +8,7 @@ BINARY_SERVER := rustunnel-server
 BINARY_CLIENT := rustunnel
 BINARY_MCP    := rustunnel-mcp
 IMAGE         := rustunnel-server
+REGISTRY_IMAGE := ghcr.io/joaoh82/rustunnel-server
 TAG           ?= latest
 
 # ── development ───────────────────────────────────────────────────────────────
@@ -100,6 +101,14 @@ release-mcp:
 ## docker-build  Build the Docker image (deploy/Dockerfile).
 docker-build:
 	docker build -f deploy/Dockerfile -t $(IMAGE):$(TAG) .
+
+## docker-push  Build and push a multi-arch image (amd64+arm64) to GHCR. Needs buildx + `docker login ghcr.io`.
+docker-push:
+	docker buildx build -f deploy/Dockerfile \
+	    --platform linux/amd64,linux/arm64 \
+	    --label org.opencontainers.image.source=https://github.com/joaoh82/rustunnel \
+	    --tag $(REGISTRY_IMAGE):$(TAG) \
+	    --push .
 
 ## docker-run   Start the server container (requires deploy/server.toml).
 docker-run:

--- a/README.md
+++ b/README.md
@@ -651,11 +651,30 @@ A full Docker guide covering both local development (self-signed cert) and
 production VPS (Let's Encrypt) is available in
 [**docs/docker-deployment.md**](docs/docker-deployment.md).
 
-### Quick reference
+### Pull the published image
+
+Multi-arch images (`linux/amd64` + `linux/arm64`) are published to GitHub
+Container Registry on every stable release — no build required:
 
 ```bash
-# Build the image (includes Next.js dashboard + Rust server)
+# Latest stable, or pin a version (e.g. :0.8.1)
+docker pull ghcr.io/joaoh82/rustunnel-server:latest
+
+# Run it with your server config mounted at /etc/rustunnel/server.toml
+docker run --rm \
+  -p 80:80 -p 443:443 -p 4040:4040 -p 8443:8443 \
+  -v "$PWD/deploy/server.toml:/etc/rustunnel/server.toml:ro" \
+  ghcr.io/joaoh82/rustunnel-server:latest
+```
+
+### Quick reference (build from source)
+
+```bash
+# Build the image locally (includes Next.js dashboard + Rust server)
 make docker-build
+
+# Build and push a multi-arch image to GHCR (maintainers; needs buildx + ghcr login)
+make docker-push
 
 # Local development (self-signed cert, no auth required)
 docker compose -f deploy/docker-compose.local.yml up

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -64,6 +64,20 @@ RUN touch crates/rustunnel-protocol/src/lib.rs \
 # ── Stage 3: runtime ──────────────────────────────────────────────────────────
 FROM debian:bookworm-slim AS runtime
 
+# OCI image metadata. `image.source` links the GHCR package to this repo so the
+# package overview page renders the repo README; `version`/`revision` are filled
+# at build time via build-args (default to dev values for plain local builds).
+ARG VERSION=dev
+ARG REVISION=unknown
+LABEL org.opencontainers.image.source="https://github.com/joaoh82/rustunnel" \
+      org.opencontainers.image.url="https://github.com/joaoh82/rustunnel" \
+      org.opencontainers.image.documentation="https://github.com/joaoh82/rustunnel/blob/main/README.md" \
+      org.opencontainers.image.title="rustunnel-server" \
+      org.opencontainers.image.description="rustunnel — self-hosted secure tunnel server (HTTP/TCP/UDP reverse proxy with TLS, live dashboard, and Prometheus metrics)" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \


### PR DESCRIPTION
## What

Wire up GHCR-driven container publishing so every stable `vX.Y.Z` tag builds `deploy/Dockerfile` and pushes `ghcr.io/joaoh82/rustunnel-server:X.Y.Z` + `:latest` (multi-arch: `linux/amd64` + `linux/arm64`). Closes the gap where the README promised a Docker deployment but **no published image existed anywhere**.

Ref: **TUNNEL-20** (surfaced from TUNNEL-14 § 0.3).

## Changes

- **`.github/workflows/release-docker.yml`** *(new)* — reusable workflow modeled on the existing `publish-mcp-image.yml`. QEMU + buildx multi-arch build, GHA layer cache, `GITHUB_TOKEN` auth (`packages: write`). Pushes the immutable `:X.Y.Z` always; `:latest` only moves for stable (hyphen-free) tags. `workflow_dispatch` lets you build an image for an already-cut tag.
- **`.github/workflows/release.yml`** — new `publish-server-image` job (`needs: [publish]`, gated `!contains(github.ref_name, '-')`, stable-only). Runs automatically on `v*` tag push.
- **`deploy/Dockerfile`** — OCI labels on the runtime stage (`source`, `description`, `licenses`, `version`, `revision`, `title`, `url`, `documentation`). `image.source` links the GHCR package to this repo so the package page renders the README; `version`/`revision` come from build-args. Labels are **also re-asserted at the build step** so seeding the package from an older tag (whose Dockerfile predates these labels) still links correctly.
- **`Makefile`** — `make docker-push` (multi-arch `buildx --push`) + `REGISTRY_IMAGE` var.
- **`README.md`** — new "Pull the published image" section (`docker pull` / `docker run`); the build path is now "Quick reference (build from source)".

## Verification

- `actionlint` clean on both workflows (also shellchecks inline `run` scripts).
- Full **native build of the real `deploy/Dockerfile`** → exit 0, 139 MB `linux/arm64` image. OCI labels resolve correctly (`image.source=https://github.com/joaoh82/rustunnel`, `version=0.8.1`, real `revision`, `AGPL-3.0`). Entrypoint binary runs: `rustunnel-server 0.8.1`.
- `make -n docker-push` / `docker-build` resolve correctly.

## Manual follow-ups after merge

1. **Seed the package** — `v0.8.1` predates this workflow, so it won't auto-build. Run once: `gh workflow run release-docker.yml -f tag=v0.8.1` (creates `:0.8.1` + `:latest`).
2. **Set package visibility → public** (package settings UI → Change visibility) so `docker pull` works without auth — same one-time step as the MCP image.
3. **Bump TUNNEL-14 `web/seo/backlinks.md` § 2** (Docker Hub / GHCR rows) in the `rustunnel-web` repo once 1–2 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)