### PR TITLE
fix(billing): derive effective plan, record churn, add webhook idempotency

### DIFF
--- a/crates/rustunnel-server/migrations/pg/0014_billing_status_and_idempotency.sql
+++ b/crates/rustunnel-server/migrations/pg/0014_billing_status_and_idempotency.sql
@@ -1,0 +1,56 @@
+-- 0014: billing correctness — status vocabulary, churn history, webhook idempotency.
+--
+-- Three related fixes:
+--   1. Normalise subscription status spelling to the canonical 'canceled'.
+--   2. Record when a subscription was canceled, so churned-but-previously-paid
+--      users can be identified (win-back campaigns) after their effective plan
+--      has already reverted to free.
+--   3. Give Stripe webhooks an idempotency key so redelivered events cannot be
+--      applied twice.
+
+-- ── 1. Status vocabulary ─────────────────────────────────────────────────────
+-- platform-api's webhook handler wrote 'cancelled' (en-GB) while every reader
+-- compares against 'canceled' (en-US, the spelling documented in 0006). Because
+-- 'cancelled' != 'canceled' is TRUE, every `status != 'canceled'` filter was a
+-- silent no-op and canceled subscriptions were treated as live everywhere.
+-- The writer is fixed in platform-api; this normalises rows already stored.
+UPDATE subscriptions SET status = 'canceled' WHERE status = 'cancelled';
+
+-- Stop the two spellings ever diverging again.
+ALTER TABLE subscriptions DROP CONSTRAINT IF EXISTS subscriptions_status_check;
+ALTER TABLE subscriptions ADD CONSTRAINT subscriptions_status_check
+    CHECK (status IN ('active', 'trialing', 'past_due', 'canceled', 'suspended'));
+
+-- ── 2. Churn history ─────────────────────────────────────────────────────────
+-- No column recorded *when* a subscription ended, and the cancellation webhook
+-- did not even touch updated_at, so there was nothing to drive a "was paid,
+-- churned on <date>" view.
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS canceled_at TIMESTAMPTZ;
+
+-- Backfill what we can for rows already canceled: current_period_end is the end
+-- of the last paid period, the closest available proxy for the churn date.
+UPDATE subscriptions
+   SET canceled_at = current_period_end
+ WHERE status = 'canceled'
+   AND canceled_at IS NULL
+   AND current_period_end IS NOT NULL;
+
+-- ── 3. Webhook idempotency ───────────────────────────────────────────────────
+-- Stripe redelivers events on timeout or non-2xx. Nothing recorded event.id, so
+-- a redelivered invoice.created would add a SECOND overage invoice item and
+-- overbill the customer. The primary key makes replay detection a plain insert.
+CREATE TABLE IF NOT EXISTS stripe_events (
+    id            TEXT PRIMARY KEY,          -- Stripe event id (evt_...)
+    type          TEXT NOT NULL,
+    processed_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Retention sweeps delete old rows by age.
+CREATE INDEX IF NOT EXISTS idx_stripe_events_processed_at
+    ON stripe_events (processed_at);
+
+-- ── Supporting indexes ───────────────────────────────────────────────────────
+-- subscriptions had no indexes at all; every read does user_id lookups and the
+-- admin/reconciliation paths filter on status.
+CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions (user_id);
+CREATE INDEX IF NOT EXISTS idx_subscriptions_status  ON subscriptions (status);

--- a/crates/rustunnel-server/src/dashboard/api.rs
+++ b/crates/rustunnel-server/src/dashboard/api.rs
@@ -1401,6 +1401,18 @@ struct AdminUsersQuery {
     #[serde(default)]
     offset: i64,
     search: Option<String>,
+    /// Effective plan, e.g. "free" | "payg". Churned paid users match "free".
+    plan: Option<String>,
+    /// "google" | "password".
+    auth_method: Option<String>,
+    /// User account status, e.g. "active" | "banned".
+    status: Option<String>,
+    /// Only users who were on a paid plan and have since canceled.
+    #[serde(default)]
+    previously_paid: bool,
+    /// "created" (default) | "last_active" | "email". Unknown values fall back
+    /// to the default rather than erroring.
+    sort: Option<String>,
 }
 
 fn default_admin_limit() -> i64 {
@@ -1423,10 +1435,22 @@ async fn admin_list_users(
         return e.into_response();
     }
 
-    let search = q.search.as_deref();
+    let filters = db::AdminUserFilters {
+        search: q.search.as_deref(),
+        plan: q.plan.as_deref(),
+        auth_method: q.auth_method.as_deref(),
+        status: q.status.as_deref(),
+        previously_paid: q.previously_paid,
+    };
+    let sort = q
+        .sort
+        .as_deref()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_default();
+
     let (users, total) = tokio::join!(
-        db::list_admin_users(&state.db.pg, q.limit, q.offset, search),
-        db::count_admin_users(&state.db.pg, search),
+        db::list_admin_users(&state.db.pg, q.limit, q.offset, filters, sort),
+        db::count_admin_users(&state.db.pg, filters),
     );
     match (users, total) {
         (Ok(users), Ok(total)) => Json(AdminUsersResponse { users, total }).into_response(),

--- a/crates/rustunnel-server/src/db/mod.rs
+++ b/crates/rustunnel-server/src/db/mod.rs
@@ -346,74 +346,179 @@ pub struct AdminUser {
     pub created_at: chrono::DateTime<chrono::Utc>,
     /// Number of API tokens belonging to this user.
     pub token_count: i64,
-    /// Name of the user's current plan (e.g. "free", "payg", "pro"), if any.
+    /// The user's *effective* plan. A canceled subscription drops the user back
+    /// to "free", so this reads "free" even though the underlying row still
+    /// points at the paid plan they used to be on.
     pub plan_name: Option<String>,
-    /// Status of the user's current subscription (e.g. "active", "past_due"), if any.
+    /// Raw status of the user's latest subscription ("active", "past_due",
+    /// "canceled", …). Kept separate from `plan_name` so the UI can show both
+    /// "free" and *why* it is free.
     pub subscription_status: Option<String>,
+    /// The paid plan this user churned off, set only once they have canceled a
+    /// non-free plan. `None` for users who never paid. Drives win-back filters.
+    pub previous_plan_name: Option<String>,
+    /// When the paid subscription ended.
+    pub canceled_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Most recent use across all of the user's tokens.
+    pub last_active_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-/// Paginated list of all users (newest first).
+/// Optional filters for the admin user list.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AdminUserFilters<'a> {
+    /// Case-insensitive substring match on email.
+    pub search: Option<&'a str>,
+    /// Match on *effective* plan, so "free" also matches churned paid users.
+    pub plan: Option<&'a str>,
+    /// "google" | "password".
+    pub auth_method: Option<&'a str>,
+    /// User account status, e.g. "active" | "banned".
+    pub status: Option<&'a str>,
+    /// Only users who were on a paid plan and have since canceled.
+    pub previously_paid: bool,
+}
+
+/// Sort orders accepted by the admin user list.
+#[derive(Debug, Default, Clone, Copy)]
+pub enum AdminUserSort {
+    /// Newest signups first.
+    #[default]
+    Created,
+    /// Most recently active first; users who never used a token sort last.
+    LastActive,
+    /// Alphabetical by email.
+    Email,
+}
+
+impl AdminUserSort {
+    /// Fixed ORDER BY clause. Never interpolates caller input.
+    fn order_by(self) -> &'static str {
+        match self {
+            Self::Created => "ORDER BY u.created_at DESC",
+            Self::LastActive => "ORDER BY tc.last_active_at DESC NULLS LAST, u.created_at DESC",
+            Self::Email => "ORDER BY u.email ASC",
+        }
+    }
+}
+
+impl std::str::FromStr for AdminUserSort {
+    type Err = ();
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "created" => Ok(Self::Created),
+            "last_active" => Ok(Self::LastActive),
+            "email" => Ok(Self::Email),
+            _ => Err(()),
+        }
+    }
+}
+
+/// The user's most recent subscription, with the plan joined in.
+///
+/// Effective plan has to be *derived* rather than read: subscribing UPGRADES
+/// the existing free row in place (see platform-api `billing::subscribe`), so
+/// once that row is canceled there is no surviving free row to fall back to.
+/// "free" is synthesised in the projection below.
+const SUB_LATERAL: &str = "
+    LEFT JOIN LATERAL (
+        SELECT p.name AS plan_name, p.billing_model, s.status, s.canceled_at
+          FROM subscriptions s JOIN plans p ON p.id = s.plan_id
+         WHERE s.user_id = u.id
+         ORDER BY s.created_at DESC
+         LIMIT 1
+    ) sub ON TRUE";
+
+/// Token count and last-activity, as a lateral so no GROUP BY is needed.
+const TOKEN_LATERAL: &str = "
+    LEFT JOIN LATERAL (
+        SELECT COUNT(*)::bigint AS token_count, MAX(t.last_used_at) AS last_active_at
+          FROM tokens t WHERE t.user_id = u.id
+    ) tc ON TRUE";
+
+/// Projection shared by the list and detail queries.
+const ADMIN_USER_COLS: &str = "
+    u.id, u.email, u.display_name, u.email_verified, u.status, u.auth_method, u.created_at,
+    tc.token_count,
+    CASE WHEN sub.status = 'canceled' THEN 'free' ELSE sub.plan_name END AS plan_name,
+    sub.status AS subscription_status,
+    CASE WHEN sub.status = 'canceled' AND sub.billing_model <> 'free'
+         THEN sub.plan_name END AS previous_plan_name,
+    CASE WHEN sub.status = 'canceled' THEN sub.canceled_at END AS canceled_at,
+    tc.last_active_at";
+
+/// Filter predicates. Bind order: $1 search, $2 plan, $3 auth_method,
+/// $4 status, $5 previously_paid.
+const ADMIN_USER_FILTERS: &str = "
+    WHERE ($1::text IS NULL OR u.email ILIKE '%' || $1 || '%')
+      AND ($2::text IS NULL OR (CASE WHEN sub.status = 'canceled'
+                                     THEN 'free' ELSE sub.plan_name END) = $2)
+      AND ($3::text IS NULL OR u.auth_method = $3)
+      AND ($4::text IS NULL OR u.status = $4)
+      AND ($5::bool IS NOT TRUE OR (sub.status = 'canceled'
+                                    AND sub.billing_model <> 'free'))";
+
+/// Paginated, filterable list of users.
 pub async fn list_admin_users(
     pool: &PgPool,
     limit: i64,
     offset: i64,
-    search: Option<&str>,
+    filters: AdminUserFilters<'_>,
+    sort: AdminUserSort,
 ) -> Result<Vec<AdminUser>> {
-    let rows: Vec<AdminUser> = sqlx::query_as(
-        "SELECT u.id, u.email, u.display_name, u.email_verified, u.status, u.auth_method, u.created_at,
-                COUNT(t.id)::bigint AS token_count,
-                (SELECT p.name FROM subscriptions s JOIN plans p ON p.id = s.plan_id
-                 WHERE s.user_id = u.id AND s.status != 'canceled'
-                 ORDER BY s.created_at DESC LIMIT 1) AS plan_name,
-                (SELECT s.status FROM subscriptions s
-                 WHERE s.user_id = u.id AND s.status != 'canceled'
-                 ORDER BY s.created_at DESC LIMIT 1) AS subscription_status
-         FROM users u
-         LEFT JOIN tokens t ON t.user_id = u.id
-         WHERE ($1::text IS NULL OR u.email ILIKE '%' || $1 || '%')
-         GROUP BY u.id
-         ORDER BY u.created_at DESC
-         LIMIT $2 OFFSET $3",
-    )
-    .bind(search)
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await?;
+    let sql = format!(
+        "SELECT {cols} FROM users u {tokens} {sub} {filters} {order} LIMIT $6 OFFSET $7",
+        cols = ADMIN_USER_COLS,
+        tokens = TOKEN_LATERAL,
+        sub = SUB_LATERAL,
+        filters = ADMIN_USER_FILTERS,
+        order = sort.order_by(),
+    );
+    let rows: Vec<AdminUser> = sqlx::query_as(&sql)
+        .bind(filters.search)
+        .bind(filters.plan)
+        .bind(filters.auth_method)
+        .bind(filters.status)
+        .bind(filters.previously_paid)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(pool)
+        .await?;
     Ok(rows)
 }
 
