### PR TITLE
chore: migrate CLAUDE.md Knowledge Base to projects-knowledge repo path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,15 +217,17 @@ GitHub Actions (`.github/workflows/ci.yml`) runs on every push/PR:
 
 ## Knowledge Base
 
-This project shares its knowledge base with its parent (rustunnel). Do **not** create a separate `Projects/rustunnel-core/` folder — entries about this child go in the parent's vault.
+This project shares its knowledge base with its parent (rustunnel). Do **not** create a separate `projects/rustunnel-core/` folder — entries about this child go in the parent's folder.
 
-### Project-specific — `~/Documents/josh-obsidian-synced/Projects/rustunnel/`
+Project knowledge lives in the private repo **`joaoh82/projects-knowledge`**, cloned at `~/projects/projects-knowledge` (clone to the same path in cloud environments). Follow the repo workflow described in the parent `CLAUDE.md`: pull before writing, work only in the repo working tree (never via the Obsidian vault path), read only this project's folder, and commit + push at session end if anything changed (this notes repo is exempt from the never-touch-`main` rule).
+
+### Project-specific — `~/projects/projects-knowledge/projects/rustunnel/`
 
 - **Code (this child):** `/Users/joaoh82/projects/rustunnel/rustunnel`
 - **Code (parent meta-repo):** `/Users/joaoh82/projects/rustunnel`
-- **Context (read first):** `~/Documents/josh-obsidian-synced/Projects/rustunnel/context.md`
-- **Notes (running journal):** `~/Documents/josh-obsidian-synced/Projects/rustunnel/notes.md`
-- **Project wiki:** `~/Documents/josh-obsidian-synced/Projects/rustunnel/wiki/`
+- **Context (read first):** `~/projects/projects-knowledge/projects/rustunnel/context.md`
+- **Notes (running journal):** `~/projects/projects-knowledge/projects/rustunnel/notes.md`
+- **Project wiki:** `~/projects/projects-knowledge/projects/rustunnel/wiki/`
 
 **How to use each:**
 
@@ -239,9 +241,9 @@ This project shares its knowledge base with its parent (rustunnel). Do **not** c
 - A decision, incident, or working note → append a dated entry to the parent's `notes.md`.
 - Reusable reference material (setup steps, credential locations, architecture) → new/updated file in the parent's `wiki/`.
 
-### Cross-project knowledge — `~/Documents/josh-obsidian-synced/vault/`
+### Cross-project knowledge — `~/Documents/josh-obsidian-synced/vault/` (Obsidian machines only)
 
 - **General wiki:** `~/Documents/josh-obsidian-synced/vault/wiki/` — start at `_master-index.md`, then drill into the relevant topic's `_index.md`.
 - **Raw dumps:** `~/Documents/josh-obsidian-synced/vault/raw/` — drop unprocessed research here as `YYYY-MM-DD-{slug}.md`.
 
-Read the general wiki when the question isn't specific to this project. Drop raw research or imported notes into `vault/raw/` so it's captured even before it's distilled.
+Read the general wiki when the question isn't specific to this project. Drop raw research or imported notes into `vault/raw/` so it's captured even before it's distilled. This vault has not moved to the knowledge repo — it only exists on machines with the Obsidian vault; if the path doesn't exist, skip it.


### PR DESCRIPTION
## What

`/init` (child mode under the `rustunnel` parent) found the child `CLAUDE.md`'s **Knowledge Base** section still referencing the legacy Obsidian path (`~/Documents/josh-obsidian-synced/Projects/rustunnel/`). This repoints it at the `joaoh82/projects-knowledge` repo (`~/projects/projects-knowledge/projects/rustunnel/`) and adds the repo workflow note, matching the current `/init` template.

## Details

- Project-specific notes preserved (the "don't create a separate `rustunnel-core` folder" line, child-crate wording).
- The cross-project Obsidian `vault/` subsection is intentionally kept — that vault hasn't migrated — now flagged as "Obsidian machines only."
- No other sections changed: architecture/commands were already current, the `## Parent project` block and `AGENTS.md` pointer were already correct.

9 insertions, 7 deletions — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)