### PR TITLE
feat(client): full-screen terminal UI and local request inspector (TUNNEL-33)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Four crates in `crates/`, plus integration tests and a Next.js dashboard (`dashb
 |-------|---------|
 | `rustunnel-protocol` | Shared `ControlFrame` enum + `TunnelProtocol` (Http/Https/Tcp/Udp/P2p) and serialization |
 | `rustunnel-server` | Server: control plane, HTTP/TCP/UDP edges, dashboard, TLS, ACME |
-| `rustunnel-client` | CLI client with auto-reconnect, local port forwarding, P2P/STUN, region auto-select |
+| `rustunnel-client` | CLI client with auto-reconnect, local port forwarding, P2P/STUN, region auto-select, Ratatui terminal UI (`src/tui/`) and a loopback request inspector (`src/inspect/`) |
 | `rustunnel-mcp` | MCP server exposing rustunnel as tools to AI agents |
 
 ## Architecture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +463,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,7 +494,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -531,6 +560,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +592,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1268,6 +1356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,8 +1403,30 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1356,6 +1472,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1479,6 +1604,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1503,6 +1634,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1579,6 +1719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1935,6 +2076,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,6 +2359,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,6 +2594,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2433,7 +2614,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2527,15 +2708,18 @@ dependencies = [
 name = "rustunnel-client"
 version = "0.8.2"
 dependencies = [
+ "axum",
  "chrono",
  "clap",
  "console",
  "dirs",
  "futures-util",
  "hex",
+ "httparse",
  "indicatif",
  "quinn",
  "rand 0.8.5",
+ "ratatui",
  "rcgen",
  "reqwest 0.12.28",
  "rustls",
@@ -2952,6 +3136,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,6 +3462,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,7 +3529,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3769,10 +3996,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-segmentation"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -4078,6 +4328,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4085,6 +4351,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ clap = { version = "4", features = ["derive", "env"] }
 serde_yaml = "0.9"
 console = "0.15"
 indicatif = "0.17"
+ratatui = "0.29"
+httparse = "1"
 rand = "0.8"
 dirs = "5"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/crates/rustunnel-client/Cargo.toml
+++ b/crates/rustunnel-client/Cargo.toml
@@ -34,6 +34,9 @@ clap = { workspace = true }
 serde_yaml = { workspace = true }
 console = { workspace = true }
 indicatif = { workspace = true }
+ratatui = { workspace = true }
+httparse = { workspace = true }
+axum = { workspace = true }
 rand = { workspace = true }
 dirs = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/rustunnel-client/src/control.rs
+++ b/crates/rustunnel-client/src/control.rs
@@ -51,6 +51,8 @@ use rustunnel_protocol::{decode_frame, encode_frame, ControlFrame, TunnelProtoco
 use crate::config::{ClientConfig, TunnelDef};
 use crate::display::{self, TunnelDisplay};
 use crate::error::{Error, Result};
+use crate::inspect::tap::ConnTap;
+use crate::inspect::{Inspector, SessionStatus, TunnelInfo};
 use crate::output;
 use crate::proxy;
 
@@ -228,8 +230,14 @@ type DataConn = Connection<WsCompat<MaybeTlsStream<tokio::net::TcpStream>>>;
 /// main event loop until the connection closes or Ctrl-C is pressed.
 ///
 /// Returns `Ok(())` on a clean exit and `Err(_)` on any unrecoverable error.
-pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()> {
+pub async fn connect(
+    config: &ClientConfig,
+    tunnels: &[TunnelDef],
+    inspector: &Arc<Inspector>,
+) -> Result<()> {
     let sp = display::spinner("Connecting to tunnel server…");
+    inspector.set_status(SessionStatus::Connecting);
+    inspector.set_server(config.server.clone());
 
     // 1. Control WebSocket —————————————————————————————————————————————————
     let ctrl_url = format!("wss://{}/_control", config.server);
@@ -512,9 +520,33 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
         warn!("data WebSocket unavailable — proxy connections will be skipped");
     }
 
-    // 5. Print startup display ————————————————————————————————————————————
-    //    Human mode: startup box. JSON mode: one NDJSON `tunnel_ready` event
-    //    per tunnel (preceded by `reconnected` when this is a re-connect).
+    // 5. Publish state + print startup display ————————————————————————————
+    //    The UIs (terminal + web inspector) read the tunnel list from the
+    //    inspector, so populate it before deciding what to print.
+    inspector.set_tunnels(
+        registered
+            .iter()
+            .map(|(t, url)| TunnelInfo {
+                name: tunnel_label(t),
+                proto: t.proto.clone(),
+                local: format!("{}:{}", t.local_host, t.local_port),
+                public_url: if url.is_empty() {
+                    match &t.p2p_target {
+                        Some(target) => format!("p2p://{target}"),
+                        None => String::new(),
+                    }
+                } else {
+                    url.clone()
+                },
+                healthy: None,
+            })
+            .collect(),
+    );
+    inspector.set_status(SessionStatus::Online);
+
+    //    Human mode: startup box (unless the terminal UI owns the screen).
+    //    JSON mode: one NDJSON `tunnel_ready` event per tunnel (preceded by
+    //    `reconnected` when this is a re-connect).
     if output::json_mode() {
         if output::take_reconnect_pending() {
             output::emit(&output::Event::Reconnected);
@@ -539,7 +571,7 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
                 t.subdomain.clone().or_else(|| t.p2p_name.clone()),
             ));
         }
-    } else {
+    } else if !crate::tui::active() {
         let display_tunnels: Vec<TunnelDisplay> = registered
             .iter()
             .map(|(t, url)| TunnelDisplay {
@@ -550,6 +582,9 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
             })
             .collect();
         display::print_startup_box(&display_tunnels);
+        if let Some(url) = inspector.session().inspect_url {
+            display::print_inspect_url(&url);
+        }
     }
 
     // 6. Spawn health-probe tasks for tunnels with a health_check ─────────
@@ -603,8 +638,59 @@ pub async fn connect(config: &ClientConfig, tunnels: &[TunnelDef]) -> Result<()>
         p2p_accept_rx,
         p2p_sub_info,
         outbound_frame_rx,
+        inspector,
     )
     .await
+}
+
+/// Display name for a tunnel: its subdomain, P2P name, or a generic fallback.
+fn tunnel_label(def: &TunnelDef) -> String {
+    def.subdomain
+        .clone()
+        .or_else(|| def.p2p_name.clone())
+        .or_else(|| def.p2p_target.clone())
+        .unwrap_or_else(|| "tunnel".into())
+}
+
+/// Everything needed to proxy one inbound connection.
+struct ConnMeta {
+    local_addr: String,
+    protocol: TunnelProtocol,
+    client_addr: String,
+    tunnel_label: String,
+}
+
+/// Start the proxy task for one connection, tapping it when the tunnel carries
+/// HTTP and inspection is enabled.
+fn spawn_proxy(meta: ConnMeta, stream: YamuxStream, conn_id: Uuid, inspector: &Arc<Inspector>) {
+    if meta.protocol == TunnelProtocol::Udp {
+        tokio::spawn(proxy::proxy_udp_connection(
+            stream,
+            meta.local_addr,
+            conn_id,
+            Arc::clone(inspector),
+        ));
+        return;
+    }
+
+    // Only HTTP tunnels carry parseable traffic; TCP stays a raw byte pipe.
+    let is_http = matches!(meta.protocol, TunnelProtocol::Http | TunnelProtocol::Https);
+    let tap = (is_http && inspector.capture_enabled()).then(|| {
+        ConnTap::new(
+            Arc::clone(inspector),
+            meta.tunnel_label,
+            conn_id,
+            meta.client_addr,
+        )
+    });
+
+    tokio::spawn(proxy::proxy_connection(
+        stream,
+        meta.local_addr,
+        conn_id,
+        Arc::clone(inspector),
+        tap,
+    ));
 }
 
 // ── main loop ─────────────────────────────────────────────────────────────────
@@ -620,6 +706,7 @@ async fn main_loop(
     mut p2p_accept_rx: Option<mpsc::Receiver<tokio::net::TcpStream>>,
     p2p_sub_info: Option<(String, String, Vec<u8>)>, // (target_name, secret_hash, raw_secret)
     mut outbound_frame_rx: mpsc::Receiver<ControlFrame>,
+    inspector: &Arc<Inspector>,
 ) -> Result<()> {
     let mut ping_interval = tokio::time::interval(PING_INTERVAL);
     ping_interval.tick().await; // skip the immediate first tick
@@ -630,7 +717,7 @@ async fn main_loop(
     // Pending maps to handle the two orderings of NewConnection vs stream:
     //   pending_conns:   NewConnection arrived first  → wait for matching stream
     //   pending_streams: stream arrived first         → wait for matching NewConnection
-    let mut pending_conns: std::collections::HashMap<Uuid, (String, TunnelProtocol)> =
+    let mut pending_conns: std::collections::HashMap<Uuid, ConnMeta> =
         std::collections::HashMap::new();
     let mut pending_streams: std::collections::HashMap<Uuid, YamuxStream> =
         std::collections::HashMap::new();
@@ -670,8 +757,17 @@ async fn main_loop(
             }
 
             // ── Ctrl-C / SIGTERM ──────────────────────────────────────────
+            //    In TUI mode the terminal is in raw mode, so no SIGINT is
+            //    generated — the UI's quit key drives the shutdown arm below.
             _ = tokio::signal::ctrl_c() => {
                 info!("received interrupt — shutting down");
+                let _ = ctrl_ws.close(None).await;
+                return Ok(());
+            }
+
+            // ── Shutdown requested by the terminal UI ─────────────────────
+            _ = inspector.shutdown_signal() => {
+                info!("shutdown requested — closing session");
                 let _ = ctrl_ws.close(None).await;
                 return Ok(());
             }
@@ -691,6 +787,16 @@ async fn main_loop(
             //    TunnelUnhealthy frames here. The select arm serialises all
             //    writes to the WS — probe tasks never touch ctrl_ws directly.
             Some(frame) = outbound_frame_rx.recv() => {
+                // Mirror health transitions into the UIs on the way past.
+                match &frame {
+                    ControlFrame::TunnelHealthy { tunnel_id } => {
+                        note_health(registered, inspector, *tunnel_id, true);
+                    }
+                    ControlFrame::TunnelUnhealthy { tunnel_id, .. } => {
+                        note_health(registered, inspector, *tunnel_id, false);
+                    }
+                    _ => {}
+                }
                 send_frame(ctrl_ws, &frame).await?;
             }
 
@@ -702,14 +808,12 @@ async fn main_loop(
                         // already-accepted local TCP connection.
                         if let Some(local_tcp) = p2p_local_streams.remove(&conn_id) {
                             debug!(%conn_id, "P2P subscriber: bridging local TCP ↔ yamux");
-                            tokio::spawn(proxy::proxy_p2p_relay(stream, local_tcp, conn_id));
-                        } else if let Some((local_addr, protocol)) = pending_conns.remove(&conn_id) {
+                            tokio::spawn(proxy::proxy_p2p_relay(
+                                stream, local_tcp, conn_id, Arc::clone(inspector),
+                            ));
+                        } else if let Some(meta) = pending_conns.remove(&conn_id) {
                             // NewConnection arrived earlier — proxy immediately.
-                            if protocol == TunnelProtocol::Udp {
-                                tokio::spawn(proxy::proxy_udp_connection(stream, local_addr, conn_id));
-                            } else {
-                                tokio::spawn(proxy::proxy_connection(stream, local_addr, conn_id));
-                            }
+                            spawn_proxy(meta, stream, conn_id, inspector);
                         } else {
                             // NewConnection hasn't arrived yet — stash the stream.
                             debug!(%conn_id, "stream arrived before NewConnection — buffering");
@@ -776,26 +880,23 @@ async fn main_loop(
                                     continue;
                                 }
 
-                                match find_local_addr(registered, &protocol) {
+                                match find_local_target(registered, &protocol) {
                                     None => {
                                         warn!(%conn_id, ?protocol,
                                             "no local address configured for protocol");
                                     }
-                                    Some(local_addr) => {
-                                        let is_udp = protocol == TunnelProtocol::Udp;
+                                    Some((local_addr, tunnel_label)) => {
+                                        let meta = ConnMeta {
+                                            local_addr,
+                                            protocol,
+                                            client_addr: client_addr.clone(),
+                                            tunnel_label,
+                                        };
                                         if let Some(stream) = pending_streams.remove(&conn_id) {
-                                            if is_udp {
-                                                tokio::spawn(proxy::proxy_udp_connection(
-                                                    stream, local_addr, conn_id,
-                                                ));
-                                            } else {
-                                                tokio::spawn(proxy::proxy_connection(
-                                                    stream, local_addr, conn_id,
-                                                ));
-                                            }
+                                            spawn_proxy(meta, stream, conn_id, inspector);
                                         } else {
                                             debug!(%conn_id, "NewConnection arrived before stream — buffering");
-                                            pending_conns.insert(conn_id, (local_addr, protocol));
+                                            pending_conns.insert(conn_id, meta);
                                         }
                                     }
                                 }
@@ -810,7 +911,9 @@ async fn main_loop(
                                     // Check if yamux stream already arrived.
                                     if let Some(yamux) = pending_streams.remove(&conn_id) {
                                         debug!(%conn_id, "P2P: yamux already arrived — bridging");
-                                        tokio::spawn(proxy::proxy_p2p_relay(yamux, local, conn_id));
+                                        tokio::spawn(proxy::proxy_p2p_relay(
+                                            yamux, local, conn_id, Arc::clone(inspector),
+                                        ));
                                     } else {
                                         p2p_local_streams.insert(conn_id, local);
                                     }
@@ -868,9 +971,11 @@ async fn main_loop(
                                 send_frame(ctrl_ws, &ControlFrame::Pong { timestamp }).await?;
                             }
 
-                            ControlFrame::Pong { .. } => {
+                            ControlFrame::Pong { timestamp } => {
                                 awaiting_pong = false;
                                 last_pong = tokio::time::Instant::now();
+                                // Round-trip to the edge, shown as live latency.
+                                inspector.set_latency(now_ms().saturating_sub(timestamp));
                             }
 
                             other => {
@@ -1010,13 +1115,13 @@ fn health_check_to_wire(
     })
 }
 
-/// Find the local address string (`"host:port"`) for a registered tunnel
-/// matching `protocol`.  Returns a raw string so that `TcpStream::connect`
-/// can perform DNS resolution (e.g. for `localhost`).
-fn find_local_addr(
+/// Find the local address (`"host:port"`) and display label of the registered
+/// tunnel matching `protocol`.  The address stays a raw string so that
+/// `TcpStream::connect` can perform DNS resolution (e.g. for `localhost`).
+fn find_local_target(
     registered: &[(TunnelDef, String)],
     protocol: &TunnelProtocol,
-) -> Option<String> {
+) -> Option<(String, String)> {
     for (def, _) in registered {
         let matches = match protocol {
             TunnelProtocol::Http | TunnelProtocol::Https => {
@@ -1027,10 +1132,29 @@ fn find_local_addr(
             TunnelProtocol::P2p => def.proto == "p2p",
         };
         if matches {
-            return Some(format!("{}:{}", def.local_host, def.local_port));
+            return Some((
+                format!("{}:{}", def.local_host, def.local_port),
+                tunnel_label(def),
+            ));
         }
     }
     None
+}
+
+/// Reflect a health-probe transition into the UIs, keyed by the tunnel's local
+/// address (what the UI tunnel list is keyed on).
+fn note_health(
+    registered: &[(TunnelDef, String)],
+    inspector: &Arc<Inspector>,
+    tunnel_id: Uuid,
+    healthy: bool,
+) {
+    for (def, _) in registered {
+        if def.registered_tunnel_id == Some(tunnel_id) {
+            inspector.set_tunnel_health(&format!("{}:{}", def.local_host, def.local_port), healthy);
+            return;
+        }
+    }
 }
 
 async fn send_frame(ws: &mut CtrlWs, frame: &ControlFrame) -> Result<()> {

--- a/crates/rustunnel-client/src/display.rs
+++ b/crates/rustunnel-client/src/display.rs
@@ -69,8 +69,20 @@ pub fn print_startup_box(tunnels: &[TunnelDisplay]) {
     println!();
 }
 
+/// Print the local inspector URL under the startup box.
+pub fn print_inspect_url(url: &str) {
+    println!(
+        "  {} {}",
+        style("Inspect").dim(),
+        style(url).cyan().underlined()
+    );
+    println!();
+}
+
 /// Print a single proxied request line (timestamp | method | path | status | duration).
-#[allow(dead_code)]
+///
+/// Used in line mode — when the terminal UI is off (`--no-tui`, piped output),
+/// requests still stream to stdout instead of vanishing.
 pub fn print_request(method: &str, path: &str, status: u16, duration_ms: u64) {
     let ts = Local::now().format("%H:%M:%S").to_string();
     let ts_str = style(ts).dim();
@@ -113,9 +125,10 @@ pub fn print_request(method: &str, path: &str, status: u16, duration_ms: u64) {
 }
 
 /// Create a spinner for an in-progress operation (e.g. connecting).
-/// Hidden in `--json` mode so output stays machine-readable.
+/// Hidden in `--json` mode so output stays machine-readable, and while the
+/// terminal UI owns the screen.
 pub fn spinner(msg: &str) -> ProgressBar {
-    if crate::output::json_mode() {
+    if crate::output::json_mode() || crate::tui::active() {
         return ProgressBar::hidden();
     }
     let pb = ProgressBar::new_spinner();

--- a/crates/rustunnel-client/src/inspect/mod.rs
+++ b/crates/rustunnel-client/src/inspect/mod.rs
@@ -379,13 +379,17 @@ impl Inspector {
     }
 
     /// Local address of the tunnel a request arrived on, for replay.
+    ///
+    /// Matches by name only. Falling back to another tunnel would let a replay
+    /// hit the wrong local service — with several HTTP tunnels registered, that
+    /// could re-issue a mutating request against a different app. Callers
+    /// surface `None` as a conflict instead.
     pub fn local_addr_for(&self, tunnel: &str) -> Option<String> {
         let session = self.session.lock().unwrap();
         session
             .tunnels
             .iter()
             .find(|t| t.name == tunnel)
-            .or_else(|| session.tunnels.first())
             .map(|t| t.local.clone())
     }
 
@@ -564,6 +568,41 @@ mod tests {
         assert_eq!(
             inspector.local_addr_for("web").as_deref(),
             Some("localhost:3000")
+        );
+    }
+
+    /// Replay must resolve the tunnel it actually belongs to. With several HTTP
+    /// tunnels registered, falling back to the first one would re-issue the
+    /// request against a different local service.
+    #[test]
+    fn local_addr_matches_by_name_and_never_falls_back() {
+        let inspector = Inspector::new(true, "edge.test:4040".into(), None);
+        inspector.set_tunnels(vec![
+            TunnelInfo {
+                name: "web".into(),
+                proto: "http".into(),
+                local: "localhost:3000".into(),
+                public_url: "https://web.edge.test".into(),
+                healthy: None,
+            },
+            TunnelInfo {
+                name: "api".into(),
+                proto: "http".into(),
+                local: "localhost:8080".into(),
+                public_url: "https://api.edge.test".into(),
+                healthy: None,
+            },
+        ]);
+
+        assert_eq!(
+            inspector.local_addr_for("api").as_deref(),
+            Some("localhost:8080"),
+            "must resolve the second tunnel, not the first"
+        );
+        assert_eq!(
+            inspector.local_addr_for("gone").as_deref(),
+            None,
+            "an unknown tunnel must not resolve to some other service"
         );
     }
 

--- a/crates/rustunnel-client/src/inspect/mod.rs
+++ b/crates/rustunnel-client/src/inspect/mod.rs
@@ -1,0 +1,588 @@
+//! Client-side request inspection.
+//!
+//! The client historically forwarded bytes without understanding them, so it
+//! could never show what was flowing through a tunnel. This module adds a
+//! passive HTTP tap over the proxy byte streams ([`tap`]) plus the shared state
+//! that both consumers read from:
+//!
+//! * the terminal UI ([`crate::tui`]) — live request log and counters
+//! * the local web inspector ([`server`]) — browsable history, bodies, replay
+//!
+//! Captured exchanges mirror the server-side `CaptureEvent` / `CapturedRequest`
+//! shape (`rustunnel-server/src/edge/capture.rs`) so both inspectors describe a
+//! request the same way. Unlike the server, the client also keeps headers and
+//! (size-capped) bodies, which is what makes replay and payload viewing
+//! possible.
+//!
+//! Everything here is in-memory only: a bounded ring buffer per process, never
+//! persisted, never reachable off-loopback.
+
+pub mod server;
+pub mod tap;
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tokio::sync::{broadcast, Notify};
+use uuid::Uuid;
+
+/// Exchanges retained in memory. Matches the server's dashboard ring capacity.
+pub const RING_CAPACITY: usize = 500;
+
+/// Per-body capture cap. Larger bodies are truncated (the exchange still
+/// records the true byte count).
+pub const BODY_CAP: usize = 64 * 1024;
+
+/// Log lines retained for the TUI log pane.
+const LOG_CAPACITY: usize = 500;
+
+// ── captured data ─────────────────────────────────────────────────────────────
+
+/// A captured body prefix.
+#[derive(Debug, Clone, Default)]
+pub struct Body {
+    /// Captured prefix, at most [`BODY_CAP`] bytes.
+    pub bytes: Vec<u8>,
+    /// Total body bytes observed (may exceed `bytes.len()`).
+    pub total: u64,
+    /// True when `total > bytes.len()`.
+    pub truncated: bool,
+}
+
+impl Body {
+    fn push(&mut self, chunk: &[u8]) {
+        self.total += chunk.len() as u64;
+        let room = BODY_CAP.saturating_sub(self.bytes.len());
+        if room == 0 {
+            self.truncated = self.total > self.bytes.len() as u64;
+            return;
+        }
+        let take = room.min(chunk.len());
+        self.bytes.extend_from_slice(&chunk[..take]);
+        self.truncated = self.total > self.bytes.len() as u64;
+    }
+
+    /// Body as text when it is valid UTF-8, else `None` (binary payload).
+    pub fn as_text(&self) -> Option<&str> {
+        std::str::from_utf8(&self.bytes).ok()
+    }
+}
+
+/// One HTTP request/response pair observed on a tunnel.
+#[derive(Debug, Clone)]
+pub struct Exchange {
+    pub id: u64,
+    pub conn_id: Uuid,
+    /// Tunnel label (subdomain or configured name).
+    pub tunnel: String,
+    /// Public client address, from the `NewConnection` control frame.
+    pub client_addr: String,
+    pub method: String,
+    pub path: String,
+    pub host: Option<String>,
+    pub status: u16,
+    pub request_headers: Vec<(String, String)>,
+    pub response_headers: Vec<(String, String)>,
+    pub request_body: Body,
+    pub response_body: Body,
+    pub duration_ms: u64,
+    pub started_at: DateTime<Utc>,
+    /// True when this exchange was produced by the inspector's replay button
+    /// rather than by real inbound traffic.
+    pub replayed: bool,
+}
+
+impl Exchange {
+    /// Compact JSON for list views — no headers or bodies.
+    pub fn to_summary_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "id": self.id,
+            "conn_id": self.conn_id.to_string(),
+            "tunnel": self.tunnel,
+            "client_addr": self.client_addr,
+            "method": self.method,
+            "path": self.path,
+            "status": self.status,
+            "duration_ms": self.duration_ms,
+            "request_bytes": self.request_body.total,
+            "response_bytes": self.response_body.total,
+            "started_at": self.started_at.to_rfc3339(),
+            "replayed": self.replayed,
+        })
+    }
+
+    /// Full JSON including headers and captured body prefixes.
+    pub fn to_detail_json(&self) -> serde_json::Value {
+        let mut v = self.to_summary_json();
+        v["host"] = serde_json::json!(self.host);
+        v["request_headers"] = headers_json(&self.request_headers);
+        v["response_headers"] = headers_json(&self.response_headers);
+        v["request_body"] = body_json(&self.request_body);
+        v["response_body"] = body_json(&self.response_body);
+        v
+    }
+}
+
+fn headers_json(headers: &[(String, String)]) -> serde_json::Value {
+    serde_json::Value::Array(
+        headers
+            .iter()
+            .map(|(k, v)| serde_json::json!({ "name": k, "value": v }))
+            .collect(),
+    )
+}
+
+fn body_json(body: &Body) -> serde_json::Value {
+    match body.as_text() {
+        Some(text) => serde_json::json!({
+            "text": text,
+            "binary": false,
+            "size": body.total,
+            "truncated": body.truncated,
+        }),
+        None => serde_json::json!({
+            "text": serde_json::Value::Null,
+            "binary": true,
+            "size": body.total,
+            "truncated": body.truncated,
+            "preview": hex_preview(&body.bytes),
+        }),
+    }
+}
+
+fn hex_preview(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .take(256)
+        .map(|b| format!("{b:02x}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// ── session state ─────────────────────────────────────────────────────────────
+
+/// Connection state of the tunnel session, as shown in the UI header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionStatus {
+    Connecting,
+    Online,
+    Reconnecting { attempt: u32 },
+    Closed,
+}
+
+impl SessionStatus {
+    pub fn label(&self) -> String {
+        match self {
+            SessionStatus::Connecting => "connecting".into(),
+            SessionStatus::Online => "online".into(),
+            SessionStatus::Reconnecting { attempt } => format!("reconnecting #{attempt}"),
+            SessionStatus::Closed => "closed".into(),
+        }
+    }
+}
+
+/// A registered tunnel, as shown in the UI tunnel list.
+#[derive(Debug, Clone, Serialize)]
+pub struct TunnelInfo {
+    pub name: String,
+    pub proto: String,
+    pub local: String,
+    pub public_url: String,
+    /// `None` when no health check is configured for this tunnel.
+    pub healthy: Option<bool>,
+}
+
+/// Everything the UIs show that is not a captured request.
+#[derive(Debug, Clone)]
+pub struct Session {
+    pub status: SessionStatus,
+    pub server: String,
+    pub region: Option<String>,
+    /// Control-plane round-trip time, measured from Ping/Pong.
+    pub latency_ms: Option<u64>,
+    pub version: String,
+    pub started_at: DateTime<Utc>,
+    pub inspect_url: Option<String>,
+    pub tunnels: Vec<TunnelInfo>,
+}
+
+// ── counters ──────────────────────────────────────────────────────────────────
+
+/// Live traffic counters. Updated from the proxy tasks.
+#[derive(Debug, Default)]
+pub struct Stats {
+    pub conns_open: AtomicU64,
+    pub conns_total: AtomicU64,
+    pub bytes_to_local: AtomicU64,
+    pub bytes_to_tunnel: AtomicU64,
+    pub requests_total: AtomicU64,
+}
+
+impl Stats {
+    pub fn snapshot(&self) -> StatsSnapshot {
+        StatsSnapshot {
+            conns_open: self.conns_open.load(Ordering::Relaxed),
+            conns_total: self.conns_total.load(Ordering::Relaxed),
+            bytes_to_local: self.bytes_to_local.load(Ordering::Relaxed),
+            bytes_to_tunnel: self.bytes_to_tunnel.load(Ordering::Relaxed),
+            requests_total: self.requests_total.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct StatsSnapshot {
+    pub conns_open: u64,
+    pub conns_total: u64,
+    pub bytes_to_local: u64,
+    pub bytes_to_tunnel: u64,
+    pub requests_total: u64,
+}
+
+// ── inspector ─────────────────────────────────────────────────────────────────
+
+/// Shared runtime state for the whole client session.
+///
+/// Created once in `main`, shared by the proxy tasks (writers), the terminal UI
+/// and the web inspector (readers). One instance always exists; `capture`
+/// decides whether the HTTP tap actually runs, so `--json` / non-TTY runs keep
+/// the original zero-overhead byte-copy path.
+pub struct Inspector {
+    /// Whether proxied HTTP connections should be tapped.
+    capture: bool,
+    store: Mutex<VecDeque<Arc<Exchange>>>,
+    events: broadcast::Sender<Arc<Exchange>>,
+    next_id: AtomicU64,
+    pub stats: Stats,
+    session: Mutex<Session>,
+    logs: Mutex<VecDeque<String>>,
+    shutdown: Notify,
+    shutdown_flag: AtomicBool,
+}
+
+impl Inspector {
+    pub fn new(capture: bool, server: String, region: Option<String>) -> Arc<Self> {
+        let (events, _) = broadcast::channel(256);
+        Arc::new(Self {
+            capture,
+            store: Mutex::new(VecDeque::with_capacity(64)),
+            events,
+            next_id: AtomicU64::new(1),
+            stats: Stats::default(),
+            session: Mutex::new(Session {
+                status: SessionStatus::Connecting,
+                server,
+                region,
+                latency_ms: None,
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                started_at: Utc::now(),
+                inspect_url: None,
+                tunnels: Vec::new(),
+            }),
+            logs: Mutex::new(VecDeque::with_capacity(64)),
+            shutdown: Notify::new(),
+            shutdown_flag: AtomicBool::new(false),
+        })
+    }
+
+    /// True when proxied HTTP traffic should be parsed and recorded.
+    pub fn capture_enabled(&self) -> bool {
+        self.capture
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<Arc<Exchange>> {
+        self.events.subscribe()
+    }
+
+    /// Record a completed exchange: assign an id, store it, notify subscribers.
+    pub fn record(&self, mut exchange: Exchange) -> Arc<Exchange> {
+        exchange.id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let exchange = Arc::new(exchange);
+
+        {
+            let mut store = self.store.lock().unwrap();
+            if store.len() == RING_CAPACITY {
+                store.pop_front();
+            }
+            store.push_back(Arc::clone(&exchange));
+        }
+        self.stats.requests_total.fetch_add(1, Ordering::Relaxed);
+
+        // A send error only means nobody is subscribed right now.
+        let _ = self.events.send(Arc::clone(&exchange));
+        exchange
+    }
+
+    /// Most recent exchanges, newest first.
+    pub fn exchanges(&self) -> Vec<Arc<Exchange>> {
+        let store = self.store.lock().unwrap();
+        store.iter().rev().cloned().collect()
+    }
+
+    pub fn exchange(&self, id: u64) -> Option<Arc<Exchange>> {
+        let store = self.store.lock().unwrap();
+        store.iter().find(|e| e.id == id).cloned()
+    }
+
+    pub fn clear(&self) {
+        self.store.lock().unwrap().clear();
+    }
+
+    /// p50 / p90 request duration over the retained exchanges.
+    pub fn latency_percentiles(&self) -> Option<(u64, u64)> {
+        let store = self.store.lock().unwrap();
+        if store.is_empty() {
+            return None;
+        }
+        let mut durations: Vec<u64> = store.iter().map(|e| e.duration_ms).collect();
+        durations.sort_unstable();
+        Some((percentile(&durations, 50), percentile(&durations, 90)))
+    }
+
+    // ── session accessors ────────────────────────────────────────────────
+
+    pub fn session(&self) -> Session {
+        self.session.lock().unwrap().clone()
+    }
+
+    pub fn set_status(&self, status: SessionStatus) {
+        self.session.lock().unwrap().status = status;
+    }
+
+    pub fn set_latency(&self, latency_ms: u64) {
+        self.session.lock().unwrap().latency_ms = Some(latency_ms);
+    }
+
+    pub fn set_inspect_url(&self, url: String) {
+        self.session.lock().unwrap().inspect_url = Some(url);
+    }
+
+    pub fn set_server(&self, server: String) {
+        self.session.lock().unwrap().server = server;
+    }
+
+    pub fn set_tunnels(&self, tunnels: Vec<TunnelInfo>) {
+        self.session.lock().unwrap().tunnels = tunnels;
+    }
+
+    /// Update the health flag of a tunnel identified by its local address.
+    pub fn set_tunnel_health(&self, local: &str, healthy: bool) {
+        let mut session = self.session.lock().unwrap();
+        for tunnel in session.tunnels.iter_mut() {
+            if tunnel.local == local {
+                tunnel.healthy = Some(healthy);
+            }
+        }
+    }
+
+    /// Local address of the tunnel a request arrived on, for replay.
+    pub fn local_addr_for(&self, tunnel: &str) -> Option<String> {
+        let session = self.session.lock().unwrap();
+        session
+            .tunnels
+            .iter()
+            .find(|t| t.name == tunnel)
+            .or_else(|| session.tunnels.first())
+            .map(|t| t.local.clone())
+    }
+
+    // ── log buffer (TUI log pane) ────────────────────────────────────────
+
+    pub fn push_log(&self, line: String) {
+        let mut logs = self.logs.lock().unwrap();
+        if logs.len() == LOG_CAPACITY {
+            logs.pop_front();
+        }
+        logs.push_back(line);
+    }
+
+    pub fn logs(&self) -> Vec<String> {
+        self.logs.lock().unwrap().iter().cloned().collect()
+    }
+
+    // ── shutdown ─────────────────────────────────────────────────────────
+
+    /// Ask the tunnel session to shut down (TUI quit key).
+    pub fn request_shutdown(&self) {
+        self.shutdown_flag.store(true, Ordering::SeqCst);
+        self.shutdown.notify_waiters();
+    }
+
+    pub fn shutdown_requested(&self) -> bool {
+        self.shutdown_flag.load(Ordering::SeqCst)
+    }
+
+    /// Resolves once [`request_shutdown`](Self::request_shutdown) is called.
+    pub async fn shutdown_signal(&self) {
+        if self.shutdown_requested() {
+            return;
+        }
+        self.shutdown.notified().await;
+    }
+}
+
+/// Nearest-rank percentile of a pre-sorted slice.
+fn percentile(sorted: &[u64], pct: usize) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let rank = (pct * sorted.len()).div_ceil(100);
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+/// Human-readable byte count for the UIs.
+pub fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "kB", "MB", "GB", "TB"];
+    let mut value = bytes as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} B")
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exchange(status: u16, duration_ms: u64) -> Exchange {
+        Exchange {
+            id: 0,
+            conn_id: Uuid::nil(),
+            tunnel: "web".into(),
+            client_addr: "203.0.113.7:51000".into(),
+            method: "GET".into(),
+            path: "/".into(),
+            host: Some("example.test".into()),
+            status,
+            request_headers: vec![("host".into(), "example.test".into())],
+            response_headers: vec![],
+            request_body: Body::default(),
+            response_body: Body::default(),
+            duration_ms,
+            started_at: Utc::now(),
+            replayed: false,
+        }
+    }
+
+    #[test]
+    fn body_capture_truncates_at_cap_but_counts_all_bytes() {
+        let mut body = Body::default();
+        body.push(&vec![b'a'; BODY_CAP - 10]);
+        body.push(&[b'b'; 100]);
+        assert_eq!(body.bytes.len(), BODY_CAP);
+        assert_eq!(body.total, (BODY_CAP - 10 + 100) as u64);
+        assert!(body.truncated);
+    }
+
+    #[test]
+    fn small_body_is_not_marked_truncated() {
+        let mut body = Body::default();
+        body.push(b"hello");
+        assert_eq!(body.as_text(), Some("hello"));
+        assert!(!body.truncated);
+        assert_eq!(body.total, 5);
+    }
+
+    #[test]
+    fn ring_buffer_evicts_oldest_beyond_capacity() {
+        let inspector = Inspector::new(true, "edge.test:4040".into(), None);
+        for i in 0..(RING_CAPACITY + 25) {
+            inspector.record(exchange(200, i as u64));
+        }
+        let stored = inspector.exchanges();
+        assert_eq!(stored.len(), RING_CAPACITY);
+        // Newest first, and ids keep counting past the ring capacity.
+        assert_eq!(stored[0].id, (RING_CAPACITY + 25) as u64);
+        assert_eq!(
+            inspector.stats.requests_total.load(Ordering::Relaxed),
+            (RING_CAPACITY + 25) as u64
+        );
+    }
+
+    #[test]
+    fn recorded_exchanges_are_broadcast_and_retrievable_by_id() {
+        let inspector = Inspector::new(true, "edge.test:4040".into(), None);
+        let mut rx = inspector.subscribe();
+        let recorded = inspector.record(exchange(201, 5));
+        assert_eq!(rx.try_recv().unwrap().id, recorded.id);
+        assert_eq!(inspector.exchange(recorded.id).unwrap().status, 201);
+        assert!(inspector.exchange(9999).is_none());
+    }
+
+    #[test]
+    fn percentiles_use_nearest_rank() {
+        let sorted: Vec<u64> = (1..=10).collect();
+        assert_eq!(percentile(&sorted, 50), 5);
+        assert_eq!(percentile(&sorted, 90), 9);
+        assert_eq!(percentile(&[], 50), 0);
+        assert_eq!(percentile(&[42], 90), 42);
+    }
+
+    #[test]
+    fn latency_percentiles_none_when_empty() {
+        let inspector = Inspector::new(true, "edge.test:4040".into(), None);
+        assert!(inspector.latency_percentiles().is_none());
+        for d in [10, 20, 30, 40, 500] {
+            inspector.record(exchange(200, d));
+        }
+        let (p50, p90) = inspector.latency_percentiles().unwrap();
+        assert_eq!(p50, 30);
+        assert_eq!(p90, 500);
+    }
+
+    #[test]
+    fn shutdown_flag_is_observable_before_awaiting() {
+        let inspector = Inspector::new(false, "edge.test:4040".into(), None);
+        assert!(!inspector.shutdown_requested());
+        inspector.request_shutdown();
+        assert!(inspector.shutdown_requested());
+    }
+
+    #[test]
+    fn tunnel_health_updates_by_local_addr() {
+        let inspector = Inspector::new(true, "edge.test:4040".into(), None);
+        inspector.set_tunnels(vec![TunnelInfo {
+            name: "web".into(),
+            proto: "http".into(),
+            local: "localhost:3000".into(),
+            public_url: "https://web.edge.test".into(),
+            healthy: None,
+        }]);
+        inspector.set_tunnel_health("localhost:3000", false);
+        assert_eq!(inspector.session().tunnels[0].healthy, Some(false));
+        assert_eq!(
+            inspector.local_addr_for("web").as_deref(),
+            Some("localhost:3000")
+        );
+    }
+
+    #[test]
+    fn byte_formatting_is_human_readable() {
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(2048), "2.0 kB");
+        assert_eq!(format_bytes(5 * 1024 * 1024), "5.0 MB");
+    }
+
+    #[test]
+    fn summary_json_omits_bodies_and_headers() {
+        let inspector = Inspector::new(true, "edge.test:4040".into(), None);
+        let ex = inspector.record(exchange(404, 12));
+        let summary = ex.to_summary_json();
+        assert_eq!(summary["status"], 404);
+        assert!(summary.get("request_headers").is_none());
+        let detail = ex.to_detail_json();
+        assert_eq!(detail["request_headers"][0]["name"], "host");
+        assert_eq!(detail["request_body"]["binary"], false);
+    }
+}

--- a/crates/rustunnel-client/src/inspect/server.rs
+++ b/crates/rustunnel-client/src/inspect/server.rs
@@ -219,9 +219,14 @@ async fn replay_request(
         )
     })?;
 
-    let url = format!("http://{}{}", local_addr, original.path);
+    let url = format!("http://{}{}", local_addr, origin_form(&original.path));
     let client = reqwest::Client::builder()
         .timeout(REPLAY_TIMEOUT)
+        // Never follow redirects. A replay must report what the local service
+        // itself returned — following a 3xx would record the destination's
+        // response instead, and would send this request (carrying the captured
+        // credentials) somewhere the service merely pointed at.
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
@@ -287,6 +292,30 @@ async fn replay_request(
     })))
 }
 
+/// Reduce a captured request-target to origin-form (`/path?query`) so it can be
+/// appended to the local base URL.
+///
+/// Most requests already arrive in origin-form. A proxy-style client may send
+/// absolute-form (`GET http://host/path HTTP/1.1`), which would otherwise
+/// concatenate into a nonsense URL like `http://localhost:3000http://host/path`.
+fn origin_form(target: &str) -> &str {
+    if target.starts_with('/') {
+        return target;
+    }
+    for scheme in ["http://", "https://"] {
+        if let Some(rest) = target.strip_prefix(scheme) {
+            // Everything from the first '/' after the authority is the path.
+            return match rest.find('/') {
+                Some(slash) => &rest[slash..],
+                None => "/",
+            };
+        }
+    }
+    // Asterisk-form (`OPTIONS *`) and anything unrecognised: replay the root
+    // rather than building an invalid URL.
+    "/"
+}
+
 /// Headers that describe a single hop and must not be copied into a replay.
 fn is_hop_by_hop(name: &str) -> bool {
     const HOP_BY_HOP: [&str; 8] = [
@@ -309,6 +338,141 @@ fn is_hop_by_hop(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::inspect::{Body, TunnelInfo};
+    use uuid::Uuid;
+
+    /// Record an exchange as if it had been captured on `tunnel`.
+    fn seed_exchange(inspector: &Arc<Inspector>, tunnel: &str, path: &str) -> u64 {
+        inspector
+            .record(Exchange {
+                id: 0,
+                conn_id: Uuid::nil(),
+                tunnel: tunnel.to_string(),
+                client_addr: "203.0.113.5:40000".into(),
+                method: "GET".into(),
+                path: path.to_string(),
+                host: None,
+                status: 200,
+                request_headers: vec![("x-marker".into(), "original".into())],
+                response_headers: vec![],
+                request_body: Body::default(),
+                response_body: Body::default(),
+                duration_ms: 1,
+                started_at: Utc::now(),
+                replayed: false,
+            })
+            .id
+    }
+
+    /// Serve one fixed response on loopback; returns its `host:port`.
+    async fn spawn_service(response: &'static str) -> String {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 4096];
+                    let _ = socket.read(&mut buf).await;
+                    let _ = socket.write_all(response.as_bytes()).await;
+                    let _ = socket.flush().await;
+                });
+            }
+        });
+        format!("127.0.0.1:{}", addr.port())
+    }
+
+    /// A replay must record the redirect the local service actually returned,
+    /// not chase it — following it would both misreport the response and send
+    /// the captured credentials on to wherever `Location` points.
+    #[tokio::test]
+    async fn replay_records_redirects_instead_of_following_them() {
+        let local = spawn_service(
+            "HTTP/1.1 302 Found\r\nLocation: http://example.com/elsewhere\r\nContent-Length: 0\r\n\r\n",
+        )
+        .await;
+
+        let inspector = Inspector::new(true, "edge.test:4040".into(), None);
+        inspector.set_tunnels(vec![TunnelInfo {
+            name: "web".into(),
+            proto: "http".into(),
+            local: local.clone(),
+            public_url: "https://web.edge.test".into(),
+            healthy: None,
+        }]);
+        let id = seed_exchange(&inspector, "web", "/go");
+
+        let response = replay_request(State(Arc::clone(&inspector)), Path(id))
+            .await
+            .expect("replay should succeed");
+
+        assert_eq!(response.0["replayed"]["status"], 302);
+        let recorded = inspector.exchanges();
+        assert!(recorded[0].replayed);
+        assert_eq!(recorded[0].status, 302);
+        assert!(
+            recorded[0]
+                .response_headers
+                .iter()
+                .any(|(k, v)| k.eq_ignore_ascii_case("location")
+                    && v == "http://example.com/elsewhere"),
+            "the Location header must be preserved for the UI"
+        );
+    }
+
+    /// Replay resolves the tunnel by name; an unknown tunnel is a conflict
+    /// rather than a request sent to some other local service.
+    #[tokio::test]
+    async fn replay_refuses_when_the_tunnel_is_unknown() {
+        let inspector = Inspector::new(true, "edge.test:4040".into(), None);
+        inspector.set_tunnels(vec![TunnelInfo {
+            name: "web".into(),
+            proto: "http".into(),
+            local: "127.0.0.1:9".into(),
+            public_url: "https://web.edge.test".into(),
+            healthy: None,
+        }]);
+        let id = seed_exchange(&inspector, "retired-tunnel", "/x");
+
+        let error = replay_request(State(Arc::clone(&inspector)), Path(id))
+            .await
+            .expect_err("must not replay against a different tunnel");
+        assert_eq!(error.0, StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn replay_normalises_an_absolute_form_request_target() {
+        let local = spawn_service("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok").await;
+
+        let inspector = Inspector::new(true, "edge.test:4040".into(), None);
+        inspector.set_tunnels(vec![TunnelInfo {
+            name: "web".into(),
+            proto: "http".into(),
+            local: local.clone(),
+            public_url: "https://web.edge.test".into(),
+            healthy: None,
+        }]);
+        // Proxy-style absolute-form target, which would otherwise build
+        // `http://127.0.0.1:PORT http://web.edge.test/thing` and fail to parse.
+        let id = seed_exchange(&inspector, "web", "http://web.edge.test/thing?a=1");
+
+        let response = replay_request(State(Arc::clone(&inspector)), Path(id))
+            .await
+            .expect("absolute-form target should still replay");
+        assert_eq!(response.0["replayed"]["status"], 200);
+    }
+
+    #[test]
+    fn origin_form_reduces_every_request_target_shape() {
+        assert_eq!(origin_form("/plain?q=1"), "/plain?q=1");
+        assert_eq!(origin_form("http://host/path?q=1"), "/path?q=1");
+        assert_eq!(origin_form("https://host:8443/deep/path"), "/deep/path");
+        assert_eq!(origin_form("http://host"), "/");
+        assert_eq!(origin_form("*"), "/");
+    }
 
     #[test]
     fn hop_by_hop_headers_are_stripped_case_insensitively() {

--- a/crates/rustunnel-client/src/inspect/server.rs
+++ b/crates/rustunnel-client/src/inspect/server.rs
@@ -1,0 +1,381 @@
+//! Local web inspector.
+//!
+//! A small axum server bound to loopback only, serving the request history
+//! captured by [`crate::inspect::tap`]: list, detail (headers + bodies), live
+//! updates over SSE, and replay against the local service.
+//!
+//! Captured payloads can contain credentials and personal data, so this server
+//! never binds anything but `127.0.0.1` and is disabled entirely with
+//! `--no-inspect`.
+
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
+use axum::response::{Html, Json};
+use axum::routing::{delete, get, post};
+use axum::Router;
+use chrono::Utc;
+use tokio::net::TcpListener;
+use tokio::sync::broadcast::error::RecvError;
+use tracing::{debug, info, warn};
+
+use super::{Body, Exchange, Inspector, BODY_CAP};
+
+/// Default inspector port — the same one ngrok uses, for muscle memory.
+pub const DEFAULT_PORT: u16 = 4040;
+
+/// How many ports past the preferred one to try before giving up.
+const PORT_SCAN_RANGE: u16 = 20;
+
+/// Never bind this port: it is reserved for other local services and is the
+/// single most likely port for the app being tunnelled.
+const RESERVED_PORT: u16 = 3000;
+
+/// How long a replayed request may take before it is abandoned.
+const REPLAY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long to wait when probing whether a port is already serving.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(150);
+
+/// Bind the inspector to loopback, starting at `preferred` and scanning
+/// forward if it is taken. Returns the listener and the URL it is reachable on.
+pub async fn bind(preferred: u16) -> Option<(TcpListener, String)> {
+    // Port 0 means "any free port" — bind once and report what we got.
+    if preferred == 0 {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.ok()?;
+        let port = listener.local_addr().ok()?.port();
+        return Some((listener, format!("http://127.0.0.1:{port}")));
+    }
+
+    for port in preferred..preferred.saturating_add(PORT_SCAN_RANGE) {
+        if port == RESERVED_PORT {
+            continue;
+        }
+        // A successful bind is not proof the port is free: on macOS/BSD,
+        // binding 127.0.0.1:P succeeds even when another process holds
+        // 0.0.0.0:P, and loopback traffic then reaches us instead of them.
+        // That would silently hijack the local tunnel server (which listens on
+        // :4040 too), so probe for a live listener before claiming the port.
+        if port_is_serving(port).await {
+            debug!(port, "inspector: port already serving — trying next");
+            continue;
+        }
+        match TcpListener::bind(("127.0.0.1", port)).await {
+            Ok(listener) => return Some((listener, format!("http://127.0.0.1:{port}"))),
+            Err(e) => debug!(port, "inspector: port unavailable ({e}) — trying next"),
+        }
+    }
+    None
+}
+
+/// True when something already accepts connections on loopback at `port`.
+async fn port_is_serving(port: u16) -> bool {
+    tokio::time::timeout(
+        PROBE_TIMEOUT,
+        tokio::net::TcpStream::connect(("127.0.0.1", port)),
+    )
+    .await
+    .is_ok_and(|result| result.is_ok())
+}
+
+/// Serve the inspector until the process exits.
+pub async fn serve(listener: TcpListener, inspector: Arc<Inspector>) {
+    let app = Router::new()
+        .route("/", get(index))
+        .route("/api/status", get(status))
+        .route("/api/requests", get(list_requests))
+        .route("/api/requests", delete(clear_requests))
+        .route("/api/requests/:id", get(request_detail))
+        .route("/api/requests/:id/replay", post(replay_request))
+        .route("/api/stream", get(stream))
+        .with_state(inspector);
+
+    if let Err(e) = axum::serve(listener, app).await {
+        warn!("inspector: server stopped: {e}");
+    }
+}
+
+// ── handlers ──────────────────────────────────────────────────────────────────
+
+async fn index() -> Html<&'static str> {
+    Html(include_str!("ui.html"))
+}
+
+async fn status(State(inspector): State<Arc<Inspector>>) -> Json<serde_json::Value> {
+    let session = inspector.session();
+    let stats = inspector.stats.snapshot();
+    let (p50, p90) = inspector.latency_percentiles().unwrap_or((0, 0));
+
+    Json(serde_json::json!({
+        "status": session.status.label(),
+        "server": session.server,
+        "region": session.region,
+        "latency_ms": session.latency_ms,
+        "version": session.version,
+        "started_at": session.started_at.to_rfc3339(),
+        "tunnels": session.tunnels,
+        "stats": stats,
+        "p50_ms": p50,
+        "p90_ms": p90,
+    }))
+}
+
+async fn list_requests(
+    State(inspector): State<Arc<Inspector>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Json<serde_json::Value> {
+    let limit: usize = params
+        .get("limit")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(200);
+
+    let method = params.get("method").map(|m| m.to_ascii_uppercase());
+    let status_filter = params.get("status").and_then(|s| s.parse::<u16>().ok());
+    let query = params.get("q").map(|q| q.to_lowercase());
+
+    let items: Vec<serde_json::Value> = inspector
+        .exchanges()
+        .into_iter()
+        .filter(|ex| method.as_ref().is_none_or(|m| &ex.method == m))
+        .filter(|ex| status_filter.is_none_or(|s| ex.status == s))
+        .filter(|ex| {
+            query.as_ref().is_none_or(|q| {
+                ex.path.to_lowercase().contains(q)
+                    || ex.method.to_lowercase().contains(q)
+                    || ex.status.to_string().contains(q)
+            })
+        })
+        .take(limit)
+        .map(|ex| ex.to_summary_json())
+        .collect();
+
+    Json(serde_json::json!({ "requests": items }))
+}
+
+async fn request_detail(
+    State(inspector): State<Arc<Inspector>>,
+    Path(id): Path<u64>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    inspector
+        .exchange(id)
+        .map(|ex| Json(ex.to_detail_json()))
+        .ok_or(StatusCode::NOT_FOUND)
+}
+
+async fn clear_requests(State(inspector): State<Arc<Inspector>>) -> StatusCode {
+    inspector.clear();
+    StatusCode::NO_CONTENT
+}
+
+/// Server-sent events: one JSON summary per captured exchange.
+async fn stream(
+    State(inspector): State<Arc<Inspector>>,
+) -> Sse<impl futures_util::Stream<Item = Result<SseEvent, Infallible>>> {
+    let receiver = inspector.subscribe();
+
+    let stream = futures_util::stream::unfold(receiver, |mut receiver| async move {
+        loop {
+            match receiver.recv().await {
+                Ok(exchange) => {
+                    let event = SseEvent::default().data(exchange.to_summary_json().to_string());
+                    return Some((Ok(event), receiver));
+                }
+                // A slow browser tab just misses events; keep the stream alive.
+                Err(RecvError::Lagged(skipped)) => {
+                    debug!(skipped, "inspector: SSE subscriber lagged");
+                    continue;
+                }
+                Err(RecvError::Closed) => return None,
+            }
+        }
+    });
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+/// Re-issue a captured request against the local service and record the result.
+async fn replay_request(
+    State(inspector): State<Arc<Inspector>>,
+    Path(id): Path<u64>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let original = inspector
+        .exchange(id)
+        .ok_or((StatusCode::NOT_FOUND, "no such request".to_string()))?;
+
+    let local_addr = inspector.local_addr_for(&original.tunnel).ok_or((
+        StatusCode::CONFLICT,
+        "no local address known for this tunnel".to_string(),
+    ))?;
+
+    let method = reqwest::Method::from_bytes(original.method.as_bytes()).map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("cannot replay method {}", original.method),
+        )
+    })?;
+
+    let url = format!("http://{}{}", local_addr, original.path);
+    let client = reqwest::Client::builder()
+        .timeout(REPLAY_TIMEOUT)
+        .build()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let mut request = client.request(method, &url);
+    for (name, value) in &original.request_headers {
+        if is_hop_by_hop(name) {
+            continue;
+        }
+        request = request.header(name, value);
+    }
+    if !original.request_body.bytes.is_empty() {
+        request = request.body(original.request_body.bytes.clone());
+    }
+
+    info!(%url, original_id = id, "inspector: replaying request");
+    let started = Instant::now();
+    let started_at = Utc::now();
+
+    let response = request
+        .send()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("replay failed: {e}")))?;
+
+    let status = response.status().as_u16();
+    let response_headers: Vec<(String, String)> = response
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or_default().to_string()))
+        .collect();
+    let body_bytes = response
+        .bytes()
+        .await
+        .map_err(|e| (StatusCode::BAD_GATEWAY, format!("replay failed: {e}")))?;
+    let duration_ms = started.elapsed().as_millis() as u64;
+
+    let mut response_body = Body::default();
+    response_body.push(&body_bytes[..body_bytes.len().min(BODY_CAP)]);
+    response_body.total = body_bytes.len() as u64;
+    response_body.truncated = body_bytes.len() > response_body.bytes.len();
+
+    let recorded = inspector.record(Exchange {
+        id: 0,
+        conn_id: original.conn_id,
+        tunnel: original.tunnel.clone(),
+        client_addr: "replay".to_string(),
+        method: original.method.clone(),
+        path: original.path.clone(),
+        host: original.host.clone(),
+        status,
+        request_headers: original.request_headers.clone(),
+        response_headers,
+        request_body: original.request_body.clone(),
+        response_body,
+        duration_ms,
+        started_at,
+        replayed: true,
+    });
+
+    Ok(Json(serde_json::json!({
+        "replayed": recorded.to_summary_json(),
+        // The capture is capped, so a huge original body cannot be replayed byte-exact.
+        "body_truncated": original.request_body.truncated,
+    })))
+}
+
+/// Headers that describe a single hop and must not be copied into a replay.
+fn is_hop_by_hop(name: &str) -> bool {
+    const HOP_BY_HOP: [&str; 8] = [
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    ];
+    let lower = name.to_ascii_lowercase();
+    // Content-Length is recomputed by the HTTP client from the body we set.
+    HOP_BY_HOP.contains(&lower.as_str()) || lower == "content-length"
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hop_by_hop_headers_are_stripped_case_insensitively() {
+        assert!(is_hop_by_hop("Connection"));
+        assert!(is_hop_by_hop("transfer-encoding"));
+        assert!(is_hop_by_hop("Content-Length"));
+        assert!(!is_hop_by_hop("Authorization"));
+        assert!(!is_hop_by_hop("Host"));
+        assert!(!is_hop_by_hop("content-type"));
+    }
+
+    #[tokio::test]
+    async fn bind_skips_the_reserved_port() {
+        // Starting the scan at the reserved port must move past it.
+        let (listener, url) = bind(RESERVED_PORT).await.expect("a port should be free");
+        let port = listener.local_addr().unwrap().port();
+        assert_ne!(port, RESERVED_PORT);
+        assert!(url.starts_with("http://127.0.0.1:"));
+    }
+
+    #[tokio::test]
+    async fn bind_falls_forward_when_the_preferred_port_is_taken() {
+        let squatter = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let taken = squatter.local_addr().unwrap().port();
+
+        let (listener, _) = bind(taken).await.expect("a later port should be free");
+        assert_ne!(listener.local_addr().unwrap().port(), taken);
+    }
+
+    /// Regression: binding 127.0.0.1:P while another process holds 0.0.0.0:P
+    /// succeeds on macOS/BSD, and loopback traffic would then reach the
+    /// inspector instead of that process — which hijacked the local tunnel
+    /// server's control port (:4040) and broke the client's own connection.
+    #[tokio::test]
+    async fn bind_skips_a_port_served_on_all_interfaces() {
+        let wildcard = TcpListener::bind(("0.0.0.0", 0)).await.unwrap();
+        let taken = wildcard.local_addr().unwrap().port();
+        // Keep accepting so the probe sees a live listener.
+        tokio::spawn(async move {
+            loop {
+                if wildcard.accept().await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let (listener, _) = bind(taken).await.expect("a later port should be free");
+        assert_ne!(
+            listener.local_addr().unwrap().port(),
+            taken,
+            "must not shadow a wildcard listener"
+        );
+    }
+
+    #[tokio::test]
+    async fn port_probe_detects_live_listeners_only() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let live = listener.local_addr().unwrap().port();
+        assert!(port_is_serving(live).await);
+
+        drop(listener);
+        assert!(!port_is_serving(live).await);
+    }
+
+    #[tokio::test]
+    async fn bind_is_loopback_only() {
+        let (listener, _) = bind(0).await.unwrap();
+        assert!(listener.local_addr().unwrap().ip().is_loopback());
+    }
+}

--- a/crates/rustunnel-client/src/inspect/tap.rs
+++ b/crates/rustunnel-client/src/inspect/tap.rs
@@ -1,0 +1,889 @@
+//! Passive HTTP/1.x tap over a proxied connection.
+//!
+//! The tunnel client forwards raw bytes. To show requests in the UIs we need
+//! method/path/status/headers/bodies, so the proxy feeds every byte it copies
+//! through a [`ConnTap`] — an observer that parses HTTP framing but never
+//! modifies, reorders, or delays the stream. Anything that stops looking like
+//! HTTP/1.x (protocol upgrades, HTTP/2 prior knowledge, malformed traffic)
+//! drops the connection into passthrough mode and the bytes keep flowing.
+//!
+//! Both directions of one connection share a [`ConnTap`]: requests and
+//! responses are paired FIFO, which is what HTTP/1.1 keep-alive and pipelining
+//! guarantee.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use super::{Body, Exchange, Inspector};
+
+/// Upper bound on a request/response head. Beyond this we stop parsing rather
+/// than buffer unboundedly.
+const MAX_HEAD: usize = 64 * 1024;
+
+/// Maximum headers parsed per message.
+const MAX_HEADERS: usize = 96;
+
+/// Maximum requests awaiting a response on one connection.
+///
+/// Real pipelining depth is tiny; a queue this deep means the response side
+/// stopped producing parseable replies, and the queue would otherwise grow for
+/// as long as the connection lives.
+const MAX_PENDING: usize = 64;
+
+// ── body framing ──────────────────────────────────────────────────────────────
+
+/// How the body of the message currently being parsed is delimited.
+#[derive(Debug)]
+enum Framing {
+    /// `Content-Length: n`.
+    Length(u64),
+    /// `Transfer-Encoding: chunked`.
+    Chunked(ChunkScanner),
+    /// Response body that ends when the connection closes.
+    UntilEof,
+}
+
+impl Framing {
+    /// Consume as much of `buf` as belongs to this body, capturing it into
+    /// `sink`. Returns the number of bytes consumed and whether the body ended.
+    fn feed(&mut self, buf: &[u8], sink: Option<&mut Body>) -> (usize, bool) {
+        match self {
+            Framing::Length(remaining) => {
+                let take = (*remaining).min(buf.len() as u64) as usize;
+                if let Some(sink) = sink {
+                    sink.push(&buf[..take]);
+                }
+                *remaining -= take as u64;
+                (take, *remaining == 0)
+            }
+            Framing::UntilEof => {
+                if let Some(sink) = sink {
+                    sink.push(buf);
+                }
+                (buf.len(), false)
+            }
+            Framing::Chunked(scanner) => scanner.feed(buf, sink),
+        }
+    }
+}
+
+/// Incremental `Transfer-Encoding: chunked` scanner.
+///
+/// Tracks chunk boundaries across arbitrary buffer splits so we know where the
+/// body ends and the next message on a keep-alive connection begins.
+#[derive(Debug)]
+struct ChunkScanner {
+    state: ChunkState,
+    /// Partial size or trailer line.
+    line: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChunkState {
+    /// Reading the hex chunk-size line.
+    Size,
+    /// Reading chunk data; `n` bytes remain.
+    Data(u64),
+    /// Consuming the CRLF that follows chunk data; `n` bytes seen so far.
+    DataCrlf(u8),
+    /// Reading trailer headers after the final chunk.
+    Trailer,
+    /// Body complete, or malformed and abandoned.
+    Done,
+}
+
+impl ChunkScanner {
+    fn new() -> Self {
+        Self {
+            state: ChunkState::Size,
+            line: Vec::new(),
+        }
+    }
+
+    fn feed(&mut self, buf: &[u8], mut sink: Option<&mut Body>) -> (usize, bool) {
+        let mut i = 0;
+        while i < buf.len() {
+            match self.state {
+                ChunkState::Size => {
+                    let byte = buf[i];
+                    i += 1;
+                    self.line.push(byte);
+                    if byte == b'\n' {
+                        match parse_chunk_size(&self.line) {
+                            Some(0) => self.state = ChunkState::Trailer,
+                            Some(n) => self.state = ChunkState::Data(n),
+                            None => self.state = ChunkState::Done,
+                        }
+                        self.line.clear();
+                    } else if self.line.len() > 64 {
+                        // A chunk-size line this long is not valid HTTP.
+                        self.state = ChunkState::Done;
+                    }
+                }
+                ChunkState::Data(remaining) => {
+                    let take = remaining.min((buf.len() - i) as u64) as usize;
+                    if let Some(sink) = sink.as_deref_mut() {
+                        sink.push(&buf[i..i + take]);
+                    }
+                    i += take;
+                    let left = remaining - take as u64;
+                    self.state = if left == 0 {
+                        ChunkState::DataCrlf(0)
+                    } else {
+                        ChunkState::Data(left)
+                    };
+                }
+                ChunkState::DataCrlf(seen) => {
+                    i += 1;
+                    self.state = if seen + 1 >= 2 {
+                        ChunkState::Size
+                    } else {
+                        ChunkState::DataCrlf(seen + 1)
+                    };
+                }
+                ChunkState::Trailer => {
+                    let byte = buf[i];
+                    i += 1;
+                    self.line.push(byte);
+                    if byte == b'\n' {
+                        let line_is_blank = matches!(self.line.as_slice(), b"\r\n" | b"\n");
+                        self.line.clear();
+                        if line_is_blank {
+                            self.state = ChunkState::Done;
+                            return (i, true);
+                        }
+                    } else if self.line.len() > MAX_HEAD {
+                        self.state = ChunkState::Done;
+                        return (i, true);
+                    }
+                }
+                ChunkState::Done => return (i, true),
+            }
+        }
+        (i, self.state == ChunkState::Done)
+    }
+}
+
+/// Parse a chunk-size line (`"1a\r\n"` or `"1a;ext=1\r\n"`).
+fn parse_chunk_size(line: &[u8]) -> Option<u64> {
+    let text = std::str::from_utf8(line).ok()?;
+    let text = text.trim_end_matches(['\r', '\n']);
+    let text = text.split(';').next()?.trim();
+    if text.is_empty() {
+        return None;
+    }
+    u64::from_str_radix(text, 16).ok()
+}
+
+// ── per-direction parser ──────────────────────────────────────────────────────
+
+#[derive(Debug)]
+enum Mode {
+    /// Accumulating a message head.
+    Head,
+    /// Reading a message body.
+    Body(Framing),
+    /// Not HTTP (or no longer HTTP) — stop looking.
+    Passthrough,
+}
+
+#[derive(Debug)]
+struct DirParser {
+    mode: Mode,
+    /// Bytes seen but not yet consumed by the parser.
+    buffer: Vec<u8>,
+}
+
+impl DirParser {
+    fn new() -> Self {
+        Self {
+            mode: Mode::Head,
+            buffer: Vec::new(),
+        }
+    }
+
+    fn passthrough(&mut self) {
+        self.mode = Mode::Passthrough;
+        self.buffer = Vec::new();
+    }
+
+    /// Offset just past the `\r\n\r\n` (or `\n\n`) ending the head, if present.
+    fn head_end(&self) -> Option<usize> {
+        let buf = &self.buffer;
+        buf.windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .map(|i| i + 4)
+            .or_else(|| buf.windows(2).position(|w| w == b"\n\n").map(|i| i + 2))
+    }
+}
+
+// ── in-flight state ───────────────────────────────────────────────────────────
+
+/// A request whose response has not completed yet.
+struct PendingRequest {
+    method: String,
+    path: String,
+    host: Option<String>,
+    headers: Vec<(String, String)>,
+    body: Body,
+    started_at: DateTime<Utc>,
+    start: Instant,
+}
+
+/// Response head awaiting its body.
+struct PendingResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: Body,
+}
+
+struct TapState {
+    inspector: Arc<Inspector>,
+    tunnel: String,
+    conn_id: Uuid,
+    client_addr: String,
+    request: DirParser,
+    response: DirParser,
+    /// Requests awaiting a response, oldest first.
+    pending: VecDeque<PendingRequest>,
+    current_response: Option<PendingResponse>,
+}
+
+impl TapState {
+    // ── request direction (tunnel → local service) ───────────────────────
+
+    fn feed_request(&mut self, bytes: &[u8]) {
+        if matches!(self.request.mode, Mode::Passthrough) {
+            return;
+        }
+        self.request.buffer.extend_from_slice(bytes);
+
+        loop {
+            match std::mem::replace(&mut self.request.mode, Mode::Head) {
+                Mode::Passthrough => {
+                    self.request.passthrough();
+                    return;
+                }
+                Mode::Head => {
+                    let Some(end) = self.request.head_end() else {
+                        if self.request.buffer.len() > MAX_HEAD {
+                            self.request.passthrough();
+                        }
+                        return;
+                    };
+                    let head: Vec<u8> = self.request.buffer.drain(..end).collect();
+                    match parse_request_head(&head) {
+                        Some((method, path, headers)) => {
+                            let framing = request_framing(&headers);
+                            let host = header_value(&headers, "host");
+                            if self.pending.len() >= MAX_PENDING {
+                                self.pending.pop_front();
+                            }
+                            self.pending.push_back(PendingRequest {
+                                method,
+                                path,
+                                host,
+                                headers,
+                                body: Body::default(),
+                                started_at: Utc::now(),
+                                start: Instant::now(),
+                            });
+                            match framing {
+                                Some(framing) => self.request.mode = Mode::Body(framing),
+                                // No body: the next bytes start a new request.
+                                None => self.request.mode = Mode::Head,
+                            }
+                        }
+                        None => {
+                            self.request.passthrough();
+                            return;
+                        }
+                    }
+                }
+                Mode::Body(mut framing) => {
+                    if self.request.buffer.is_empty() {
+                        self.request.mode = Mode::Body(framing);
+                        return;
+                    }
+                    let sink = self.pending.back_mut().map(|p| &mut p.body);
+                    let (consumed, done) = framing.feed(&self.request.buffer, sink);
+                    self.request.buffer.drain(..consumed);
+                    self.request.mode = if done {
+                        Mode::Head
+                    } else {
+                        Mode::Body(framing)
+                    };
+                    if !done {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    // ── response direction (local service → tunnel) ──────────────────────
+
+    fn feed_response(&mut self, bytes: &[u8]) {
+        if matches!(self.response.mode, Mode::Passthrough) {
+            return;
+        }
+        self.response.buffer.extend_from_slice(bytes);
+
+        loop {
+            match std::mem::replace(&mut self.response.mode, Mode::Head) {
+                Mode::Passthrough => {
+                    self.response.passthrough();
+                    return;
+                }
+                Mode::Head => {
+                    let Some(end) = self.response.head_end() else {
+                        if self.response.buffer.len() > MAX_HEAD {
+                            self.response.passthrough();
+                        }
+                        return;
+                    };
+                    let head: Vec<u8> = self.response.buffer.drain(..end).collect();
+                    let Some((status, headers)) = parse_response_head(&head) else {
+                        self.response.passthrough();
+                        return;
+                    };
+
+                    // Interim responses (100 Continue, 103 Early Hints) carry no
+                    // body and do not complete the request they belong to.
+                    if (100..200).contains(&status) && status != 101 {
+                        self.response.mode = Mode::Head;
+                        continue;
+                    }
+
+                    // Protocol upgrade (WebSocket, h2c): record the handshake,
+                    // then stop parsing — the rest of the connection is not HTTP.
+                    if status == 101 {
+                        self.current_response = Some(PendingResponse {
+                            status,
+                            headers,
+                            body: Body::default(),
+                        });
+                        self.complete_exchange();
+                        self.request.passthrough();
+                        self.response.passthrough();
+                        return;
+                    }
+
+                    let method = self.pending.front().map(|p| p.method.as_str());
+                    let framing = response_framing(status, method, &headers);
+                    self.current_response = Some(PendingResponse {
+                        status,
+                        headers,
+                        body: Body::default(),
+                    });
+                    match framing {
+                        Some(framing) => self.response.mode = Mode::Body(framing),
+                        None => {
+                            self.complete_exchange();
+                            self.response.mode = Mode::Head;
+                        }
+                    }
+                }
+                Mode::Body(mut framing) => {
+                    if self.response.buffer.is_empty() {
+                        self.response.mode = Mode::Body(framing);
+                        return;
+                    }
+                    let sink = self.current_response.as_mut().map(|r| &mut r.body);
+                    let (consumed, done) = framing.feed(&self.response.buffer, sink);
+                    self.response.buffer.drain(..consumed);
+                    if done {
+                        self.complete_exchange();
+                        self.response.mode = Mode::Head;
+                    } else {
+                        self.response.mode = Mode::Body(framing);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Pair the finished response with its request and record the exchange.
+    fn complete_exchange(&mut self) {
+        let Some(response) = self.current_response.take() else {
+            return;
+        };
+        // A response with no matching request means we started tapping
+        // mid-stream; record what we know rather than dropping it.
+        let request = self.pending.pop_front();
+        let (method, path, host, request_headers, request_body, started_at, duration_ms) =
+            match request {
+                Some(req) => (
+                    req.method,
+                    req.path,
+                    req.host,
+                    req.headers,
+                    req.body,
+                    req.started_at,
+                    req.start.elapsed().as_millis() as u64,
+                ),
+                None => (
+                    "?".to_string(),
+                    "?".to_string(),
+                    None,
+                    Vec::new(),
+                    Body::default(),
+                    Utc::now(),
+                    0,
+                ),
+            };
+
+        self.inspector.record(Exchange {
+            id: 0,
+            conn_id: self.conn_id,
+            tunnel: self.tunnel.clone(),
+            client_addr: self.client_addr.clone(),
+            method,
+            path,
+            host,
+            status: response.status,
+            request_headers,
+            response_headers: response.headers,
+            request_body,
+            response_body: response.body,
+            duration_ms,
+            started_at,
+            replayed: false,
+        });
+    }
+
+    /// Connection closed: flush a response that was delimited by EOF.
+    fn finish(&mut self) {
+        if matches!(self.response.mode, Mode::Body(Framing::UntilEof)) {
+            self.complete_exchange();
+        }
+    }
+}
+
+// ── public handle ─────────────────────────────────────────────────────────────
+
+/// Observer handle shared by both copy directions of one proxied connection.
+#[derive(Clone)]
+pub struct ConnTap {
+    state: Arc<Mutex<TapState>>,
+}
+
+impl ConnTap {
+    pub fn new(
+        inspector: Arc<Inspector>,
+        tunnel: String,
+        conn_id: Uuid,
+        client_addr: String,
+    ) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(TapState {
+                inspector,
+                tunnel,
+                conn_id,
+                client_addr,
+                request: DirParser::new(),
+                response: DirParser::new(),
+                pending: VecDeque::new(),
+                current_response: None,
+            })),
+        }
+    }
+
+    /// Bytes travelling from the tunnel towards the local service.
+    pub fn observe_request(&self, bytes: &[u8]) {
+        if let Ok(mut state) = self.state.lock() {
+            state.feed_request(bytes);
+        }
+    }
+
+    /// Bytes travelling from the local service back to the tunnel.
+    pub fn observe_response(&self, bytes: &[u8]) {
+        if let Ok(mut state) = self.state.lock() {
+            state.feed_response(bytes);
+        }
+    }
+
+    /// Connection closed — flush anything delimited by EOF.
+    pub fn finish(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.finish();
+        }
+    }
+}
+
+// ── head parsing ──────────────────────────────────────────────────────────────
+
+type Headers = Vec<(String, String)>;
+
+/// Parse a request head into `(method, path, headers)`.
+fn parse_request_head(head: &[u8]) -> Option<(String, String, Headers)> {
+    let mut header_buf = [httparse::EMPTY_HEADER; MAX_HEADERS];
+    let mut req = httparse::Request::new(&mut header_buf);
+    match req.parse(head) {
+        Ok(httparse::Status::Complete(_)) => {}
+        // Incomplete cannot happen (we only parse a terminated head) and any
+        // parse error means this is not HTTP/1.x.
+        _ => return None,
+    }
+    Some((
+        req.method?.to_string(),
+        req.path?.to_string(),
+        collect_headers(req.headers),
+    ))
+}
+
+/// Parse a response head into `(status, headers)`.
+fn parse_response_head(head: &[u8]) -> Option<(u16, Headers)> {
+    let mut header_buf = [httparse::EMPTY_HEADER; MAX_HEADERS];
+    let mut res = httparse::Response::new(&mut header_buf);
+    match res.parse(head) {
+        Ok(httparse::Status::Complete(_)) => {}
+        _ => return None,
+    }
+    Some((res.code?, collect_headers(res.headers)))
+}
+
+fn collect_headers(headers: &[httparse::Header<'_>]) -> Headers {
+    headers
+        .iter()
+        .filter(|h| !h.name.is_empty())
+        .map(|h| {
+            (
+                h.name.to_string(),
+                String::from_utf8_lossy(h.value).into_owned(),
+            )
+        })
+        .collect()
+}
+
+fn header_value(headers: &Headers, name: &str) -> Option<String> {
+    headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(name))
+        .map(|(_, v)| v.clone())
+}
+
+fn is_chunked(headers: &Headers) -> bool {
+    header_value(headers, "transfer-encoding")
+        .map(|v| v.to_ascii_lowercase().contains("chunked"))
+        .unwrap_or(false)
+}
+
+fn content_length(headers: &Headers) -> Option<u64> {
+    header_value(headers, "content-length")?.trim().parse().ok()
+}
+
+/// Body framing for a request. `None` means the request has no body.
+fn request_framing(headers: &Headers) -> Option<Framing> {
+    if is_chunked(headers) {
+        return Some(Framing::Chunked(ChunkScanner::new()));
+    }
+    match content_length(headers) {
+        Some(0) | None => None,
+        Some(n) => Some(Framing::Length(n)),
+    }
+}
+
+/// Body framing for a response. `None` means the response has no body.
+///
+/// Per RFC 9112 §6.3 a response to HEAD, and any 204/304, never has a body even
+/// when it advertises a `Content-Length`.
+fn response_framing(
+    status: u16,
+    request_method: Option<&str>,
+    headers: &Headers,
+) -> Option<Framing> {
+    if status == 204 || status == 304 {
+        return None;
+    }
+    if request_method.is_some_and(|m| m.eq_ignore_ascii_case("HEAD")) {
+        return None;
+    }
+    if is_chunked(headers) {
+        return Some(Framing::Chunked(ChunkScanner::new()));
+    }
+    match content_length(headers) {
+        Some(0) => None,
+        Some(n) => Some(Framing::Length(n)),
+        // No length and not chunked: the body runs until the connection closes.
+        None => Some(Framing::UntilEof),
+    }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn tap() -> (ConnTap, Arc<Inspector>) {
+        let inspector = Inspector::new(true, "edge.test:4040".into(), None);
+        let tap = ConnTap::new(
+            Arc::clone(&inspector),
+            "web".into(),
+            Uuid::nil(),
+            "203.0.113.9:44321".into(),
+        );
+        (tap, inspector)
+    }
+
+    #[test]
+    fn simple_request_response_is_captured() {
+        let (tap, inspector) = tap();
+        tap.observe_request(b"GET /hello?q=1 HTTP/1.1\r\nHost: demo.test\r\n\r\n");
+        tap.observe_response(
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello",
+        );
+
+        let captured = inspector.exchanges();
+        assert_eq!(captured.len(), 1);
+        let ex = &captured[0];
+        assert_eq!(ex.method, "GET");
+        assert_eq!(ex.path, "/hello?q=1");
+        assert_eq!(ex.status, 200);
+        assert_eq!(ex.host.as_deref(), Some("demo.test"));
+        assert_eq!(ex.response_body.as_text(), Some("hello"));
+        assert_eq!(ex.client_addr, "203.0.113.9:44321");
+        assert!(!ex.replayed);
+    }
+
+    #[test]
+    fn request_body_is_captured_and_paired() {
+        let (tap, inspector) = tap();
+        tap.observe_request(
+            b"POST /api/items HTTP/1.1\r\nHost: demo.test\r\nContent-Length: 13\r\n\r\n{\"name\":\"x\"}\n",
+        );
+        tap.observe_response(b"HTTP/1.1 201 Created\r\nContent-Length: 2\r\n\r\nok");
+
+        let ex = &inspector.exchanges()[0];
+        assert_eq!(ex.method, "POST");
+        assert_eq!(ex.status, 201);
+        assert_eq!(ex.request_body.as_text(), Some("{\"name\":\"x\"}\n"));
+        assert_eq!(ex.response_body.as_text(), Some("ok"));
+    }
+
+    #[test]
+    fn keep_alive_connection_pairs_requests_in_order() {
+        let (tap, inspector) = tap();
+        tap.observe_request(b"GET /one HTTP/1.1\r\nHost: d\r\n\r\n");
+        tap.observe_response(b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\na");
+        tap.observe_request(b"GET /two HTTP/1.1\r\nHost: d\r\n\r\n");
+        tap.observe_response(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
+
+        let captured = inspector.exchanges(); // newest first
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[1].path, "/one");
+        assert_eq!(captured[1].status, 200);
+        assert_eq!(captured[0].path, "/two");
+        assert_eq!(captured[0].status, 404);
+    }
+
+    #[test]
+    fn messages_split_across_arbitrary_buffer_boundaries() {
+        let (tap, inspector) = tap();
+        let request = b"POST /split HTTP/1.1\r\nHost: d\r\nContent-Length: 10\r\n\r\n0123456789";
+        let response = b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nbody";
+        // One byte at a time — the worst case for an incremental parser.
+        for byte in request {
+            tap.observe_request(&[*byte]);
+        }
+        for byte in response {
+            tap.observe_response(&[*byte]);
+        }
+
+        let ex = &inspector.exchanges()[0];
+        assert_eq!(ex.path, "/split");
+        assert_eq!(ex.request_body.as_text(), Some("0123456789"));
+        assert_eq!(ex.response_body.as_text(), Some("body"));
+    }
+
+    #[test]
+    fn chunked_response_is_decoded_and_terminated() {
+        let (tap, inspector) = tap();
+        tap.observe_request(b"GET /stream HTTP/1.1\r\nHost: d\r\n\r\n");
+        tap.observe_response(
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n",
+        );
+        // A second request/response proves the scanner found the body's end.
+        tap.observe_request(b"GET /after HTTP/1.1\r\nHost: d\r\n\r\n");
+        tap.observe_response(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+
+        let captured = inspector.exchanges();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[1].response_body.as_text(), Some("hello world"));
+        assert_eq!(captured[0].path, "/after");
+    }
+
+    #[test]
+    fn chunked_with_extensions_and_trailers() {
+        let (tap, inspector) = tap();
+        tap.observe_request(b"GET /t HTTP/1.1\r\nHost: d\r\n\r\n");
+        tap.observe_response(
+            b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4;ext=1\r\nabcd\r\n0\r\nX-Trace: 9\r\n\r\n",
+        );
+        tap.observe_request(b"GET /next HTTP/1.1\r\nHost: d\r\n\r\n");
+        tap.observe_response(b"HTTP/1.1 204 No Content\r\n\r\n");
+
+        let captured = inspector.exchanges();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[1].response_body.as_text(), Some("abcd"));
+        assert_eq!(captured[0].status, 204);
+    }
+
+    #[test]
+    fn head_response_has_no_body_despite_content_length() {
+        let (tap, inspector) = tap();
+        tap.observe_request(b"HEAD /page HTTP/1.1\r\nHost: d\r\n\r\n");
+        tap.observe_response(b"HTTP/1.1 200 OK\r\nContent-Length: 1024\r\n\r\n");
+        // The next response must still be parsed correctly.
+        tap.observe_request(b"GET /page HTTP/1.1\r\nHost: d\r\n\r\n");
+        tap.observe_response(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi");
+
+        let captured = inspector.exchanges();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(captured[1].method, "HEAD");
+        assert_eq!(captured[1].response_body.total, 0);
+        assert_eq!(captured[0].response_body.as_text(), Some("hi"));
+    }
+
+    #[test]
+    fn interim_100_continue_does_not_consume_the_request() {
+        let (tap, inspector) = tap();
+        tap.observe_request(
+            b"POST /upload HTTP/1.1\r\nHost: d\r\nExpect: 100-continue\r\nContent-Length: 3\r\n\r\nabc",
+        );
+        tap.observe_response(b"HTTP/1.1 100 Continue\r\n\r\n");
+        tap.observe_response(b"HTTP/1.1 201 Created\r\nContent-Length: 0\r\n\r\n");
+
+        let captured = inspector.exchanges();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].status, 201);
+        assert_eq!(captured[0].method, "POST");
+        assert_eq!(captured[0].request_body.as_text(), Some("abc"));
+    }
+
+    #[test]
+    fn websocket_upgrade_is_recorded_then_stops_parsing() {
+        let (tap, inspector) = tap();
+        tap.observe_request(
+            b"GET /ws HTTP/1.1\r\nHost: d\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+        );
+        tap.observe_response(
+            b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+        );
+        // Post-upgrade frames are opaque binary and must not be parsed as HTTP.
+        tap.observe_request(&[0x81, 0x05, b'h', b'e', b'l', b'l', b'o']);
+        tap.observe_response(&[0x81, 0x02, 0xff, 0xfe]);
+
+        let captured = inspector.exchanges();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].status, 101);
+        assert_eq!(captured[0].path, "/ws");
+    }
+
+    #[test]
+    fn non_http_traffic_falls_back_to_passthrough() {
+        let (tap, inspector) = tap();
+        // A TLS ClientHello — not HTTP.
+        tap.observe_request(&[0x16, 0x03, 0x01, 0x02, 0x00, 0x01, 0x00, 0x01, 0xfc]);
+        tap.observe_response(&[0x16, 0x03, 0x03, 0x00, 0x5a]);
+        assert!(inspector.exchanges().is_empty());
+    }
+
+    #[test]
+    fn eof_delimited_response_is_flushed_on_close() {
+        let (tap, inspector) = tap();
+        tap.observe_request(b"GET /legacy HTTP/1.0\r\n\r\n");
+        tap.observe_response(b"HTTP/1.0 200 OK\r\nContent-Type: text/plain\r\n\r\nstreamed");
+        assert!(inspector.exchanges().is_empty(), "not complete until EOF");
+
+        tap.finish();
+        let captured = inspector.exchanges();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].response_body.as_text(), Some("streamed"));
+    }
+
+    #[test]
+    fn oversized_head_stops_parsing_instead_of_buffering() {
+        let (tap, inspector) = tap();
+        let giant = vec![b'x'; MAX_HEAD + 1024];
+        tap.observe_request(&giant);
+        tap.observe_response(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+        // The response still parses; the request side gave up cleanly.
+        assert_eq!(inspector.exchanges().len(), 1);
+        assert_eq!(inspector.exchanges()[0].method, "?");
+    }
+
+    #[test]
+    fn large_body_is_truncated_but_totals_are_exact() {
+        let (tap, inspector) = tap();
+        let payload = vec![b'z'; super::super::BODY_CAP + 5000];
+        tap.observe_request(b"GET /big HTTP/1.1\r\nHost: d\r\n\r\n");
+        let head = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n",
+            payload.len()
+        );
+        tap.observe_response(head.as_bytes());
+        tap.observe_response(&payload);
+
+        let ex = &inspector.exchanges()[0];
+        assert_eq!(ex.response_body.total, payload.len() as u64);
+        assert_eq!(ex.response_body.bytes.len(), super::super::BODY_CAP);
+        assert!(ex.response_body.truncated);
+    }
+
+    /// A connection whose responses never parse must not accumulate requests
+    /// forever — the queue is capped and keeps the most recent entries.
+    #[test]
+    fn pending_requests_are_capped_when_responses_never_arrive() {
+        let (tap, inspector) = tap();
+        for i in 0..(MAX_PENDING + 40) {
+            tap.observe_request(format!("GET /r{i} HTTP/1.1\r\nHost: d\r\n\r\n").as_bytes());
+        }
+
+        let queued = tap.state.lock().unwrap().pending.len();
+        assert_eq!(queued, MAX_PENDING);
+
+        // The next response pairs with the oldest *retained* request.
+        tap.observe_response(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+        let captured = inspector.exchanges();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].path, format!("/r{}", 40));
+    }
+
+    #[test]
+    fn chunk_size_parsing_handles_extensions_and_junk() {
+        assert_eq!(parse_chunk_size(b"1a\r\n"), Some(26));
+        assert_eq!(parse_chunk_size(b"0\r\n"), Some(0));
+        assert_eq!(parse_chunk_size(b"ff;name=value\r\n"), Some(255));
+        assert_eq!(parse_chunk_size(b"\r\n"), None);
+        assert_eq!(parse_chunk_size(b"zz\r\n"), None);
+    }
+
+    #[test]
+    fn response_framing_rules() {
+        let chunked = vec![("Transfer-Encoding".to_string(), "chunked".to_string())];
+        let length = vec![("Content-Length".to_string(), "42".to_string())];
+        assert!(matches!(
+            response_framing(200, Some("GET"), &chunked),
+            Some(Framing::Chunked(_))
+        ));
+        assert!(matches!(
+            response_framing(200, Some("GET"), &length),
+            Some(Framing::Length(42))
+        ));
+        assert!(response_framing(304, Some("GET"), &length).is_none());
+        assert!(response_framing(204, Some("GET"), &[].to_vec()).is_none());
+        assert!(response_framing(200, Some("head"), &length).is_none());
+        assert!(matches!(
+            response_framing(200, Some("GET"), &[].to_vec()),
+            Some(Framing::UntilEof)
+        ));
+    }
+}

--- a/crates/rustunnel-client/src/inspect/ui.html
+++ b/crates/rustunnel-client/src/inspect/ui.html
@@ -1,0 +1,321 @@
+<!-- Local request inspector UI. Served by inspect::server on loopback only. -->
+<!-- Self-contained on purpose: no CDN, no build step, no network access. -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>rustunnel — inspect</title>
+<style>
+  :root {
+    --bg: #ffffff; --panel: #f7f8fa; --border: #e3e6ea; --text: #1d2127;
+    --muted: #6b7280; --accent: #0b7285; --sel: #e7f5f8;
+    --green: #197d3f; --yellow: #9a6700; --red: #b42318; --cyan: #0b7285; --violet: #6d28d9;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #14171c; --panel: #1a1e24; --border: #2a2f37; --text: #e6e9ef;
+      --muted: #9099a6; --accent: #3bc9db; --sel: #1e2a30;
+      --green: #51cf66; --yellow: #fcc419; --red: #ff6b6b; --cyan: #3bc9db; --violet: #b197fc;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font: 14px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+    height: 100vh; display: flex; flex-direction: column;
+  }
+  header {
+    display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+    padding: 10px 16px; border-bottom: 1px solid var(--border); background: var(--panel);
+  }
+  .brand { font-weight: 700; letter-spacing: -0.01em; }
+  .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--green); margin-right: 6px; }
+  .dot.off { background: var(--red); }
+  .meta { color: var(--muted); font-size: 12px; display: flex; gap: 14px; flex-wrap: wrap; }
+  .meta b { color: var(--text); font-weight: 600; }
+  .spacer { flex: 1; }
+  input[type=search] {
+    padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px;
+    background: var(--bg); color: var(--text); min-width: 200px; font: inherit;
+  }
+  button {
+    padding: 6px 12px; border: 1px solid var(--border); border-radius: 6px;
+    background: var(--bg); color: var(--text); cursor: pointer; font: inherit;
+  }
+  button:hover { border-color: var(--accent); color: var(--accent); }
+  button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+  button.primary:hover { opacity: .9; color: #fff; }
+  button:disabled { opacity: .5; cursor: not-allowed; }
+
+  main { flex: 1; display: flex; min-height: 0; }
+  #list { width: 46%; min-width: 320px; overflow-y: auto; border-right: 1px solid var(--border); }
+  #detail { flex: 1; overflow-y: auto; padding: 16px; min-width: 0; }
+
+  table { width: 100%; border-collapse: collapse; }
+  tbody tr { cursor: pointer; border-bottom: 1px solid var(--border); }
+  tbody tr:hover { background: var(--panel); }
+  tbody tr.selected { background: var(--sel); }
+  td { padding: 7px 10px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  td.path { font-family: var(--mono); font-size: 12.5px; max-width: 1px; width: 100%; }
+  td.num { text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; font-size: 12px; }
+  .m { font-family: var(--mono); font-weight: 600; font-size: 12px; }
+  .m.GET { color: var(--cyan); } .m.POST { color: var(--yellow); }
+  .m.PUT, .m.PATCH { color: var(--violet); } .m.DELETE { color: var(--red); }
+  .s2 { color: var(--green); font-weight: 600; } .s3 { color: var(--cyan); }
+  .s4 { color: var(--yellow); font-weight: 600; } .s5 { color: var(--red); font-weight: 600; }
+  .replay-tag {
+    font-size: 10px; text-transform: uppercase; letter-spacing: .04em;
+    border: 1px solid var(--border); border-radius: 4px; padding: 0 4px; color: var(--muted);
+  }
+
+  .empty { padding: 40px 20px; text-align: center; color: var(--muted); }
+  h2 { margin: 0 0 4px; font-size: 18px; font-family: var(--mono); word-break: break-all; }
+  .sub { color: var(--muted); font-size: 12px; margin-bottom: 14px; }
+  .tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin-bottom: 14px; }
+  .tab {
+    padding: 7px 12px; cursor: pointer; border: none; background: none;
+    color: var(--muted); border-bottom: 2px solid transparent; border-radius: 0;
+  }
+  .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+  .tab:hover { color: var(--accent); }
+  section h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 16px 0 6px; }
+  pre {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 6px;
+    padding: 10px 12px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px;
+    white-space: pre-wrap; word-break: break-word; margin: 0;
+  }
+  dl { display: grid; grid-template-columns: max-content 1fr; gap: 2px 16px; margin: 0; font-size: 13px; }
+  dt { color: var(--muted); }
+  dd { margin: 0; font-family: var(--mono); font-size: 12.5px; word-break: break-all; }
+  .kv { font-family: var(--mono); font-size: 12.5px; }
+  .kv div { padding: 3px 0; border-bottom: 1px solid var(--border); word-break: break-all; }
+  .kv span { color: var(--accent); }
+  .note { color: var(--muted); font-size: 12px; margin-top: 6px; }
+  .err { color: var(--red); }
+</style>
+</head>
+<body>
+<header>
+  <span class="brand">rustunnel</span>
+  <span id="status"><span class="dot"></span><span id="status-text">connecting</span></span>
+  <div class="meta" id="meta"></div>
+  <span class="spacer"></span>
+  <input type="search" id="filter" placeholder="Filter method, path, status…" autocomplete="off">
+  <button id="clear">Clear</button>
+</header>
+
+<main>
+  <div id="list"><div class="empty">Waiting for requests…</div></div>
+  <div id="detail"><div class="empty">Select a request to inspect it.</div></div>
+</main>
+
+<script>
+"use strict";
+const rows = new Map();      // id -> summary
+let selectedId = null;
+let activeTab = "summary";
+let detailCache = null;      // full detail of the selected request
+
+const $ = (id) => document.getElementById(id);
+const esc = (s) => String(s ?? "").replace(/[&<>"']/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+const statusClass = (s) => "s" + String(s).charAt(0);
+const fmtBytes = (n) => {
+  if (n < 1024) return n + " B";
+  const units = ["kB", "MB", "GB"];
+  let v = n / 1024, i = 0;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return v.toFixed(1) + " " + units[i];
+};
+const fmtTime = (iso) => {
+  const d = new Date(iso);
+  return isNaN(d) ? "" : d.toLocaleTimeString([], { hour12: false });
+};
+
+// ── request list ────────────────────────────────────────────────────────────
+
+function matchesFilter(r) {
+  const q = $("filter").value.trim().toLowerCase();
+  if (!q) return true;
+  return (r.path + " " + r.method + " " + r.status).toLowerCase().includes(q);
+}
+
+function renderList() {
+  const items = [...rows.values()].sort((a, b) => b.id - a.id).filter(matchesFilter);
+  const list = $("list");
+  if (!items.length) {
+    list.innerHTML = '<div class="empty">No requests yet. Send traffic through your tunnel.</div>';
+    return;
+  }
+  list.innerHTML = "<table><tbody>" + items.map((r) => `
+    <tr data-id="${r.id}" class="${r.id === selectedId ? "selected" : ""}">
+      <td class="num">${fmtTime(r.started_at)}</td>
+      <td><span class="m ${esc(r.method)}">${esc(r.method)}</span></td>
+      <td class="path">${esc(r.path)}${r.replayed ? ' <span class="replay-tag">replay</span>' : ""}</td>
+      <td class="num ${statusClass(r.status)}">${r.status}</td>
+      <td class="num">${r.duration_ms} ms</td>
+    </tr>`).join("") + "</tbody></table>";
+
+  for (const tr of list.querySelectorAll("tr")) {
+    tr.onclick = () => select(Number(tr.dataset.id));
+  }
+}
+
+function addRow(summary) {
+  rows.set(summary.id, summary);
+  renderList();
+}
+
+// ── detail pane ─────────────────────────────────────────────────────────────
+
+async function select(id) {
+  selectedId = id;
+  renderList();
+  const res = await fetch(`/api/requests/${id}`);
+  if (!res.ok) {
+    $("detail").innerHTML = '<div class="empty err">This request is no longer in the buffer.</div>';
+    return;
+  }
+  detailCache = await res.json();
+  renderDetail();
+}
+
+function renderDetail() {
+  const d = detailCache;
+  if (!d) return;
+  const tabs = ["summary", "headers", "raw"];
+  $("detail").innerHTML = `
+    <h2><span class="m ${esc(d.method)}">${esc(d.method)}</span> ${esc(d.path)}</h2>
+    <div class="sub">
+      <span class="${statusClass(d.status)}">${d.status}</span> ·
+      ${d.duration_ms} ms · ${esc(d.client_addr)} · ${fmtTime(d.started_at)}
+      ${d.replayed ? ' · <span class="replay-tag">replay</span>' : ""}
+    </div>
+    <div class="tabs">
+      ${tabs.map((t) => `<button class="tab ${t === activeTab ? "active" : ""}" data-tab="${t}">${t[0].toUpperCase() + t.slice(1)}</button>`).join("")}
+      <span class="spacer"></span>
+      <button class="primary" id="replay">Replay</button>
+    </div>
+    <div id="tab-body"></div>`;
+
+  for (const tab of $("detail").querySelectorAll(".tab")) {
+    tab.onclick = () => { activeTab = tab.dataset.tab; renderDetail(); };
+  }
+  $("replay").onclick = replay;
+  $("tab-body").innerHTML = { summary: tabSummary, headers: tabHeaders, raw: tabRaw }[activeTab](d);
+}
+
+function bodyBlock(label, body) {
+  if (!body || body.size === 0) return `<h3>${label}</h3><p class="note">No body.</p>`;
+  const note = body.truncated
+    ? `<p class="note">Showing the first ${fmtBytes(body.text ? body.text.length : 0)} of ${fmtBytes(body.size)} — capture is capped.</p>`
+    : "";
+  if (body.binary) {
+    return `<h3>${label} <span class="note">(binary, ${fmtBytes(body.size)})</span></h3>
+            <pre>${esc(body.preview || "")}</pre>${note}`;
+  }
+  return `<h3>${label} <span class="note">(${fmtBytes(body.size)})</span></h3>
+          <pre>${esc(body.text)}</pre>${note}`;
+}
+
+function tabSummary(d) {
+  return `
+    <dl>
+      <dt>Tunnel</dt><dd>${esc(d.tunnel)}</dd>
+      <dt>Host</dt><dd>${esc(d.host || "—")}</dd>
+      <dt>Client</dt><dd>${esc(d.client_addr)}</dd>
+      <dt>Request</dt><dd>${fmtBytes(d.request_bytes)}</dd>
+      <dt>Response</dt><dd>${fmtBytes(d.response_bytes)}</dd>
+    </dl>
+    ${bodyBlock("Request body", d.request_body)}
+    ${bodyBlock("Response body", d.response_body)}`;
+}
+
+function headerList(headers) {
+  if (!headers.length) return '<p class="note">None.</p>';
+  return '<div class="kv">' + headers
+    .map((h) => `<div><span>${esc(h.name)}:</span> ${esc(h.value)}</div>`).join("") + "</div>";
+}
+
+function tabHeaders(d) {
+  return `<h3>Request headers</h3>${headerList(d.request_headers)}
+          <h3>Response headers</h3>${headerList(d.response_headers)}`;
+}
+
+function tabRaw(d) {
+  const head = (first, headers) =>
+    [first, ...headers.map((h) => `${h.name}: ${h.value}`)].join("\n");
+  const reqBody = d.request_body.binary ? "[binary body]" : (d.request_body.text || "");
+  const resBody = d.response_body.binary ? "[binary body]" : (d.response_body.text || "");
+  return `
+    <h3>Request</h3>
+    <pre>${esc(head(`${d.method} ${d.path} HTTP/1.1`, d.request_headers))}\n\n${esc(reqBody)}</pre>
+    <h3>Response</h3>
+    <pre>${esc(head(`HTTP/1.1 ${d.status}`, d.response_headers))}\n\n${esc(resBody)}</pre>`;
+}
+
+async function replay() {
+  const button = $("replay");
+  button.disabled = true;
+  button.textContent = "Replaying…";
+  try {
+    const res = await fetch(`/api/requests/${selectedId}/replay`, { method: "POST" });
+    if (!res.ok) {
+      const text = await res.text();
+      button.textContent = "Replay failed";
+      $("tab-body").insertAdjacentHTML("afterbegin", `<p class="err">${esc(text)}</p>`);
+      return;
+    }
+    const result = await res.json();
+    addRow(result.replayed);
+    await select(result.replayed.id);   // jump to the replayed request
+  } finally {
+    setTimeout(() => { if ($("replay")) { $("replay").disabled = false; $("replay").textContent = "Replay"; } }, 800);
+  }
+}
+
+// ── header status ───────────────────────────────────────────────────────────
+
+async function refreshStatus() {
+  try {
+    const s = await (await fetch("/api/status")).json();
+    $("status-text").textContent = s.status;
+    $("status").querySelector(".dot").className = "dot" + (s.status === "online" ? "" : " off");
+    const tunnels = s.tunnels.map((t) =>
+      `<span><b>${esc(t.public_url)}</b> → ${esc(t.local)}</span>`).join("");
+    $("meta").innerHTML = tunnels + `
+      <span>conns <b>${s.stats.conns_open}</b> open / ${s.stats.conns_total} total</span>
+      <span>↑ <b>${fmtBytes(s.stats.bytes_to_tunnel)}</b> ↓ <b>${fmtBytes(s.stats.bytes_to_local)}</b></span>
+      <span>p50 <b>${s.p50_ms} ms</b> · p90 <b>${s.p90_ms} ms</b></span>
+      ${s.latency_ms != null ? `<span>edge <b>${s.latency_ms} ms</b></span>` : ""}`;
+  } catch (e) {
+    $("status-text").textContent = "inspector offline";
+    $("status").querySelector(".dot").className = "dot off";
+  }
+}
+
+// ── boot ────────────────────────────────────────────────────────────────────
+
+$("filter").oninput = renderList;
+$("clear").onclick = async () => {
+  await fetch("/api/requests", { method: "DELETE" });
+  rows.clear();
+  selectedId = null;
+  detailCache = null;
+  $("detail").innerHTML = '<div class="empty">Select a request to inspect it.</div>';
+  renderList();
+};
+
+fetch("/api/requests?limit=500")
+  .then((r) => r.json())
+  .then((data) => { data.requests.forEach((r) => rows.set(r.id, r)); renderList(); });
+
+new EventSource("/api/stream").onmessage = (event) => addRow(JSON.parse(event.data));
+
+refreshStatus();
+setInterval(refreshStatus, 2000);
+</script>
+</body>
+</html>

--- a/crates/rustunnel-client/src/main.rs
+++ b/crates/rustunnel-client/src/main.rs
@@ -345,7 +345,11 @@ async fn run_session(
     if use_inspector {
         match inspect::server::bind(ui.inspect_port).await {
             Some((listener, url)) => {
-                inspector.set_inspect_url(url);
+                inspector.set_inspect_url(url.clone());
+                // Human modes print this under the startup box / in the TUI
+                // header; JSON consumers get it as an event so the bound port
+                // is discoverable rather than invisible.
+                output::emit(&output::Event::InspectorReady { url });
                 tokio::spawn(inspect::server::serve(listener, Arc::clone(&inspector)));
             }
             None => warn!(

--- a/crates/rustunnel-client/src/main.rs
+++ b/crates/rustunnel-client/src/main.rs
@@ -11,21 +11,33 @@ mod control;
 mod display;
 mod error;
 mod health;
+mod inspect;
 mod output;
 mod p2p_direct;
 mod proxy;
 mod reconnect;
 mod regions;
 mod stun;
+mod tui;
 mod version;
 
+use std::io::IsTerminal;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
 
 use clap::{Args, Parser, Subcommand};
 use console::Term;
+use tokio::sync::broadcast::error::RecvError;
+use tracing::warn;
 use tracing_subscriber::EnvFilter;
 
 use config::{ClientConfig, TunnelDef};
+use inspect::{Exchange, Inspector, SessionStatus};
+
+/// How long to wait for the tunnel session to wind down after the UI exits
+/// before abandoning it. The process is on its way out either way.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
 
 // ── CLI definition ────────────────────────────────────────────────────────────
 
@@ -104,6 +116,27 @@ struct TunnelArgs {
     /// reconnecting, reconnected, error.
     #[arg(long)]
     json: bool,
+
+    #[command(flatten)]
+    ui: UiArgs,
+}
+
+/// Flags controlling the two user interfaces. Shared by every tunnel command.
+#[derive(Args, Clone, Copy)]
+struct UiArgs {
+    /// Disable the full-screen terminal UI and print one line per request
+    /// instead. Implied when stdout is not a terminal or `--json` is used.
+    #[arg(long)]
+    no_tui: bool,
+
+    /// Port for the local web inspector. Scans forward if taken; 0 picks any
+    /// free port.
+    #[arg(long, default_value_t = inspect::server::DEFAULT_PORT)]
+    inspect_port: u16,
+
+    /// Disable the local web inspector.
+    #[arg(long)]
+    no_inspect: bool,
 }
 
 #[derive(Args, Clone)]
@@ -152,6 +185,9 @@ struct P2pArgs {
     /// reconnecting, reconnected, error.
     #[arg(long)]
     json: bool,
+
+    #[command(flatten)]
+    ui: UiArgs,
 }
 
 #[derive(Args)]
@@ -165,6 +201,9 @@ struct StartArgs {
     /// reconnecting, reconnected, error.
     #[arg(long)]
     json: bool,
+
+    #[command(flatten)]
+    ui: UiArgs,
 }
 
 #[derive(Args)]
@@ -275,10 +314,113 @@ async fn run_tunnel(proto: &str, args: TunnelArgs) -> error::Result<()> {
         args.subdomain,
     )];
 
-    if args.no_reconnect {
-        control::connect(&cfg, &tunnels).await
+    run_session(cfg, tunnels, args.no_reconnect, args.ui).await
+}
+
+// ── session runner ────────────────────────────────────────────────────────────
+
+/// Start the inspector and the terminal UI (when appropriate), then run the
+/// tunnel session under them.
+///
+/// The terminal UI is skipped whenever stdout is not a terminal, `--no-tui` is
+/// passed, or `--json` is active — those runs keep the original line-based
+/// behaviour exactly.
+async fn run_session(
+    cfg: ClientConfig,
+    tunnels: Vec<TunnelDef>,
+    no_reconnect: bool,
+    ui: UiArgs,
+) -> error::Result<()> {
+    let use_tui = !output::json_mode() && !ui.no_tui && std::io::stdout().is_terminal();
+    let use_inspector = !ui.no_inspect;
+
+    // HTTP is only parsed when something will actually display it.
+    let inspector = Inspector::new(
+        use_tui || use_inspector,
+        cfg.server.clone(),
+        cfg.region.clone(),
+    );
+    tui::set_log_sink(Arc::clone(&inspector));
+
+    if use_inspector {
+        match inspect::server::bind(ui.inspect_port).await {
+            Some((listener, url)) => {
+                inspector.set_inspect_url(url);
+                tokio::spawn(inspect::server::serve(listener, Arc::clone(&inspector)));
+            }
+            None => warn!(
+                port = ui.inspect_port,
+                "no free port for the local inspector — continuing without it"
+            ),
+        }
+    }
+
+    // Without the terminal UI, requests still stream to stdout one line each.
+    if !use_tui && !output::json_mode() && inspector.capture_enabled() {
+        tokio::spawn(print_request_lines(inspector.subscribe()));
+    }
+
+    if !use_tui {
+        return run_tunnels(cfg, tunnels, no_reconnect, inspector).await;
+    }
+
+    // With the terminal UI, the session runs behind it. Whichever ends first
+    // stops the other: quitting the UI shuts the session down, and a session
+    // that dies wakes the UI so the terminal is restored before we report why.
+    let mut session = tokio::spawn({
+        let inspector = Arc::clone(&inspector);
+        async move {
+            let result = run_tunnels(cfg, tunnels, no_reconnect, Arc::clone(&inspector)).await;
+            inspector.set_status(SessionStatus::Closed);
+            inspector.request_shutdown();
+            result
+        }
+    });
+
+    let ui_result = tui::run(Arc::clone(&inspector)).await;
+    inspector.request_shutdown();
+
+    let session_result = match tokio::time::timeout(SHUTDOWN_GRACE, &mut session).await {
+        Ok(Ok(result)) => result,
+        // The task panicked or was cancelled; the UI already exited cleanly.
+        Ok(Err(_)) => Ok(()),
+        Err(_) => {
+            session.abort();
+            Ok(())
+        }
+    };
+
+    ui_result.map_err(error::Error::Io)?;
+    session_result
+}
+
+async fn run_tunnels(
+    cfg: ClientConfig,
+    tunnels: Vec<TunnelDef>,
+    no_reconnect: bool,
+    inspector: Arc<Inspector>,
+) -> error::Result<()> {
+    if no_reconnect {
+        control::connect(&cfg, &tunnels, &inspector).await
     } else {
-        reconnect::run_with_reconnect(cfg, tunnels).await
+        reconnect::run_with_reconnect(cfg, tunnels, inspector).await
+    }
+}
+
+/// Line-mode request log: one line per captured request, mirroring the terminal
+/// UI's request table for pipes, CI, and `--no-tui`.
+async fn print_request_lines(mut exchanges: tokio::sync::broadcast::Receiver<Arc<Exchange>>) {
+    loop {
+        match exchanges.recv().await {
+            Ok(exchange) => display::print_request(
+                &exchange.method,
+                &exchange.path,
+                exchange.status,
+                exchange.duration_ms,
+            ),
+            Err(RecvError::Lagged(_)) => continue,
+            Err(RecvError::Closed) => return,
+        }
     }
 }
 
@@ -325,11 +467,7 @@ async fn run_p2p(args: P2pArgs) -> error::Result<()> {
 
     let tunnels = vec![tunnel];
 
-    if args.no_reconnect {
-        control::connect(&cfg, &tunnels).await
-    } else {
-        reconnect::run_with_reconnect(cfg, tunnels).await
-    }
+    run_session(cfg, tunnels, args.no_reconnect, args.ui).await
 }
 
 async fn run_start(args: StartArgs) -> error::Result<()> {
@@ -355,7 +493,7 @@ async fn run_start(args: StartArgs) -> error::Result<()> {
     }
 
     let tunnels: Vec<TunnelDef> = cfg.tunnels.values().cloned().collect();
-    reconnect::run_with_reconnect(cfg, tunnels).await
+    run_session(cfg, tunnels, false, args.ui).await
 }
 
 async fn run_token(cmd: TokenCmd) -> error::Result<()> {
@@ -542,8 +680,10 @@ fn init_tracing() {
         )
         .with_target(false)
         // Diagnostics go to stderr so stdout stays clean for tunnel output
-        // (and valid NDJSON in --json mode).
-        .with_writer(std::io::stderr)
+        // (and valid NDJSON in --json mode). While the terminal UI owns the
+        // screen they are buffered for its log pane instead of corrupting it.
+        .with_writer(tui::LogWriter)
+        .with_ansi(std::io::stderr().is_terminal())
         .compact()
         .init();
 }

--- a/crates/rustunnel-client/src/output.rs
+++ b/crates/rustunnel-client/src/output.rs
@@ -5,6 +5,7 @@
 //! self-contained event object with an `"event"` discriminator field:
 //!
 //! ```json
+//! {"event":"inspector_ready","url":"http://127.0.0.1:4040"}
 //! {"event":"tunnel_ready","protocol":"http","public_url":"https://x.example.com","local_port":3000,...}
 //! {"event":"reconnecting","attempt":1,"reason":"connection error: ...","delay_secs":1.0}
 //! {"event":"reconnected"}
@@ -51,6 +52,10 @@ pub fn take_reconnect_pending() -> bool {
 #[derive(Debug, Serialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum Event {
+    /// The local request inspector is listening. Emitted once at startup,
+    /// before any `tunnel_ready`, and omitted entirely with `--no-inspect` —
+    /// so the listening port is never a silent side effect in automation.
+    InspectorReady { url: String },
     /// A tunnel is registered and ready to receive traffic.
     /// `public_url` is always set; `public_addr` (host:port) is additionally
     /// set for tcp/udp tunnels.
@@ -193,6 +198,17 @@ mod tests {
         let v: serde_json::Value =
             serde_json::from_str(&serde_json::to_string(&ev).unwrap()).unwrap();
         assert_eq!(v["public_addr"], "edge.rustunnel.com:30001");
+    }
+
+    #[test]
+    fn inspector_ready_event_shape() {
+        let ev = Event::InspectorReady {
+            url: "http://127.0.0.1:4040".into(),
+        };
+        assert_eq!(
+            serde_json::to_string(&ev).unwrap(),
+            r#"{"event":"inspector_ready","url":"http://127.0.0.1:4040"}"#
+        );
     }
 
     #[test]

--- a/crates/rustunnel-client/src/proxy.rs
+++ b/crates/rustunnel-client/src/proxy.rs
@@ -2,14 +2,43 @@
 //!
 //! `proxy_connection` bridges a yamux data stream (the tunnel side) with a
 //! fresh TCP connection to the local service.
+//!
+//! Connections are copied byte-for-byte. When request inspection is active the
+//! copy additionally feeds every byte to a [`ConnTap`], which parses HTTP
+//! framing without touching the stream itself — see [`crate::inspect::tap`].
 
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::time::Instant;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 use yamux::Stream as YamuxStream;
+
+use crate::inspect::tap::ConnTap;
+use crate::inspect::Inspector;
+
+/// Copy buffer size. Matches the order of magnitude `copy_bidirectional` uses.
+const COPY_BUF: usize = 16 * 1024;
+
+/// Decrements the open-connection gauge however the proxy task ends.
+struct ConnGuard(Arc<Inspector>);
+
+impl ConnGuard {
+    fn new(inspector: Arc<Inspector>) -> Self {
+        inspector.stats.conns_open.fetch_add(1, Ordering::Relaxed);
+        inspector.stats.conns_total.fetch_add(1, Ordering::Relaxed);
+        Self(inspector)
+    }
+}
+
+impl Drop for ConnGuard {
+    fn drop(&mut self) {
+        self.0.stats.conns_open.fetch_sub(1, Ordering::Relaxed);
+    }
+}
 
 /// Proxy bytes between `yamux_stream` (tunnel-side) and a new TCP connection
 /// to `local_addr` (service-side).
@@ -17,9 +46,20 @@ use yamux::Stream as YamuxStream;
 /// `local_addr` is a `"host:port"` string; `TcpStream::connect` performs DNS
 /// resolution so both IP literals and hostnames (e.g. `localhost`) are accepted.
 ///
+/// `tap` is `Some` only for HTTP tunnels while inspection is enabled; otherwise
+/// the original untapped copy runs.
+///
 /// Logs byte counts and duration on completion.
-pub async fn proxy_connection(yamux_stream: YamuxStream, local_addr: String, conn_id: Uuid) {
+pub async fn proxy_connection(
+    yamux_stream: YamuxStream,
+    local_addr: String,
+    conn_id: Uuid,
+    inspector: Arc<Inspector>,
+    tap: Option<ConnTap>,
+) {
     debug!(%conn_id, %local_addr, "proxy: connecting to local service");
+
+    let _guard = ConnGuard::new(Arc::clone(&inspector));
 
     let mut local = match tokio::net::TcpStream::connect(&local_addr).await {
         Ok(s) => s,
@@ -39,12 +79,37 @@ pub async fn proxy_connection(yamux_stream: YamuxStream, local_addr: String, con
 
     let started = Instant::now();
 
-    match tokio::io::copy_bidirectional(&mut local, &mut remote).await {
-        Ok((up, down)) => {
+    let result = match &tap {
+        Some(tap) => copy_tapped(&mut local, &mut remote, &inspector, tap).await,
+        None => {
+            // No inspection: keep the original zero-overhead copy, but still
+            // account for the bytes moved so TCP/UDP tunnels get counters.
+            tokio::io::copy_bidirectional(&mut local, &mut remote)
+                .await
+                .map(|(to_tunnel, to_local)| {
+                    inspector
+                        .stats
+                        .bytes_to_tunnel
+                        .fetch_add(to_tunnel, Ordering::Relaxed);
+                    inspector
+                        .stats
+                        .bytes_to_local
+                        .fetch_add(to_local, Ordering::Relaxed);
+                    (to_local, to_tunnel)
+                })
+        }
+    };
+
+    if let Some(tap) = &tap {
+        tap.finish();
+    }
+
+    match result {
+        Ok((to_local, to_tunnel)) => {
             info!(
                 %conn_id,
-                bytes_to_local   = up,
-                bytes_to_tunnel  = down,
+                bytes_to_local   = to_local,
+                bytes_to_tunnel  = to_tunnel,
                 duration_ms      = started.elapsed().as_millis() as u64,
                 "proxy: connection done"
             );
@@ -55,6 +120,90 @@ pub async fn proxy_connection(yamux_stream: YamuxStream, local_addr: String, con
     }
 }
 
+/// Bidirectional copy that reports every byte to `tap`.
+///
+/// Mirrors `tokio::io::copy_bidirectional`: each direction shuts down its
+/// writer at EOF, and the first error ends the whole connection.
+/// Returns `(bytes_to_local, bytes_to_tunnel)`.
+async fn copy_tapped<L, R>(
+    local: L,
+    remote: R,
+    inspector: &Arc<Inspector>,
+    tap: &ConnTap,
+) -> std::io::Result<(u64, u64)>
+where
+    L: AsyncRead + AsyncWrite + Unpin,
+    R: AsyncRead + AsyncWrite + Unpin,
+{
+    let (mut local_reader, mut local_writer) = tokio::io::split(local);
+    let (mut remote_reader, mut remote_writer) = tokio::io::split(remote);
+
+    // Tunnel → local service: these bytes are HTTP requests.
+    let to_local = pump(&mut remote_reader, &mut local_writer, |chunk| {
+        inspector
+            .stats
+            .bytes_to_local
+            .fetch_add(chunk.len() as u64, Ordering::Relaxed);
+        tap.observe_request(chunk);
+    });
+
+    // Local service → tunnel: these bytes are HTTP responses.
+    let to_tunnel = pump(&mut local_reader, &mut remote_writer, |chunk| {
+        inspector
+            .stats
+            .bytes_to_tunnel
+            .fetch_add(chunk.len() as u64, Ordering::Relaxed);
+        tap.observe_response(chunk);
+    });
+
+    tokio::pin!(to_local, to_tunnel);
+
+    let (mut bytes_to_local, mut bytes_to_tunnel) = (0u64, 0u64);
+    let (mut local_done, mut tunnel_done) = (false, false);
+
+    while !local_done || !tunnel_done {
+        tokio::select! {
+            result = &mut to_local, if !local_done => {
+                local_done = true;
+                bytes_to_local = result?;
+            }
+            result = &mut to_tunnel, if !tunnel_done => {
+                tunnel_done = true;
+                bytes_to_tunnel = result?;
+            }
+        }
+    }
+
+    Ok((bytes_to_local, bytes_to_tunnel))
+}
+
+/// Copy `reader` into `writer`, handing each chunk to `observe` after it has
+/// been forwarded. Shuts the writer down on EOF so the peer sees the half-close.
+async fn pump<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    mut observe: impl FnMut(&[u8]),
+) -> std::io::Result<u64>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buf = vec![0u8; COPY_BUF];
+    let mut total = 0u64;
+
+    loop {
+        let n = reader.read(&mut buf).await?;
+        if n == 0 {
+            let _ = writer.shutdown().await;
+            return Ok(total);
+        }
+        writer.write_all(&buf[..n]).await?;
+        writer.flush().await?;
+        total += n as u64;
+        observe(&buf[..n]);
+    }
+}
+
 /// Bridge a yamux stream with an already-accepted local TCP connection.
 /// Used by P2P subscribers — the local TCP connection was accepted on the
 /// subscriber's listener before the relay was established.
@@ -62,18 +211,28 @@ pub async fn proxy_p2p_relay(
     yamux_stream: YamuxStream,
     mut local: tokio::net::TcpStream,
     conn_id: Uuid,
+    inspector: Arc<Inspector>,
 ) {
     debug!(%conn_id, "p2p relay: bridging local TCP ↔ yamux");
+    let _guard = ConnGuard::new(Arc::clone(&inspector));
     let _ = local.set_nodelay(true);
     let mut remote = yamux_stream.compat();
     let started = Instant::now();
 
     match tokio::io::copy_bidirectional(&mut local, &mut remote).await {
         Ok((up, down)) => {
+            inspector
+                .stats
+                .bytes_to_tunnel
+                .fetch_add(up, Ordering::Relaxed);
+            inspector
+                .stats
+                .bytes_to_local
+                .fetch_add(down, Ordering::Relaxed);
             info!(
                 %conn_id,
-                bytes_to_local = up,
-                bytes_to_tunnel = down,
+                bytes_to_local = down,
+                bytes_to_tunnel = up,
                 duration_ms = started.elapsed().as_millis() as u64,
                 "p2p relay: connection done"
             );
@@ -90,8 +249,15 @@ const MAX_DATAGRAM_SIZE: usize = 65535;
 /// Proxy UDP datagrams between a yamux data stream (tunnel-side) and a local
 /// UDP socket (service-side).  Uses 4-byte big-endian length framing over the
 /// yamux byte stream to preserve datagram boundaries.
-pub async fn proxy_udp_connection(yamux_stream: YamuxStream, local_addr: String, conn_id: Uuid) {
+pub async fn proxy_udp_connection(
+    yamux_stream: YamuxStream,
+    local_addr: String,
+    conn_id: Uuid,
+    inspector: Arc<Inspector>,
+) {
     debug!(%conn_id, %local_addr, "udp proxy: connecting to local service");
+
+    let _guard = ConnGuard::new(Arc::clone(&inspector));
 
     let local = match tokio::net::UdpSocket::bind("0.0.0.0:0").await {
         Ok(s) => s,
@@ -118,6 +284,7 @@ pub async fn proxy_udp_connection(yamux_stream: YamuxStream, local_addr: String,
                 match result {
                     Ok(data) => {
                         total_bytes += data.len() as u64;
+                        inspector.stats.bytes_to_local.fetch_add(data.len() as u64, Ordering::Relaxed);
                         if local.send(&data).await.is_err() {
                             break;
                         }
@@ -131,6 +298,7 @@ pub async fn proxy_udp_connection(yamux_stream: YamuxStream, local_addr: String,
                 match result {
                     Ok(n) => {
                         total_bytes += n as u64;
+                        inspector.stats.bytes_to_tunnel.fetch_add(n as u64, Ordering::Relaxed);
                         let len = n as u32;
                         if remote.write_all(&len.to_be_bytes()).await.is_err() {
                             break;

--- a/crates/rustunnel-client/src/reconnect.rs
+++ b/crates/rustunnel-client/src/reconnect.rs
@@ -7,6 +7,7 @@
 //! Delay schedule:
 //!   initial = 1 s, multiplier = 2×, max = 60 s, jitter = ±20 %
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use rand::Rng;
@@ -15,6 +16,7 @@ use tracing::{info, warn};
 use crate::config::{ClientConfig, TunnelDef};
 use crate::control;
 use crate::error::{Error, Result};
+use crate::inspect::{Inspector, SessionStatus};
 use crate::output;
 
 const INITIAL_DELAY: Duration = Duration::from_secs(1);
@@ -27,33 +29,46 @@ const JITTER: f64 = 0.20; // ±20 %
 /// Returns `Ok(())` when the connection ends cleanly (e.g. Ctrl-C) and
 /// `Err(_)` on a fatal, non-retryable error (auth or tunnel-registration
 /// rejection).
-pub async fn run_with_reconnect(config: ClientConfig, tunnels: Vec<TunnelDef>) -> Result<()> {
+pub async fn run_with_reconnect(
+    config: ClientConfig,
+    tunnels: Vec<TunnelDef>,
+    inspector: Arc<Inspector>,
+) -> Result<()> {
     let mut delay = INITIAL_DELAY;
     let mut attempt: u32 = 0;
     let mut last_error = String::new();
 
     loop {
+        if inspector.shutdown_requested() {
+            return Ok(());
+        }
+
         if attempt > 0 {
             output::note_reconnecting();
+            inspector.set_status(SessionStatus::Reconnecting { attempt });
             if output::json_mode() {
                 output::emit(&output::Event::Reconnecting {
                     attempt,
                     reason: last_error.clone(),
                     delay_secs: delay.as_secs_f64(),
                 });
-            } else {
+            } else if !crate::tui::active() {
                 eprintln!(
                     "  Reconnecting in {:.1}s (attempt {attempt})…",
                     delay.as_secs_f64()
                 );
             }
-            tokio::time::sleep(delay).await;
+            // A backoff wait must not delay a shutdown the user already asked for.
+            tokio::select! {
+                _ = tokio::time::sleep(delay) => {}
+                _ = inspector.shutdown_signal() => return Ok(()),
+            }
             delay = next_delay(delay);
         }
 
         info!(attempt, "connecting to tunnel server");
 
-        match control::connect(&config, &tunnels).await {
+        match control::connect(&config, &tunnels, &inspector).await {
             Ok(()) => {
                 // Clean exit (e.g. Ctrl-C) — stop retrying.
                 info!("connection closed cleanly");

--- a/crates/rustunnel-client/src/tui/mod.rs
+++ b/crates/rustunnel-client/src/tui/mod.rs
@@ -1,0 +1,491 @@
+//! Full-screen terminal UI.
+//!
+//! Takes over the terminal for the lifetime of the session and shows what the
+//! old startup box could not: live connection state, per-tunnel health, traffic
+//! counters, and a scrolling log of every request flowing through the tunnel.
+//!
+//! The UI only ever *reads* [`Inspector`] state, so it can be skipped entirely
+//! — `--json`, `--no-tui` and non-TTY runs keep the original line-based output
+//! and the tunnel behaves identically.
+
+mod ui;
+
+use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use tokio::sync::mpsc;
+
+use crate::inspect::{Exchange, Inspector};
+
+/// True while the terminal UI owns the screen. Console output (spinner,
+/// startup box, tracing) must route elsewhere while this is set.
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Where tracing output goes while the UI is active.
+static LOG_SINK: OnceLock<Arc<Inspector>> = OnceLock::new();
+
+/// True while the terminal UI owns the screen.
+pub fn active() -> bool {
+    ACTIVE.load(Ordering::Relaxed)
+}
+
+fn set_active(active: bool) {
+    ACTIVE.store(active, Ordering::Relaxed);
+}
+
+/// Route tracing output into this inspector's log buffer while the UI runs.
+pub fn set_log_sink(inspector: Arc<Inspector>) {
+    let _ = LOG_SINK.set(inspector);
+}
+
+/// `tracing` writer that keeps diagnostics off the screen while the UI is up.
+///
+/// Without this, every `warn!` would punch a hole through the rendered frame.
+/// Captured lines are shown in the UI's log pane instead (`l`).
+pub struct LogWriter;
+
+impl io::Write for LogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if !active() {
+            return io::Write::write(&mut io::stderr(), buf);
+        }
+        if let Some(inspector) = LOG_SINK.get() {
+            for line in String::from_utf8_lossy(buf).lines() {
+                if !line.trim().is_empty() {
+                    inspector.push_log(line.to_string());
+                }
+            }
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if active() {
+            return Ok(());
+        }
+        io::Write::flush(&mut io::stderr())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogWriter {
+    type Writer = LogWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        LogWriter
+    }
+}
+
+/// Redraw interval. Fast enough to feel live, slow enough to stay cheap.
+const TICK: Duration = Duration::from_millis(250);
+
+/// Seconds of request-rate history kept for the sparkline.
+const RPS_HISTORY: usize = 60;
+
+/// How long the input thread waits for a key before re-checking for shutdown.
+const INPUT_POLL: Duration = Duration::from_millis(150);
+
+/// UI state. Everything else is read live from the [`Inspector`].
+pub struct App {
+    inspector: Arc<Inspector>,
+    /// Index of the topmost visible request row (0 = newest).
+    offset: usize,
+    /// Stick to the newest request as traffic arrives.
+    follow: bool,
+    /// Show the log pane instead of the request list.
+    show_logs: bool,
+    /// Completed requests per second, oldest first.
+    rps_history: Vec<u64>,
+    /// Requests counted in the current second.
+    rps_current: u64,
+    quit: bool,
+}
+
+impl App {
+    fn new(inspector: Arc<Inspector>) -> Self {
+        Self {
+            inspector,
+            offset: 0,
+            follow: true,
+            show_logs: false,
+            rps_history: vec![0; RPS_HISTORY],
+            rps_current: 0,
+            quit: false,
+        }
+    }
+
+    fn on_key(&mut self, code: KeyCode, modifiers: KeyModifiers) {
+        let ctrl = modifiers.contains(KeyModifiers::CONTROL);
+        match code {
+            KeyCode::Char('q') | KeyCode::Esc => self.quit = true,
+            KeyCode::Char('c') if ctrl => self.quit = true,
+            KeyCode::Char('c') => {
+                self.inspector.clear();
+                self.offset = 0;
+            }
+            KeyCode::Char('f') => {
+                self.follow = !self.follow;
+                if self.follow {
+                    self.offset = 0;
+                }
+            }
+            KeyCode::Char('l') => self.show_logs = !self.show_logs,
+            KeyCode::Up | KeyCode::Char('k') => self.scroll_back(1),
+            KeyCode::Down | KeyCode::Char('j') => self.scroll_forward(1),
+            KeyCode::PageUp => self.scroll_back(10),
+            KeyCode::PageDown => self.scroll_forward(10),
+            KeyCode::Home | KeyCode::Char('g') => {
+                self.offset = 0;
+                self.follow = true;
+            }
+            KeyCode::End | KeyCode::Char('G') => {
+                self.offset = self.max_offset();
+                self.follow = false;
+            }
+            _ => {}
+        }
+    }
+
+    /// Scroll towards older entries (further from the newest).
+    fn scroll_back(&mut self, lines: usize) {
+        self.offset = (self.offset + lines).min(self.max_offset());
+        self.follow = false;
+    }
+
+    /// Scroll back towards the newest entries.
+    fn scroll_forward(&mut self, lines: usize) {
+        self.offset = self.offset.saturating_sub(lines);
+        if self.offset == 0 {
+            self.follow = true;
+        }
+    }
+
+    fn max_offset(&self) -> usize {
+        let len = if self.show_logs {
+            self.inspector.logs().len()
+        } else {
+            self.inspector.exchanges().len()
+        };
+        len.saturating_sub(1)
+    }
+
+    fn on_exchange(&mut self, _exchange: &Exchange) {
+        self.rps_current += 1;
+        if self.follow {
+            self.offset = 0;
+        } else {
+            // Keep the viewport anchored on the same rows as newer ones arrive.
+            self.offset = (self.offset + 1).min(self.max_offset());
+        }
+    }
+
+    /// Roll the per-second request counter into the sparkline history.
+    fn on_second(&mut self) {
+        self.rps_history.remove(0);
+        self.rps_history.push(self.rps_current);
+        self.rps_current = 0;
+    }
+}
+
+/// Run the terminal UI until the user quits or the session ends.
+///
+/// Always restores the terminal, including on panic.
+pub async fn run(inspector: Arc<Inspector>) -> io::Result<()> {
+    let mut terminal = ratatui::init();
+    set_active(true);
+
+    // ratatui::init() installs a restoring panic hook; chain ours after it so
+    // the terminal is sane even if that behaviour ever changes.
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        set_active(false);
+        ratatui::restore();
+        previous_hook(info);
+    }));
+
+    let result = run_loop(&mut terminal, inspector).await;
+
+    set_active(false);
+    ratatui::restore();
+    result
+}
+
+async fn run_loop(
+    terminal: &mut ratatui::DefaultTerminal,
+    inspector: Arc<Inspector>,
+) -> io::Result<()> {
+    let mut app = App::new(Arc::clone(&inspector));
+    let mut exchanges = inspector.subscribe();
+
+    // crossterm's event API is blocking, so it lives on its own thread and
+    // feeds the async loop through a channel.
+    let (input_tx, mut input_rx) = mpsc::channel::<Event>(64);
+    let stop_input = Arc::new(AtomicBool::new(false));
+    let input_thread = std::thread::spawn({
+        let stop = Arc::clone(&stop_input);
+        move || {
+            while !stop.load(Ordering::Relaxed) {
+                match event::poll(INPUT_POLL) {
+                    Ok(true) => match event::read() {
+                        Ok(ev) => {
+                            if input_tx.blocking_send(ev).is_err() {
+                                break;
+                            }
+                        }
+                        Err(_) => break,
+                    },
+                    Ok(false) => {}
+                    Err(_) => break,
+                }
+            }
+        }
+    });
+
+    let mut tick = tokio::time::interval(TICK);
+    let mut second = tokio::time::interval(Duration::from_secs(1));
+
+    terminal.draw(|frame| ui::draw(frame, &app))?;
+
+    while !app.quit {
+        tokio::select! {
+            Some(event) = input_rx.recv() => {
+                match event {
+                    Event::Key(key) if key.kind == KeyEventKind::Press => {
+                        app.on_key(key.code, key.modifiers);
+                    }
+                    // Redraw on resize; other events are ignored.
+                    Event::Resize(_, _) => {}
+                    _ => continue,
+                }
+            }
+            result = exchanges.recv() => {
+                match result {
+                    Ok(exchange) => app.on_exchange(&exchange),
+                    // Lagging just means we missed a few rows in the counter.
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+            _ = second.tick() => app.on_second(),
+            _ = tick.tick() => {}
+            _ = inspector.shutdown_signal() => break,
+        }
+
+        terminal.draw(|frame| ui::draw(frame, &app))?;
+    }
+
+    // Quitting the UI ends the session.
+    inspector.request_shutdown();
+    stop_input.store(true, Ordering::Relaxed);
+    let _ = input_thread.join();
+    Ok(())
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inspect::Body;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn app_with(count: usize) -> App {
+        let inspector = Inspector::new(true, "edge.test:4040".into(), None);
+        for _ in 0..count {
+            inspector.record(Exchange {
+                id: 0,
+                conn_id: Uuid::nil(),
+                tunnel: "web".into(),
+                client_addr: "203.0.113.1:1".into(),
+                method: "GET".into(),
+                path: "/".into(),
+                host: None,
+                status: 200,
+                request_headers: vec![],
+                response_headers: vec![],
+                request_body: Body::default(),
+                response_body: Body::default(),
+                duration_ms: 1,
+                started_at: Utc::now(),
+                replayed: false,
+            });
+        }
+        App::new(inspector)
+    }
+
+    #[test]
+    fn quit_keys_set_the_quit_flag() {
+        for (code, modifiers) in [
+            (KeyCode::Char('q'), KeyModifiers::NONE),
+            (KeyCode::Esc, KeyModifiers::NONE),
+            (KeyCode::Char('c'), KeyModifiers::CONTROL),
+        ] {
+            let mut app = app_with(0);
+            app.on_key(code, modifiers);
+            assert!(app.quit, "{code:?} should quit");
+        }
+    }
+
+    #[test]
+    fn plain_c_clears_instead_of_quitting() {
+        let mut app = app_with(3);
+        app.on_key(KeyCode::Char('c'), KeyModifiers::NONE);
+        assert!(!app.quit);
+        assert!(app.inspector.exchanges().is_empty());
+    }
+
+    #[test]
+    fn scrolling_disables_follow_and_clamps_to_the_oldest_row() {
+        let mut app = app_with(5);
+        assert!(app.follow);
+
+        app.on_key(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.offset, 1);
+        assert!(!app.follow, "scrolling back stops following");
+
+        app.on_key(KeyCode::PageUp, KeyModifiers::NONE);
+        assert_eq!(app.offset, 4, "clamped to the oldest row");
+
+        app.on_key(KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(app.offset, 3);
+        assert!(!app.follow);
+
+        app.on_key(KeyCode::Home, KeyModifiers::NONE);
+        assert_eq!(app.offset, 0);
+        assert!(app.follow, "jumping to the newest resumes following");
+    }
+
+    #[test]
+    fn new_requests_keep_the_viewport_anchored_when_not_following() {
+        let mut app = app_with(5);
+        app.on_key(KeyCode::Up, KeyModifiers::NONE); // offset 1, follow off
+        let before = app.offset;
+
+        let inspector = Arc::clone(&app.inspector);
+        let exchanges = inspector.exchanges();
+        app.on_exchange(&exchanges[0]);
+
+        assert_eq!(app.offset, before + 1, "the same rows stay in view");
+        assert_eq!(app.rps_current, 1);
+    }
+
+    #[test]
+    fn following_pins_the_view_to_the_newest_request() {
+        let mut app = app_with(5);
+        let exchanges = app.inspector.exchanges();
+        app.on_exchange(&exchanges[0]);
+        assert_eq!(app.offset, 0);
+    }
+
+    #[test]
+    fn per_second_rollup_shifts_the_sparkline_history() {
+        let mut app = app_with(0);
+        app.rps_current = 7;
+        app.on_second();
+        assert_eq!(app.rps_history.len(), RPS_HISTORY);
+        assert_eq!(*app.rps_history.last().unwrap(), 7);
+        assert_eq!(app.rps_current, 0);
+    }
+
+    #[test]
+    fn log_pane_toggles_and_uses_its_own_length_for_bounds() {
+        let mut app = app_with(2);
+        app.inspector.push_log("one".into());
+        app.on_key(KeyCode::Char('l'), KeyModifiers::NONE);
+        assert!(app.show_logs);
+        assert_eq!(app.max_offset(), 0, "one log line, so no scrolling");
+    }
+
+    // ── rendering ────────────────────────────────────────────────────────
+
+    /// Render one frame into an in-memory terminal and return it as text.
+    fn render(app: &App, width: u16, height: u16) -> String {
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, height)).unwrap();
+        terminal.draw(|frame| super::ui::draw(frame, app)).unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let mut text = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                text.push_str(buffer[(x, y)].symbol());
+            }
+            text.push('\n');
+        }
+        text
+    }
+
+    #[test]
+    fn full_frame_shows_session_tunnel_and_requests() {
+        let app = app_with(3);
+        app.inspector
+            .set_status(crate::inspect::SessionStatus::Online);
+        app.inspector.set_latency(57);
+        app.inspector
+            .set_inspect_url("http://127.0.0.1:4040".to_string());
+        app.inspector.set_tunnels(vec![crate::inspect::TunnelInfo {
+            name: "web".into(),
+            proto: "http".into(),
+            local: "localhost:3000".into(),
+            public_url: "http://bb176fb6.eu.edge.rustunnel.com".into(),
+            healthy: Some(true),
+        }]);
+
+        let frame = render(&app, 110, 26);
+        // `cargo test -p rustunnel-client full_frame -- --nocapture` prints the
+        // layout, which is the quickest way to eyeball a UI change.
+        println!("{frame}");
+
+        // Header
+        assert!(frame.contains("rustunnel"), "{frame}");
+        assert!(frame.contains("online"), "{frame}");
+        assert!(frame.contains("57ms"), "latency is shown: {frame}");
+        assert!(frame.contains("http://127.0.0.1:4040"), "{frame}");
+        // Tunnels
+        assert!(frame.contains("HTTP"), "{frame}");
+        assert!(frame.contains("bb176fb6.eu.edge.rustunnel.com"), "{frame}");
+        assert!(frame.contains("→ localhost:3000"), "{frame}");
+        assert!(frame.contains("healthy"), "{frame}");
+        // Traffic + request log + footer
+        assert!(frame.contains("req/s"), "{frame}");
+        assert!(frame.contains("Requests"), "{frame}");
+        assert!(frame.contains("GET"), "{frame}");
+        assert!(frame.contains("200"), "{frame}");
+        assert!(frame.contains("quit"), "footer hints: {frame}");
+    }
+
+    #[test]
+    fn empty_state_and_narrow_terminals_render_without_panicking() {
+        let app = app_with(0);
+        let frame = render(&app, 100, 24);
+        assert!(frame.contains("waiting for traffic"), "{frame}");
+        assert!(frame.contains("registering"), "{frame}");
+
+        // Small and awkward sizes must not panic (ratatui truncates instead).
+        for (width, height) in [(20, 10), (40, 14), (200, 60), (10, 5)] {
+            render(&app, width, height);
+        }
+    }
+
+    #[test]
+    fn paused_scrolling_is_reflected_in_the_frame() {
+        let mut app = app_with(3);
+        app.on_key(KeyCode::Up, KeyModifiers::NONE);
+        let frame = render(&app, 100, 24);
+        assert!(frame.contains("(paused)"), "{frame}");
+        assert!(frame.contains("follow"), "footer offers resuming: {frame}");
+    }
+
+    #[test]
+    fn log_pane_renders_captured_lines() {
+        let mut app = app_with(1);
+        app.inspector.push_log("WARN heartbeat timeout".into());
+        app.on_key(KeyCode::Char('l'), KeyModifiers::NONE);
+        let frame = render(&app, 100, 24);
+        assert!(frame.contains("Logs"), "{frame}");
+        assert!(frame.contains("WARN heartbeat timeout"), "{frame}");
+    }
+}

--- a/crates/rustunnel-client/src/tui/ui.rs
+++ b/crates/rustunnel-client/src/tui/ui.rs
@@ -1,0 +1,395 @@
+//! Terminal UI rendering.
+//!
+//! Layout, top to bottom: session header, tunnel list, traffic counters, the
+//! live request log (or the log pane), and a key hint footer. Colours follow
+//! the palette the client already used for request lines.
+
+use chrono::Utc;
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style, Stylize};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Sparkline, Table};
+use ratatui::Frame;
+
+use super::App;
+use crate::inspect::{format_bytes, Exchange, Session, SessionStatus};
+
+/// Rows reserved for the tunnel list before it starts scrolling.
+const MAX_TUNNEL_ROWS: usize = 4;
+
+pub fn draw(frame: &mut Frame, app: &App) {
+    let session = app.inspector.session();
+    let tunnel_rows = session.tunnels.len().clamp(1, MAX_TUNNEL_ROWS) as u16;
+
+    let areas = Layout::vertical([
+        Constraint::Length(5),               // header
+        Constraint::Length(tunnel_rows + 2), // tunnels
+        Constraint::Length(4),               // traffic
+        Constraint::Min(5),                  // requests / logs
+        Constraint::Length(1),               // footer
+    ])
+    .split(frame.area());
+
+    draw_header(frame, areas[0], &session);
+    draw_tunnels(frame, areas[1], &session);
+    draw_traffic(frame, areas[2], app);
+    if app.show_logs {
+        draw_logs(frame, areas[3], app);
+    } else {
+        draw_requests(frame, areas[3], app);
+    }
+    draw_footer(frame, areas[4], app);
+}
+
+// ── header ────────────────────────────────────────────────────────────────────
+
+fn draw_header(frame: &mut Frame, area: Rect, session: &Session) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(Span::styled(
+            " rustunnel ",
+            Style::default().add_modifier(Modifier::BOLD),
+        ))
+        .title_alignment(Alignment::Left);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let columns =
+        Layout::horizontal([Constraint::Percentage(45), Constraint::Percentage(55)]).split(inner);
+
+    let (status_symbol, status_style) = match &session.status {
+        SessionStatus::Online => ("●", Style::default().fg(Color::Green)),
+        SessionStatus::Connecting => ("◌", Style::default().fg(Color::Yellow)),
+        SessionStatus::Reconnecting { .. } => ("◌", Style::default().fg(Color::Yellow)),
+        SessionStatus::Closed => ("●", Style::default().fg(Color::Red)),
+    };
+
+    let left = vec![
+        Line::from(vec![
+            label("Session"),
+            Span::styled(status_symbol, status_style),
+            Span::raw(" "),
+            Span::styled(session.status.label(), status_style),
+        ]),
+        Line::from(vec![label("Uptime"), Span::raw(uptime(session))]),
+        Line::from(vec![label("Version"), Span::raw(session.version.clone())]),
+    ];
+
+    let region = match (&session.region, session.latency_ms) {
+        (Some(region), Some(latency)) => format!("{region} · {latency}ms"),
+        (Some(region), None) => region.clone(),
+        (None, Some(latency)) => format!("{latency}ms"),
+        (None, None) => "—".to_string(),
+    };
+
+    let right = vec![
+        Line::from(vec![label("Server"), Span::raw(session.server.clone())]),
+        Line::from(vec![label("Region"), Span::raw(region)]),
+        Line::from(vec![
+            label("Inspect"),
+            match &session.inspect_url {
+                Some(url) => Span::styled(url.clone(), Style::default().fg(Color::Cyan)),
+                None => Span::styled("disabled", Style::default().fg(Color::DarkGray)),
+            },
+        ]),
+    ];
+
+    frame.render_widget(Paragraph::new(left), columns[0]);
+    frame.render_widget(Paragraph::new(right), columns[1]);
+}
+
+/// Fixed-width dim label so the two header columns line up.
+fn label(text: &str) -> Span<'static> {
+    Span::styled(format!("{text:<9}"), Style::default().fg(Color::DarkGray))
+}
+
+fn uptime(session: &Session) -> String {
+    let elapsed = Utc::now()
+        .signed_duration_since(session.started_at)
+        .num_seconds()
+        .max(0);
+    format!(
+        "{:02}:{:02}:{:02}",
+        elapsed / 3600,
+        (elapsed % 3600) / 60,
+        elapsed % 60
+    )
+}
+
+// ── tunnels ───────────────────────────────────────────────────────────────────
+
+fn draw_tunnels(frame: &mut Frame, area: Rect, session: &Session) {
+    let block = Block::default().borders(Borders::ALL).title(" Tunnels ");
+
+    if session.tunnels.is_empty() {
+        let waiting = Paragraph::new(Line::from(Span::styled(
+            "registering…",
+            Style::default().fg(Color::DarkGray),
+        )))
+        .block(block);
+        frame.render_widget(waiting, area);
+        return;
+    }
+
+    let rows: Vec<Row> = session
+        .tunnels
+        .iter()
+        .map(|tunnel| {
+            let health = match tunnel.healthy {
+                Some(true) => Span::styled("● healthy", Style::default().fg(Color::Green)),
+                Some(false) => Span::styled("● unhealthy", Style::default().fg(Color::Red)),
+                None => Span::styled("", Style::default()),
+            };
+            Row::new(vec![
+                Cell::from(Span::styled(
+                    tunnel.proto.to_uppercase(),
+                    Style::default().fg(Color::Yellow).bold(),
+                )),
+                Cell::from(Span::styled(
+                    tunnel.name.clone(),
+                    Style::default().fg(Color::DarkGray),
+                )),
+                Cell::from(Span::styled(
+                    tunnel.public_url.clone(),
+                    Style::default().fg(Color::Green).bold(),
+                )),
+                Cell::from(Span::styled(
+                    format!("→ {}", tunnel.local),
+                    Style::default().fg(Color::DarkGray),
+                )),
+                Cell::from(health),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(6),
+            Constraint::Length(12),
+            Constraint::Min(24),
+            Constraint::Length(24),
+            Constraint::Length(12),
+        ],
+    )
+    .block(block);
+
+    frame.render_widget(table, area);
+}
+
+// ── traffic ───────────────────────────────────────────────────────────────────
+
+fn draw_traffic(frame: &mut Frame, area: Rect, app: &App) {
+    let block = Block::default().borders(Borders::ALL).title(" Traffic ");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let columns = Layout::horizontal([Constraint::Min(40), Constraint::Length(24)]).split(inner);
+
+    let stats = app.inspector.stats.snapshot();
+    let (p50, p90) = app.inspector.latency_percentiles().unwrap_or((0, 0));
+
+    let counters = vec![
+        Line::from(vec![
+            label("Conns"),
+            Span::styled(
+                stats.conns_open.to_string(),
+                Style::default().fg(Color::Cyan).bold(),
+            ),
+            Span::styled(" open · ", Style::default().fg(Color::DarkGray)),
+            Span::raw(stats.conns_total.to_string()),
+            Span::styled(" total    ", Style::default().fg(Color::DarkGray)),
+            label("Requests"),
+            Span::raw(stats.requests_total.to_string()),
+        ]),
+        Line::from(vec![
+            label("Traffic"),
+            Span::styled("↑ ", Style::default().fg(Color::DarkGray)),
+            Span::raw(format_bytes(stats.bytes_to_tunnel)),
+            Span::styled("  ↓ ", Style::default().fg(Color::DarkGray)),
+            Span::raw(format_bytes(stats.bytes_to_local)),
+            Span::styled("    ", Style::default()),
+            label("Latency"),
+            Span::raw(format!("p50 {p50}ms · p90 {p90}ms")),
+        ]),
+    ];
+    frame.render_widget(Paragraph::new(counters), columns[0]);
+
+    let peak = app.rps_history.iter().copied().max().unwrap_or(1).max(1);
+    let sparkline = Sparkline::default()
+        .block(Block::default().title(Span::styled("req/s", Style::default().fg(Color::DarkGray))))
+        .data(&app.rps_history)
+        .max(peak)
+        .style(Style::default().fg(Color::Cyan));
+    frame.render_widget(sparkline, columns[1]);
+}
+
+// ── request log ───────────────────────────────────────────────────────────────
+
+fn draw_requests(frame: &mut Frame, area: Rect, app: &App) {
+    let exchanges = app.inspector.exchanges();
+    let follow = if app.follow { "" } else { " (paused)" };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Requests{follow} "));
+
+    if exchanges.is_empty() {
+        let hint = Paragraph::new(Line::from(Span::styled(
+            "waiting for traffic…",
+            Style::default().fg(Color::DarkGray),
+        )))
+        .block(block);
+        frame.render_widget(hint, area);
+        return;
+    }
+
+    let capacity = block.inner(area).height as usize;
+    let rows: Vec<Row> = exchanges
+        .iter()
+        .skip(app.offset)
+        .take(capacity)
+        .map(|exchange| request_row(exchange))
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(8),  // time
+            Constraint::Length(7),  // method
+            Constraint::Min(20),    // path
+            Constraint::Length(5),  // status
+            Constraint::Length(9),  // duration
+            Constraint::Length(22), // client
+        ],
+    )
+    .block(block);
+
+    frame.render_widget(table, area);
+}
+
+fn request_row(exchange: &Exchange) -> Row<'static> {
+    let time = exchange
+        .started_at
+        .with_timezone(&chrono::Local)
+        .format("%H:%M:%S")
+        .to_string();
+
+    let path = if exchange.replayed {
+        format!("{} ↻", exchange.path)
+    } else {
+        exchange.path.clone()
+    };
+
+    Row::new(vec![
+        Cell::from(Span::styled(time, Style::default().fg(Color::DarkGray))),
+        Cell::from(Span::styled(
+            exchange.method.clone(),
+            method_style(&exchange.method),
+        )),
+        Cell::from(path),
+        Cell::from(Span::styled(
+            exchange.status.to_string(),
+            status_style(exchange.status),
+        )),
+        Cell::from(Span::styled(
+            format!("{} ms", exchange.duration_ms),
+            duration_style(exchange.duration_ms),
+        )),
+        Cell::from(Span::styled(
+            exchange.client_addr.clone(),
+            Style::default().fg(Color::DarkGray),
+        )),
+    ])
+}
+
+fn method_style(method: &str) -> Style {
+    let color = match method {
+        "GET" => Color::Cyan,
+        "POST" => Color::Yellow,
+        "PUT" | "PATCH" => Color::Magenta,
+        "DELETE" => Color::Red,
+        _ => Color::White,
+    };
+    Style::default().fg(color).add_modifier(Modifier::BOLD)
+}
+
+fn status_style(status: u16) -> Style {
+    let style = Style::default();
+    match status {
+        200..=299 => style.fg(Color::Green).add_modifier(Modifier::BOLD),
+        300..=399 => style.fg(Color::Cyan),
+        400..=499 => style.fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        500..=599 => style.fg(Color::Red).add_modifier(Modifier::BOLD),
+        _ => style.fg(Color::White),
+    }
+}
+
+fn duration_style(duration_ms: u64) -> Style {
+    let color = match duration_ms {
+        0..=99 => Color::Green,
+        100..=999 => Color::Yellow,
+        _ => Color::Red,
+    };
+    Style::default().fg(color)
+}
+
+// ── log pane ──────────────────────────────────────────────────────────────────
+
+fn draw_logs(frame: &mut Frame, area: Rect, app: &App) {
+    let block = Block::default().borders(Borders::ALL).title(" Logs ");
+    let capacity = block.inner(area).height as usize;
+
+    let logs = app.inspector.logs();
+    let lines: Vec<Line> = logs
+        .iter()
+        .rev()
+        .skip(app.offset)
+        .take(capacity)
+        .map(|line| Line::from(Span::raw(line.clone())))
+        .collect();
+
+    let content = if lines.is_empty() {
+        vec![Line::from(Span::styled(
+            "no log output",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    } else {
+        lines
+    };
+
+    frame.render_widget(Paragraph::new(content).block(block), area);
+}
+
+// ── footer ────────────────────────────────────────────────────────────────────
+
+fn draw_footer(frame: &mut Frame, area: Rect, app: &App) {
+    let pane = if app.show_logs { "requests" } else { "logs" };
+    let follow = if app.follow { "pause" } else { "follow" };
+
+    let hints = vec![
+        key("q"),
+        Span::raw(" quit  "),
+        key("↑↓"),
+        Span::raw(" scroll  "),
+        key("f"),
+        Span::raw(format!(" {follow}  ")),
+        key("c"),
+        Span::raw(" clear  "),
+        key("l"),
+        Span::raw(format!(" {pane}")),
+    ];
+
+    frame.render_widget(
+        Paragraph::new(Line::from(hints)).style(Style::default().fg(Color::DarkGray)),
+        area,
+    );
+}
+
+fn key(name: &str) -> Span<'static> {
+    Span::styled(
+        name.to_string(),
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
+    )
+}

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -21,9 +21,10 @@
 6. [Region Selection](#region-selection)
 7. [Reconnection Behavior](#reconnection-behavior)
 8. [Terminal Output](#terminal-output)
-9. [Environment Variables](#environment-variables)
-10. [Error Reference](#error-reference)
-11. [Troubleshooting](#troubleshooting)
+9. [Request Inspector](#request-inspector)
+10. [Environment Variables](#environment-variables)
+11. [Error Reference](#error-reference)
+12. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -517,6 +518,9 @@ This table summarises all flags across all commands:
 | `--no-reconnect` | http, tcp | Exit on failure instead of reconnecting |
 | `--insecure` | http, tcp | Skip TLS certificate verification |
 | `--json` | http, tcp, udp, p2p, start, token create | Emit machine-readable NDJSON events on stdout instead of human output |
+| `--no-tui` | http, tcp, udp, p2p, start | Disable the full-screen terminal UI; print one line per request instead |
+| `--inspect-port <port>` | http, tcp, udp, p2p, start | Port for the local web inspector (default `4040`; `0` picks any free port) |
+| `--no-inspect` | http, tcp, udp, p2p, start | Disable the local web inspector |
 | `-c, --config <path>` | start | Config file path |
 | `--name <label>` | token create | Token label (required) |
 | `--admin-token <token>` | token create | Admin token for dashboard API |
@@ -600,7 +604,61 @@ rustunnel http 3000 --no-reconnect || echo "Tunnel exited"
 
 ## Terminal Output
 
-### Connecting spinner
+When stdout is a terminal, the client takes over the screen with a live UI.
+Otherwise — piped output, CI, `--no-tui`, or `--json` — it falls back to the
+line-based output described further down.
+
+### Terminal UI
+
+```
+┌ rustunnel ───────────────────────────────────────────────────────────────────┐
+│Session  ● online                    Server   eu.edge.rustunnel.com:4040      │
+│Uptime   00:12:43                    Region   eu · 57ms                       │
+│Version  0.8.2                       Inspect  http://127.0.0.1:4040           │
+└──────────────────────────────────────────────────────────────────────────────┘
+┌ Tunnels ─────────────────────────────────────────────────────────────────────┐
+│HTTP   web    http://bb176fb6.eu.edge.rustunnel.com  → localhost:3000  ● healthy│
+└──────────────────────────────────────────────────────────────────────────────┘
+┌ Traffic ─────────────────────────────────────────────────────────────────────┐
+│Conns    2 open · 27 total    Requests 1204                        req/s       │
+│Traffic  ↑ 1.2 MB  ↓ 830.0 kB    Latency  p50 6ms · p90 41ms      ▁▂▃▅▂▁▃▂    │
+└──────────────────────────────────────────────────────────────────────────────┘
+┌ Requests ────────────────────────────────────────────────────────────────────┐
+│23:21:54 GET     /style.css                    200   3 ms    95.99.57.76:51224│
+│23:21:53 POST    /api/items                    201  18 ms    95.99.57.76:51223│
+│23:21:53 GET     /missing                      404   2 ms    95.99.57.76:51222│
+└──────────────────────────────────────────────────────────────────────────────┘
+q quit  ↑↓ scroll  f pause  c clear  l logs
+```
+
+- **Session** — connection state, uptime, client version, edge server, region and
+  live control-plane latency (measured from the keepalive round-trip), and the
+  local inspector URL.
+- **Tunnels** — one row per tunnel with its public URL, local target, and health
+  when a `health_check` is configured.
+- **Traffic** — open/total connections, bytes each way, p50/p90 request duration,
+  and a requests-per-second sparkline.
+- **Requests** — live log of every HTTP request: time, method, path, status,
+  duration, and the public client address. Replayed requests are marked `↻`.
+
+Keys:
+
+| Key | Action |
+|-----|--------|
+| `q`, `Esc`, `Ctrl-C` | Quit (closes the tunnel) |
+| `↑` `↓` / `k` `j` | Scroll the request log |
+| `PgUp` / `PgDn` | Scroll by page |
+| `g` / `G` | Jump to newest / oldest |
+| `f` | Pause or resume following new requests |
+| `c` | Clear the captured requests |
+| `l` | Toggle the log pane (client diagnostics) |
+
+Only HTTP tunnels produce request rows. TCP and UDP tunnels are opaque byte
+streams, so they show connection and traffic counters only.
+
+### Line mode
+
+With `--no-tui`, a non-terminal stdout, or `--json`, output stays line-based.
 
 While establishing the connection a spinner is shown:
 
@@ -609,8 +667,6 @@ While establishing the connection a spinner is shown:
 ⠹ Authenticating…
 ⠸ Registering tunnels…
 ```
-
-### Startup box
 
 Once all tunnels are registered, a bordered box appears:
 
@@ -625,6 +681,8 @@ Once all tunnels are registered, a bordered box appears:
 ╰────────────────────────────────────────────────────────────╯
 
   ✓ Tunnels active. Press Ctrl-C to quit.
+
+  Inspect http://127.0.0.1:4040
 ```
 
 Color coding:
@@ -632,6 +690,14 @@ Color coding:
 - Tunnel name — dim
 - Public URL — **bold green**
 - Border — cyan
+
+Requests then stream one per line as they arrive:
+
+```
+23:21:54    GET /style.css                     200 3ms
+23:21:53   POST /api/items                     201 18ms
+23:21:53    GET /missing                       404 2ms
+```
 
 ### JSON output (`--json`)
 
@@ -645,7 +711,52 @@ Events: `tunnel_ready` (includes `public_addr` host:port for tcp/udp), `reconnec
 
 ### Graceful shutdown
 
-Press `Ctrl-C` to cleanly close the tunnel and exit. The control WebSocket is closed before the process exits.
+Press `Ctrl-C` to cleanly close the tunnel and exit. The control WebSocket is closed before the process exits. In the terminal UI, `q` and `Esc` do the same.
+
+---
+
+## Request Inspector
+
+Every tunnel session also starts a small web inspector on loopback, printed at
+startup and shown in the terminal UI:
+
+```
+Inspect http://127.0.0.1:4040
+```
+
+Open it to browse everything that flowed through the tunnel:
+
+- **Request list** — live-updating, with method, path, status, and duration.
+  Filter by method, path, or status.
+- **Detail view** — Summary (bodies), Headers (full request and response
+  headers), and Raw (the reconstructed HTTP messages).
+- **Replay** — re-issue any captured request against your local service without
+  the original caller doing anything. Handy for webhooks: trigger once, then
+  iterate against the same payload. Replayed requests appear in the list marked
+  `replay`.
+
+### Scope and limits
+
+- Captures **HTTP tunnels only**. TCP and UDP tunnels are raw byte streams; they
+  contribute connection and traffic counters but no request entries.
+- Keeps the **last 500 requests in memory**, per process. Nothing is written to
+  disk and nothing survives a restart.
+- Bodies are captured up to **64 KB each**; larger ones are marked truncated
+  (the reported size is still exact). A truncated request body cannot be
+  replayed byte-for-byte.
+- WebSocket and other upgraded connections are recorded as their handshake
+  (`101`); the frames afterwards are not parsed.
+
+### Configuration
+
+| Flag | Effect |
+|------|--------|
+| `--inspect-port <port>` | Bind a specific port (default `4040`). If it is taken, the next free port is used and the real URL is displayed. |
+| `--no-inspect` | Disable the inspector entirely. |
+
+The inspector binds `127.0.0.1` only and has no authentication, so treat it as
+local-only — captured payloads may contain credentials, tokens, and personal
+data. Use `--no-inspect` on shared or multi-user machines.
 
 ---
 

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -707,7 +707,14 @@ With `--json`, the spinner and startup box are suppressed and stdout instead car
 {"event":"tunnel_ready","protocol":"http","public_url":"https://myapp.tunnel.example.com","local_port":3000,"local_host":"localhost","tunnel_id":"6f9a…","name":"myapp"}
 ```
 
-Events: `tunnel_ready` (includes `public_addr` host:port for tcp/udp), `reconnecting` (`attempt`, `reason`, `delay_secs`), `reconnected`, `error` (`code`, `message`, `hint`; exit code 1 follows), and `token_created` (for `token create --json`). Diagnostics still go to stderr.
+Events: `inspector_ready` (`url`; emitted once at startup when the request inspector is enabled), `tunnel_ready` (includes `public_addr` host:port for tcp/udp), `reconnecting` (`attempt`, `reason`, `delay_secs`), `reconnected`, `error` (`code`, `message`, `hint`; exit code 1 follows), and `token_created` (for `token create --json`). Diagnostics still go to stderr.
+
+A `--json` session that also runs the inspector emits it first, so a script can pick the port up before any traffic arrives:
+
+```json
+{"event":"inspector_ready","url":"http://127.0.0.1:4040"}
+{"event":"tunnel_ready","protocol":"http","public_url":"https://myapp.tunnel.example.com","local_port":3000,"local_host":"localhost"}
+```
 
 ### Graceful shutdown
 
@@ -753,6 +760,10 @@ Open it to browse everything that flowed through the tunnel:
 |------|--------|
 | `--inspect-port <port>` | Bind a specific port (default `4040`). If it is taken, the next free port is used and the real URL is displayed. |
 | `--no-inspect` | Disable the inspector entirely. |
+
+Because the port can shift when the preferred one is taken, always read the
+actual URL rather than assuming `4040` — from the terminal UI header, the line
+under the startup box, or the `inspector_ready` event in `--json` mode.
 
 The inspector binds `127.0.0.1` only and has no authentication, so treat it as
 local-only — captured payloads may contain credentials, tokens, and personal


### PR DESCRIPTION
Closes the two gaps in TUNNEL-33: the CLI printed a static box and went silent, with no way to see what flowed through a tunnel.

## What changed

**Part 0 — HTTP visibility.** The client forwarded bytes without understanding them, which is why the styled `print_request` helper had been dead code since it was written. `proxy.rs` now feeds every copied byte through a passive HTTP/1.x tap (`inspect/tap.rs`) that parses framing — `Content-Length`, chunked (with extensions and trailers), EOF-delimited — without modifying, reordering, or delaying the stream. Anything that stops looking like HTTP/1.x (WebSocket upgrades, HTTP/2 prior knowledge, malformed traffic) drops to passthrough and bytes keep flowing untouched. I chose byte-level sniffing over a hyper-based intercepting proxy (Option A in the ticket) precisely to avoid changing tunnel semantics.

Captured exchanges mirror the server's `CaptureEvent`/`CapturedRequest` shape, plus headers and 64 KB-capped bodies — which is what makes payload display and replay possible.

**Part 1 — Terminal UI** (`src/tui/`). Ratatui alternate screen: session status, region + live keepalive latency, per-tunnel health (the existing `health.rs` probes were never displayed before), connection/byte/p50/p90 counters with a req/s sparkline, and a scrolling request log. Keys: `q`/`Esc`/`Ctrl-C` quit, `↑↓`/`jk` scroll, `f` follow, `c` clear, `l` log pane.

**Part 2 — Web inspector** (`src/inspect/server.rs`). Loopback-only axum server on `:4040` — request list, detail (Summary/Headers/Raw), SSE live tail, and replay against the local service. UI is a single self-contained HTML file, no build step or CDN.

## Degradation (unchanged behaviour where it matters)

| Mode | Behaviour |
|------|-----------|
| `--json` | Byte-identical to before — verified stdout stays pure NDJSON |
| non-TTY stdout | No TUI; startup box + live request lines |
| `--no-tui` | Same as above, on a TTY |
| `--no-inspect` | No web server, no port bound |
| TCP/UDP tunnels | Connection and byte counters only; no HTTP parsing |

## Bug found and fixed during testing

The inspector bound `127.0.0.1:4040` while the local tunnel server held `0.0.0.0:4040` — macOS/BSD allow the more specific bind, so loopback traffic reached the inspector instead of the server and **the client broke its own control connection**. `bind()` now probes for a live listener before claiming a port. Regression test included; this would have hit anyone running the documented local dev setup.

## Testing

62 client unit tests (up from 28), workspace green, `make check` clean.

- Tap: keep-alive pairing, byte-at-a-time splits, chunked + extensions/trailers, HEAD, `100 Continue`, `101` upgrade, non-HTTP passthrough, EOF-delimited, oversized head, body truncation, pending-queue cap.
- TUI: rendered via `TestBackend` and asserted on content; small/awkward terminal sizes don't panic.
- Inspector: port scan, reserved-port skip, wildcard-shadow regression, loopback-only.

End-to-end against a real local server + demo app: all request types captured with correct method/path/status/bodies, chunked decoded, replay re-issued a POST and recorded it, SSE pushed live rows, `--json` stayed clean, TCP tunnel showed byte counters with zero HTTP entries.

## Notes

- **Ratatui 0.29, not 0.30** as the ticket suggested — 0.29 is the last single-crate release; 0.30 splits into `ratatui-core`/`-widgets`/`-backend` with breaking API changes. Worth revisiting as a follow-up, not as part of a first cut.
- Docs updated: `docs/client-guide.md` gets the new flags, a Terminal UI section, and a Request Inspector section (including the local-only security note — captured payloads may contain credentials).

## Follow-ups (not in scope here)

- Inspector captures HTTP only; TCP tunnels could get a byte-stream viewer.
- The server's own capture pipeline still stubs bodies/headers (`dashboard/capture.rs:124`) — the client-side model here is a reference for filling that in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)