-/// Total user count (for pagination).
-pub async fn count_admin_users(pool: &PgPool, search: Option<&str>) -> Result<i64> {
-    let (count,): (i64,) = sqlx::query_as(
-        "SELECT COUNT(*)::bigint FROM users \
-         WHERE ($1::text IS NULL OR email ILIKE '%' || $1 || '%')",
-    )
-    .bind(search)
-    .fetch_one(pool)
-    .await?;
+/// Total user count matching the same filters (for pagination).
+///
+/// Keeps the subscription lateral so the plan/previously-paid filters mean the
+/// same thing here as they do in `list_admin_users`.
+pub async fn count_admin_users(pool: &PgPool, filters: AdminUserFilters<'_>) -> Result<i64> {
+    let sql = format!(
+        "SELECT COUNT(*)::bigint FROM users u {sub} {filters}",
+        sub = SUB_LATERAL,
+        filters = ADMIN_USER_FILTERS,
+    );
+    let (count,): (i64,) = sqlx::query_as(&sql)
+        .bind(filters.search)
+        .bind(filters.plan)
+        .bind(filters.auth_method)
+        .bind(filters.status)
+        .bind(filters.previously_paid)
+        .fetch_one(pool)
+        .await?;
     Ok(count)
 }
 
-/// Single user detail with their token list.
+/// Single user detail.
 pub async fn get_admin_user(pool: &PgPool, user_id: &uuid::Uuid) -> Result<Option<AdminUser>> {
-    let row: Option<AdminUser> = sqlx::query_as(
-        "SELECT u.id, u.email, u.display_name, u.email_verified, u.status, u.auth_method, u.created_at,
-                COUNT(t.id)::bigint AS token_count,
-                (SELECT p.name FROM subscriptions s JOIN plans p ON p.id = s.plan_id
-                 WHERE s.user_id = u.id AND s.status != 'canceled'
-                 ORDER BY s.created_at DESC LIMIT 1) AS plan_name,
-                (SELECT s.status FROM subscriptions s
-                 WHERE s.user_id = u.id AND s.status != 'canceled'
-                 ORDER BY s.created_at DESC LIMIT 1) AS subscription_status
-         FROM users u
-         LEFT JOIN tokens t ON t.user_id = u.id
-         WHERE u.id = $1
-         GROUP BY u.id",
-    )
-    .bind(user_id)
-    .fetch_optional(pool)
-    .await?;
+    let sql = format!(
+        "SELECT {cols} FROM users u {tokens} {sub} WHERE u.id = $1",
+        cols = ADMIN_USER_COLS,
+        tokens = TOKEN_LATERAL,
+        sub = SUB_LATERAL,
+    );
+    let row: Option<AdminUser> = sqlx::query_as(&sql)
+        .bind(user_id)
+        .fetch_optional(pool)
+        .await?;
     Ok(row)
 }
 


### PR DESCRIPTION
**Deploy this first.** platform-api's changes write `canceled_at` and must satisfy the new `CHECK` constraint, both added here.

## Why

A paying customer canceled on 29 June. The admin dashboard still listed them as `payg`, and nothing anywhere told us they'd gone. Root cause turned out to be a spelling mismatch.

platform-api's webhook wrote `status = 'cancelled'` (en-GB) — the only place that spelling was ever written. Five queries filter with `!= 'canceled'` (en-US, the spelling migration 0006 documents). Since `'cancelled' != 'canceled'` is **TRUE**, the canceled row passed every filter.

**All five `!= 'canceled'` filters were silent no-ops.** Canceled subscriptions were treated as live everywhere they were read.

## What's here

**Migration 0014**
- Normalises stored rows to `canceled`, plus a `CHECK` constraint so the two spellings can't diverge again
- Adds `subscriptions.canceled_at` (nothing recorded *when* a subscription ended — the cancel webhook didn't even touch `updated_at`), backfilled from `current_period_end`
- Adds `stripe_events` for webhook idempotency (consumed by the platform-api PR)
- First indexes on `subscriptions` — it had none

**Effective plan.** Fixing the spelling alone would have made it *worse*: the row would then be excluded, `plan_name` would go `NULL`, and the list would render `—`. Subscribing UPGRADES the free row in place, so a canceled row leaves no free row to fall back to. `plan_name` is now derived (`free` when canceled) with `previous_plan_name` + `canceled_at` preserved separately, so churned-but-previously-paid users stay identifiable for win-back.

**Filters.** `plan`, `auth_method`, `status`, `previously_paid`, and sort by `created`/`last_active`/`email` (fixed ORDER BY strings — no caller input interpolated). Both correlated subqueries collapse into one LATERAL; the token count moves to its own, dropping `GROUP BY` entirely.

## Verification

Against Postgres 16 — all 12 migrations apply clean, then with seeded churned/active/free users:

| user | plan_name | previous_plan | canceled_at |
|---|---|---|---|
| churned | `free` | `payg` | 2026-06-29 |
| freebie | `free` | — | — |
| paying | `payg` | — | — |

Every filter combination returns the expected set; `previously_paid` returns exactly the churned user. `UPDATE ... SET status='cancelled'` is now rejected by the constraint.

`cargo check`, `fmt --check`, `clippy -D warnings` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)