### PR TITLE
ci: build server image on native arm64 runners instead of QEMU

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -5,9 +5,12 @@
 # PUBLIC (github.com → profile → Packages → rustunnel-server → settings →
 # visibility) so `docker pull` works without auth.
 #
-# Note: the arm64 layer is built under QEMU emulation (the Rust server + the
-# Next.js dashboard both compile inside the image), so a cold run is slow; the
-# buildx GHA cache keeps subsequent runs reasonable.
+# Each arch builds on a NATIVE runner (amd64 on ubuntu-latest, arm64 on the
+# free ubuntu-24.04-arm runners) — no QEMU emulation, so the from-source Rust +
+# Next.js compile runs at native speed on both. Each leg pushes its image by
+# digest; the merge job then stitches them into one multi-arch manifest list
+# tagged :X.Y.Z (+ :latest for stable tags). See:
+# https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
 name: Publish server Docker image
 
 on:
@@ -23,14 +26,32 @@ on:
         required: true
         type: string
 
+env:
+  REGISTRY_IMAGE: ghcr.io/joaoh82/rustunnel-server
+
 jobs:
-  publish-image:
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
+      - name: Prepare platform slug
+        id: prep
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "slug=${platform//\//-}" >> "$GITHUB_OUTPUT"
+
       # Build from the tagged source so the image contains that version's code.
       - name: Checkout tag
         uses: actions/checkout@v4
@@ -41,24 +62,11 @@ jobs:
         id: meta
         run: |
           TAG="${{ inputs.tag }}"
-          VERSION="${TAG#v}"
-          # Always publish the immutable version tag. Only move :latest for
-          # stable releases — pre-release tags carry a hyphen (e.g. v1.0.0-rc1).
-          TAGS="ghcr.io/joaoh82/rustunnel-server:${VERSION}"
-          if [[ "$TAG" != *-* ]]; then
-            TAGS="${TAGS}"$'\n'"ghcr.io/joaoh82/rustunnel-server:latest"
-          fi
           {
-            echo "version=${VERSION}"
+            echo "version=${TAG#v}"
             echo "revision=$(git rev-parse HEAD)"
             echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo "tags<<EOF"
-            echo "$TAGS"
-            echo "EOF"
           } >> "$GITHUB_OUTPUT"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
@@ -70,20 +78,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: deploy/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform }}
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
             REVISION=${{ steps.meta.outputs.revision }}
-          # Re-asserted here (not only in the Dockerfile) so the labels — above
-          # all image.source, which links the package to this repo and renders
-          # the README on the package page — are present even when (re)building
-          # an older tag whose Dockerfile predates them.
+          # Per-arch image labels. Re-asserted here (not only in the Dockerfile)
+          # so they're present even when (re)building an older tag whose
+          # Dockerfile predates them. image.source is what links the package to
+          # this repo; the merge job also stamps it on the manifest index.
           labels: |
             org.opencontainers.image.source=https://github.com/joaoh82/rustunnel
             org.opencontainers.image.url=https://github.com/joaoh82/rustunnel
@@ -94,6 +102,77 @@ jobs:
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.revision=${{ steps.meta.outputs.revision }}
             org.opencontainers.image.created=${{ steps.meta.outputs.created }}
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=server-image-${{ steps.prep.outputs.slug }}
+          cache-to: type=gha,mode=max,scope=server-image-${{ steps.prep.outputs.slug }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.prep.outputs.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge multi-arch manifest
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          # Always publish the immutable version tag. Only move :latest for
+          # stable releases — pre-release tags carry a hyphen (e.g. v1.0.0-rc1).
+          tags=( -t "${REGISTRY_IMAGE}:${VERSION}" )
+          if [[ "$TAG" != *-* ]]; then
+            tags+=( -t "${REGISTRY_IMAGE}:latest" )
+          fi
+          # One @sha256:<digest> ref per arch image (filenames are the digests).
+          refs=()
+          for digest in *; do
+            refs+=( "${REGISTRY_IMAGE}@sha256:${digest}" )
+          done
+          # Stamp OCI metadata on the manifest index too — image.source links
+          # the GHCR package to this repo so the package page renders the README.
+          docker buildx imagetools create "${tags[@]}" \
+            --annotation "index:org.opencontainers.image.source=https://github.com/joaoh82/rustunnel" \
+            --annotation "index:org.opencontainers.image.description=rustunnel — self-hosted secure tunnel server (HTTP/TCP/UDP reverse proxy with TLS, live dashboard, and Prometheus metrics)" \
+            --annotation "index:org.opencontainers.image.licenses=AGPL-3.0" \
+            "${refs[@]}"
+
+      - name: Inspect pushed image
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          docker buildx imagetools inspect "${REGISTRY_IMAGE}:${TAG#v}"


### PR DESCRIPTION
## Why

The multi-arch server image landed in #91 built the `linux/arm64` layer under **QEMU emulation**, which compiles the full Rust server *and* the Next.js dashboard on an emulated CPU. A dispatch run on `v0.8.1` sat on the build step for **over an hour** and was cancelled. Worse, it's slow on *every* release — the source changes each tag, so the emulated compile re-runs and the layer cache can't rescue it.

## What

Switch to the canonical native-runner pattern ([Docker docs](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners)):

- **`build` matrix job** — each arch on its own native runner (`linux/amd64` → `ubuntu-latest`, `linux/arm64` → the free `ubuntu-24.04-arm` runners, which this public repo gets at no cost). No QEMU; each arch compiles at native speed, in parallel (~native single-arch time instead of an hour).
- Each leg pushes its image **by digest** (`push-by-digest=true`), uploads the digest as an artifact, with **per-arch GHA cache scopes** so the legs don't clobber each other.
- **`merge` job** — downloads both digests and stitches them into one multi-arch manifest list tagged `:X.Y.Z` (+ `:latest` for stable tags) via `docker buildx imagetools create`, then inspects the result.

## Metadata / package linking

- OCI labels are applied to **each arch image** (build-args + `labels:`) **and** as **index-level annotations** on the manifest in the merge job. `org.opencontainers.image.source` links the GHCR package to this repo so the package page renders the README.
- `:latest` stays **stable-only** (hyphen tags = pre-releases).

## Unchanged

`release.yml`'s `publish-server-image` job calls the same reusable workflow with the same `tag` input and `contents: read` + `packages: write` — no change needed there.

## Verification

- `actionlint` clean (workflow + inline shell).
- Supersedes the QEMU build approach from #91. The `deploy/Dockerfile`, `make docker-push`, and README changes from #91 are unaffected.

## Follow-up (unchanged from #91)

After merge: `gh workflow run release-docker.yml -f tag=v0.8.1` to seed `:0.8.1` + `:latest`, then set the GHCR package **public**, then bump TUNNEL-14 `web/seo/backlinks.md` § 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)