### PR TITLE
docs: /init refresh — document plain_http_mode, add AGENTS.md source-of-truth pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,16 @@
 # AGENTS.md
 
-Guidance for AI agents working in or with this repository.
+> **`CLAUDE.md` in this directory is the source of truth.** Read it in full
+> before doing any work here — it contains the working guidelines (git/branch
+> rules, knowledge base, task management, pull-request registration, reserved
+> ports, engineering defaults) and points to the parent `rustunnel` `CLAUDE.md`
+> for the rest. If anything in this file conflicts with `CLAUDE.md`,
+> `CLAUDE.md` wins.
 
-> Building/working **on** this codebase? See [`CLAUDE.md`](./CLAUDE.md) for build,
-> test, and lint commands and the architecture overview.
+The rest of this file is about using rustunnel **as a tool** from an agent
+session — it does not describe how to build or change this codebase. For build,
+test, and lint commands and the architecture overview, see
+[`CLAUDE.md`](./CLAUDE.md).
 
 ## Using rustunnel as a tool (expose local services)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ rustunnel is a self-hosted secure tunnel server written in Rust (similar to ngro
 
 ## Parent project
 
-**Parent project:** [rustunnel](/Users/joaoh82/projects/rustunnel/CLAUDE.md) — read for shared dev commands, env vars, and cross-service architecture.
+**Parent project:** [rustunnel](/Users/joaoh82/projects/rustunnel/CLAUDE.md) — read for shared dev commands, env vars, cross-service architecture, **and the global working guidelines** (never-touch-main, task management, pull-request registration, reserved ports, engineering defaults). Those guideline sections live only in the parent `CLAUDE.md` — this file does not duplicate them.
 
 ### How I fit in
 
@@ -16,12 +16,12 @@ This crate (`rustunnel/`) is the **core tunnel server + CLI client + MCP server*
 
 | Sibling | Stack | Dev port | Role |
 |---------|-------|----------|------|
-| `rustunnel-web/` | Rust (Axum) + Next.js 15 | 3001 / 3000 | Platform API + public website (registration, JWT, billing) |
+| `rustunnel-web/` | Rust (Axum) + Next.js 15 | 3001 / 3000 | Platform API + public website + marketing pages (registration, JWT, billing) |
 | `rustunnel-admin-dashboard/` | Next.js 14 | 3002 | Internal admin UI |
-| `rustunnel-landing/` | Next.js 15 | 3000 | Marketing landing |
 | `rustunnel-private/` | Markdown / Bash / Ansible | — | Ops docs, provisioning playbooks |
 | `docs/` | Mintlify (MDX) | 3000 | Public documentation |
 | `homebrew-rustunnelcli/` | Ruby | — | Homebrew tap formula |
+| `rustunnel-status/` | Upptime (YAML + Actions) | — | `status.rustunnel.com`, probes every edge |
 
 This server shares its **PostgreSQL database** with `rustunnel-web/platform-api` (the `tokens` table is the auth boundary). Edge servers (`eu`, `us`, `ap`) all run this binary; `platform-api` runs on a separate VPS at `api.rustunnel.com`.
 
@@ -187,6 +187,7 @@ All client↔server signaling uses JSON-serialized `ControlFrame` over WebSocket
 
 - **Local dev:** `deploy/local/server.toml` — self-signed certs, `require_auth = false`, PostgreSQL at `localhost:5432`
 - **Production template:** `deploy/server.toml` — Let's Encrypt + wildcard DNS, PostgreSQL, full rate limits
+- **`plain_http_mode`** (port 80 behaviour) — `"proxy"` serves tunnel subdomains over plain HTTP with `X-Forwarded-Proto: http` (ngrok parity; required for HMAC-signed webhooks configured with an `http://` URL, e.g. Twilio) and 308-redirects everything else; `"redirect"` (the code default) 308s every request. All three edges run `"proxy"` — the live per-region files are `../rustunnel-private/scripts/config/server.{eu,us,ap}.toml`
 - **Client config:** `~/.rustunnel/config.yml` (managed via `rustunnel setup` wizard)
 
 ## Observability


### PR DESCRIPTION
`/init` refresh across the rustunnel meta-repo and every sub-repo. Docs only — no code, config, or dependency changes.

**`CLAUDE.md`**

- **New "Configuration" entry for `plain_http_mode`:** port-80 behaviour was undocumented here even though all three edges run `"proxy"` (the code default is `"redirect"`). Notes why it matters — HMAC-signed webhooks configured with an `http://` URL, e.g. Twilio — and points at the live per-region files in `rustunnel-private/scripts/config/`.
- **Sibling table:** dropped the defunct `rustunnel-landing/` (marketing folded into `rustunnel-web/web/`) and added the missing `rustunnel-status/`.
- **Parent pointer:** now names the full set of global guideline sections, including pull-request registration.

**`AGENTS.md`**

This file is the only one in the fleet that lacked the standard source-of-truth pointer blockquote — it opened straight into the rustunnel-as-a-tool/MCP guidance. Added the pointer at the top and a sentence clarifying the split: this file is about *using* rustunnel from an agent session, `CLAUDE.md` is about *building* it. All the MCP tool documentation below is untouched.

Part of a set of PRs opened across all 8 rustunnel repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
