### PR TITLE
chore: bump version to 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-client"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "axum",
  "chrono",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-mcp"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "clap",
  "reqwest 0.12.28",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-protocol"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "rustunnel-server"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "arc-swap",
  "axum",

--- a/crates/rustunnel-client/Cargo.toml
+++ b/crates/rustunnel-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-client"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "CLI client for rustunnel — open-source secure tunnel server. Expose local HTTP/HTTPS/TCP/UDP services from your machine to a public URL."
 keywords = ["tunnel", "ngrok", "cli", "webhook", "reverse-proxy"]

--- a/crates/rustunnel-mcp/Cargo.toml
+++ b/crates/rustunnel-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-mcp"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "MCP (Model Context Protocol) server for rustunnel. Lets AI agents (Claude Code, Cursor, Windsurf) create and manage public tunnels to local services from inside an agent session."
 keywords = ["mcp", "tunnel", "claude", "ai-agent", "webhook"]

--- a/crates/rustunnel-protocol/Cargo.toml
+++ b/crates/rustunnel-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-protocol"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "Shared protocol types for rustunnel — the open-source secure tunnel server. Used by rustunnel-server, rustunnel-client, and rustunnel-mcp."
 keywords = ["tunnel", "ngrok", "protocol", "rustunnel"]

--- a/crates/rustunnel-server/Cargo.toml
+++ b/crates/rustunnel-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustunnel-server"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "Self-hosted, secure tunnel server in Rust. Exposes local HTTP/HTTPS/TCP/UDP services via TLS-encrypted WebSocket. Open-source ngrok alternative with multi-region and Prometheus metrics."
 keywords = ["tunnel", "ngrok", "self-hosted", "reverse-proxy", "webhook"]


### PR DESCRIPTION
Version bump to **0.8.3** across all four crates ahead of the release tag.

Ships the CLI terminal UI + local request inspector from #96 (TUNNEL-33). Client-only feature work — no server changes, so nothing deploys to the edge servers; this is a CLI + MCP binary release.

Mechanical, mirrors the `chore/bump-0.8.2` process (#95): four crate `Cargo.toml` versions + `Cargo.lock`. `rustunnel --version` now reports `0.8.3`.

Once merged, `v0.8.3` gets tagged on the merge commit to trigger `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)